### PR TITLE
feat: implement song library (library.py)

### DIFF
--- a/src/library.py
+++ b/src/library.py
@@ -1,0 +1,163 @@
+"""Song library backed by a JSON file on disk.
+
+Manages a collection of imported songs. Each song has metadata (title, artist,
+model used, etc.) and a directory under ``data/songs/{id}/`` where the original
+file and separated stems are stored.
+"""
+
+import json
+import os
+import shutil
+import uuid
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+
+
+@dataclass
+class Song:
+    """Metadata for a single imported song."""
+
+    id: str
+    title: str
+    artist: str
+    original_path: str
+    stems_path: str
+    model_used: str
+    date_added: str
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Song":
+        """Deserialize from a plain dictionary."""
+        return cls(**data)
+
+
+class SongLibrary:
+    """JSON-backed song library with CRUD operations.
+
+    On construction the data directory structure is created if it does not
+    already exist, and any previously persisted songs are loaded into memory.
+
+    Args:
+        data_dir: Root data directory (contains ``library.json`` and ``songs/``).
+    """
+
+    def __init__(self, data_dir: str) -> None:
+        self._data_dir = data_dir
+        self._songs_dir = os.path.join(data_dir, "songs")
+        self._json_path = os.path.join(data_dir, "library.json")
+        self._songs: list[Song] = []
+
+        os.makedirs(self._songs_dir, exist_ok=True)
+
+        if os.path.isfile(self._json_path):
+            self._load()
+        else:
+            self._save()
+
+    @property
+    def songs(self) -> list[Song]:
+        """Return a shallow copy of the song list."""
+        return list(self._songs)
+
+    def get_song(self, song_id: str) -> Song | None:
+        """Return the song with *song_id*, or ``None`` if not found."""
+        for song in self._songs:
+            if song.id == song_id:
+                return song
+        return None
+
+    def add_song(
+        self,
+        title: str,
+        artist: str,
+        original_path: str,
+        model_used: str = "",
+    ) -> Song:
+        """Add a new song to the library.
+
+        Creates a per-song directory and persists the updated index.
+
+        Args:
+            title: Display title.
+            artist: Display artist.
+            original_path: Path to the source audio file.
+            model_used: Name of the separation model (set later if empty).
+
+        Returns:
+            The newly created :class:`Song`.
+        """
+        song_id = uuid.uuid4().hex[:12]
+        song_dir = os.path.join(self._songs_dir, song_id)
+        os.makedirs(song_dir, exist_ok=True)
+
+        song = Song(
+            id=song_id,
+            title=title,
+            artist=artist,
+            original_path=original_path,
+            stems_path=song_dir,
+            model_used=model_used,
+            date_added=datetime.now(timezone.utc).isoformat(),
+        )
+        self._songs.append(song)
+        self._save()
+        return song
+
+    def remove_song(self, song_id: str) -> None:
+        """Remove a song by ID, deleting its data directory.
+
+        Raises:
+            KeyError: If *song_id* is not in the library.
+        """
+        song = self.get_song(song_id)
+        if song is None:
+            raise KeyError(f"Song '{song_id}' not found")
+
+        if os.path.isdir(song.stems_path):
+            shutil.rmtree(song.stems_path)
+
+        self._songs = [s for s in self._songs if s.id != song_id]
+        self._save()
+
+    def update_song(self, song_id: str, **fields: str) -> Song:
+        """Update one or more fields on an existing song.
+
+        Only the supplied keyword arguments are changed; other fields are
+        left untouched.  The ``id`` field cannot be changed.
+
+        Raises:
+            KeyError: If *song_id* is not in the library.
+
+        Returns:
+            The updated :class:`Song`.
+        """
+        song = self.get_song(song_id)
+        if song is None:
+            raise KeyError(f"Song '{song_id}' not found")
+
+        fields.pop("id", None)
+        for key, value in fields.items():
+            if hasattr(song, key):
+                setattr(song, key, value)
+
+        self._save()
+        return song
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        """Read the JSON index from disk."""
+        with open(self._json_path, encoding="utf-8") as f:
+            data = json.load(f)
+        self._songs = [Song.from_dict(entry) for entry in data]
+
+    def _save(self) -> None:
+        """Write the current song list to the JSON index."""
+        with open(self._json_path, "w", encoding="utf-8") as f:
+            json.dump([s.to_dict() for s in self._songs], f, indent=2)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,228 @@
+"""Tests for the song library."""
+
+import json
+import os
+import shutil
+
+import pytest
+
+from src.library import SongLibrary, Song
+
+
+@pytest.fixture
+def library_dir(tmp_path):
+    """Provide a temporary data directory for the library."""
+    return str(tmp_path / "data")
+
+
+@pytest.fixture
+def library(library_dir):
+    """Create a SongLibrary backed by a temporary directory."""
+    return SongLibrary(data_dir=library_dir)
+
+
+@pytest.fixture
+def fake_audio(tmp_path):
+    """Create a fake audio file to use as import source."""
+    import numpy as np
+    import soundfile as sf
+
+    path = tmp_path / "test_song.wav"
+    silence = np.zeros((44100, 2), dtype=np.float32)
+    sf.write(str(path), silence, 44100)
+    return str(path)
+
+
+class TestSongDataclass:
+
+    def test_song_has_required_fields(self):
+        song = Song(
+            id="abc123",
+            title="Test Song",
+            artist="Test Artist",
+            original_path="test.wav",
+            stems_path="/data/songs/abc123",
+            model_used="htdemucs",
+            date_added="2026-03-20T12:00:00",
+        )
+        assert song.id == "abc123"
+        assert song.title == "Test Song"
+        assert song.artist == "Test Artist"
+        assert song.original_path == "test.wav"
+        assert song.stems_path == "/data/songs/abc123"
+        assert song.model_used == "htdemucs"
+        assert song.date_added == "2026-03-20T12:00:00"
+
+    def test_song_to_dict(self):
+        song = Song(
+            id="abc123",
+            title="Test Song",
+            artist="Test Artist",
+            original_path="test.wav",
+            stems_path="/data/songs/abc123",
+            model_used="htdemucs",
+            date_added="2026-03-20T12:00:00",
+        )
+        d = song.to_dict()
+        assert d["id"] == "abc123"
+        assert d["title"] == "Test Song"
+        assert isinstance(d, dict)
+
+    def test_song_from_dict(self):
+        d = {
+            "id": "abc123",
+            "title": "Test Song",
+            "artist": "Test Artist",
+            "original_path": "test.wav",
+            "stems_path": "/data/songs/abc123",
+            "model_used": "htdemucs",
+            "date_added": "2026-03-20T12:00:00",
+        }
+        song = Song.from_dict(d)
+        assert song.id == "abc123"
+        assert song.title == "Test Song"
+
+
+class TestSongLibraryInit:
+
+    def test_creates_data_directories(self, library, library_dir):
+        assert os.path.isdir(library_dir)
+        assert os.path.isdir(os.path.join(library_dir, "songs"))
+
+    def test_creates_empty_library_json(self, library, library_dir):
+        json_path = os.path.join(library_dir, "library.json")
+        assert os.path.isfile(json_path)
+        with open(json_path) as f:
+            data = json.load(f)
+        assert data == []
+
+    def test_loads_existing_library(self, library_dir):
+        # Pre-populate library.json.
+        os.makedirs(library_dir, exist_ok=True)
+        json_path = os.path.join(library_dir, "library.json")
+        existing = [{
+            "id": "existing",
+            "title": "Old Song",
+            "artist": "Old Artist",
+            "original_path": "old.wav",
+            "stems_path": "/data/songs/existing",
+            "model_used": "htdemucs",
+            "date_added": "2026-01-01T00:00:00",
+        }]
+        with open(json_path, "w") as f:
+            json.dump(existing, f)
+
+        lib = SongLibrary(data_dir=library_dir)
+        assert len(lib.songs) == 1
+        assert lib.songs[0].title == "Old Song"
+
+
+class TestSongLibraryCRUD:
+
+    def test_add_song(self, library, fake_audio):
+        song = library.add_song(
+            title="My Song",
+            artist="My Artist",
+            original_path=fake_audio,
+        )
+        assert song.title == "My Song"
+        assert song.artist == "My Artist"
+        assert song.id  # Non-empty ID generated
+        assert len(library.songs) == 1
+
+    def test_add_song_creates_song_directory(self, library, library_dir, fake_audio):
+        song = library.add_song(
+            title="My Song",
+            artist="My Artist",
+            original_path=fake_audio,
+        )
+        song_dir = os.path.join(library_dir, "songs", song.id)
+        assert os.path.isdir(song_dir)
+
+    def test_add_song_persists_to_json(self, library, library_dir, fake_audio):
+        library.add_song(
+            title="My Song",
+            artist="My Artist",
+            original_path=fake_audio,
+        )
+        json_path = os.path.join(library_dir, "library.json")
+        with open(json_path) as f:
+            data = json.load(f)
+        assert len(data) == 1
+        assert data[0]["title"] == "My Song"
+
+    def test_get_song_by_id(self, library, fake_audio):
+        song = library.add_song(
+            title="Findable",
+            artist="Artist",
+            original_path=fake_audio,
+        )
+        found = library.get_song(song.id)
+        assert found is not None
+        assert found.title == "Findable"
+
+    def test_get_song_not_found(self, library):
+        assert library.get_song("nonexistent") is None
+
+    def test_remove_song(self, library, library_dir, fake_audio):
+        song = library.add_song(
+            title="To Remove",
+            artist="Artist",
+            original_path=fake_audio,
+        )
+        song_dir = os.path.join(library_dir, "songs", song.id)
+        assert os.path.isdir(song_dir)
+
+        library.remove_song(song.id)
+        assert len(library.songs) == 0
+        assert not os.path.exists(song_dir)
+
+    def test_remove_song_persists_to_json(self, library, library_dir, fake_audio):
+        song = library.add_song(
+            title="To Remove",
+            artist="Artist",
+            original_path=fake_audio,
+        )
+        library.remove_song(song.id)
+        json_path = os.path.join(library_dir, "library.json")
+        with open(json_path) as f:
+            data = json.load(f)
+        assert len(data) == 0
+
+    def test_remove_nonexistent_song_raises(self, library):
+        with pytest.raises(KeyError):
+            library.remove_song("nonexistent")
+
+    def test_update_song(self, library, fake_audio):
+        song = library.add_song(
+            title="Original",
+            artist="Artist",
+            original_path=fake_audio,
+        )
+        library.update_song(song.id, title="Updated Title")
+        updated = library.get_song(song.id)
+        assert updated.title == "Updated Title"
+        assert updated.artist == "Artist"  # Unchanged
+
+    def test_update_song_persists(self, library, library_dir, fake_audio):
+        song = library.add_song(
+            title="Original",
+            artist="Artist",
+            original_path=fake_audio,
+        )
+        library.update_song(song.id, model_used="htdemucs_6s")
+
+        json_path = os.path.join(library_dir, "library.json")
+        with open(json_path) as f:
+            data = json.load(f)
+        assert data[0]["model_used"] == "htdemucs_6s"
+
+    def test_update_nonexistent_song_raises(self, library):
+        with pytest.raises(KeyError):
+            library.update_song("nonexistent", title="Nope")
+
+    def test_songs_property_returns_copy(self, library, fake_audio):
+        library.add_song(title="Song", artist="A", original_path=fake_audio)
+        songs = library.songs
+        songs.clear()
+        assert len(library.songs) == 1  # Internal list unaffected


### PR DESCRIPTION
## What
Implements the JSON-backed song library for managing imported songs.

## How
- `Song` dataclass with `to_dict()`/`from_dict()` serialization
- `SongLibrary` class with full CRUD: `add_song`, `get_song`, `remove_song`, `update_song`
- JSON persistence to `data/library.json`, auto-created on first run
- Per-song directories under `data/songs/{id}/` for stems storage
- UUIDs for song IDs, UTC timestamps for `date_added`

## Testing
- [x] 18 unit tests covering Song dataclass, library init, and all CRUD operations
- [x] Full test suite passes (58 tests, 0 failures)

Fixes #4