### PR TITLE
feat: implement stem exporter (exporter.py)

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -1,0 +1,87 @@
+"""Export individual stems or custom mixes as WAV files.
+
+Reads stem WAV files from disk and writes either a single stem copy
+or a mixed-down combination of selected stems to a new file.
+"""
+
+import os
+
+import numpy as np
+import soundfile as sf
+
+from src.separator import SAMPLE_RATE
+
+
+class StemExporter:
+    """Exports stems or custom mixes from separated audio.
+
+    Args:
+        stem_paths: Mapping of stem name to WAV file path on disk.
+    """
+
+    def __init__(self, stem_paths: dict[str, str]) -> None:
+        self.stem_paths = dict(stem_paths)
+
+    @property
+    def available_stems(self) -> list[str]:
+        """Return the list of available stem names."""
+        return list(self.stem_paths.keys())
+
+    def export_stem(self, stem_name: str, output_path: str) -> None:
+        """Export a single stem to a WAV file.
+
+        Args:
+            stem_name: Name of the stem to export.
+            output_path: Destination file path.
+
+        Raises:
+            KeyError: If *stem_name* is not available.
+        """
+        if stem_name not in self.stem_paths:
+            raise KeyError(f"Stem '{stem_name}' not found")
+
+        audio, sr = sf.read(self.stem_paths[stem_name], dtype="float32")
+
+        os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+        sf.write(output_path, audio, sr)
+
+    def export_mix(
+        self,
+        output_path: str,
+        stem_names: list[str] | None = None,
+        muted_stems: set[str] | None = None,
+    ) -> None:
+        """Export a mix of selected stems to a WAV file.
+
+        Args:
+            output_path: Destination file path.
+            stem_names: Stems to include. Defaults to all available stems.
+            muted_stems: Stems to exclude from the mix. Applied after
+                *stem_names* filtering.
+
+        Raises:
+            ValueError: If the resulting stem list is empty.
+        """
+        if stem_names is None:
+            stem_names = self.available_stems
+
+        if muted_stems:
+            stem_names = [s for s in stem_names if s not in muted_stems]
+
+        if not stem_names:
+            raise ValueError("No stems selected for export")
+
+        # Load and sum the selected stems.
+        mixed = None
+        for name in stem_names:
+            audio, sr = sf.read(self.stem_paths[name], dtype="float32")
+            if mixed is None:
+                mixed = audio.copy()
+            else:
+                min_len = min(mixed.shape[0], audio.shape[0])
+                mixed[:min_len] += audio[:min_len]
+
+        np.clip(mixed, -1.0, 1.0, out=mixed)
+
+        os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+        sf.write(output_path, mixed, SAMPLE_RATE)

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,134 @@
+"""Tests for the stem exporter."""
+
+import os
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from src.exporter import StemExporter
+from src.separator import SAMPLE_RATE
+
+
+@pytest.fixture
+def stem_dir(tmp_path):
+    """Create a directory with fake stem WAV files."""
+    stems = tmp_path / "stems"
+    stems.mkdir()
+
+    sr = SAMPLE_RATE
+    duration_frames = sr * 2  # 2 seconds
+
+    for name, freq in (("vocals", 220), ("drums", 440), ("bass", 110), ("other", 660)):
+        t = np.linspace(0, 2.0, duration_frames, dtype=np.float32)
+        signal = 0.3 * np.sin(2 * np.pi * freq * t)
+        stereo = np.column_stack([signal, signal])
+        sf.write(str(stems / f"{name}.wav"), stereo, sr)
+
+    return str(stems)
+
+
+@pytest.fixture
+def exporter(stem_dir):
+    """Create a StemExporter pointed at the fake stems."""
+    stem_paths = {}
+    for name in ("vocals", "drums", "bass", "other"):
+        stem_paths[name] = os.path.join(stem_dir, f"{name}.wav")
+    return StemExporter(stem_paths)
+
+
+class TestStemExporterInit:
+
+    def test_init_stores_stem_paths(self, exporter):
+        assert len(exporter.stem_paths) == 4
+        assert "vocals" in exporter.stem_paths
+
+    def test_available_stems(self, exporter):
+        assert set(exporter.available_stems) == {"vocals", "drums", "bass", "other"}
+
+
+class TestExportSingleStem:
+
+    def test_export_single_stem_wav(self, exporter, tmp_path):
+        out = str(tmp_path / "vocals_export.wav")
+        exporter.export_stem("vocals", out)
+
+        assert os.path.isfile(out)
+        audio, sr = sf.read(out)
+        assert sr == SAMPLE_RATE
+        assert audio.ndim == 2
+        assert audio.shape[1] == 2
+        assert audio.shape[0] == SAMPLE_RATE * 2
+
+    def test_export_stem_content_matches_source(self, exporter, tmp_path, stem_dir):
+        out = str(tmp_path / "bass_export.wav")
+        exporter.export_stem("bass", out)
+
+        original, _ = sf.read(os.path.join(stem_dir, "bass.wav"), dtype="float32")
+        exported, _ = sf.read(out, dtype="float32")
+        assert np.allclose(original, exported, atol=1e-5)
+
+    def test_export_nonexistent_stem_raises(self, exporter, tmp_path):
+        out = str(tmp_path / "nope.wav")
+        with pytest.raises(KeyError):
+            exporter.export_stem("guitar", out)
+
+    def test_export_creates_parent_directory(self, exporter, tmp_path):
+        out = str(tmp_path / "nested" / "deep" / "vocals.wav")
+        exporter.export_stem("vocals", out)
+        assert os.path.isfile(out)
+
+
+class TestExportMix:
+
+    def test_export_mix_all_stems(self, exporter, tmp_path):
+        out = str(tmp_path / "full_mix.wav")
+        exporter.export_mix(out)
+
+        assert os.path.isfile(out)
+        audio, sr = sf.read(out)
+        assert sr == SAMPLE_RATE
+        assert audio.ndim == 2
+        assert audio.shape[0] == SAMPLE_RATE * 2
+
+    def test_export_mix_subset(self, exporter, tmp_path):
+        out = str(tmp_path / "no_vocals.wav")
+        exporter.export_mix(out, stem_names=["drums", "bass", "other"])
+
+        audio, sr = sf.read(out, dtype="float32")
+        assert sr == SAMPLE_RATE
+
+        # Should not contain the vocals frequency component.
+        # Just verify it has audio content.
+        assert np.max(np.abs(audio)) > 0.1
+
+    def test_export_mix_with_muted(self, exporter, tmp_path):
+        out = str(tmp_path / "muted_mix.wav")
+        exporter.export_mix(out, muted_stems={"vocals"})
+
+        full_out = str(tmp_path / "full.wav")
+        exporter.export_mix(full_out)
+
+        muted, _ = sf.read(out, dtype="float32")
+        full, _ = sf.read(full_out, dtype="float32")
+
+        # Muted mix should have lower energy.
+        assert np.sum(muted ** 2) < np.sum(full ** 2)
+
+    def test_export_mix_empty_raises(self, exporter, tmp_path):
+        out = str(tmp_path / "empty.wav")
+        with pytest.raises(ValueError):
+            exporter.export_mix(out, stem_names=[])
+
+    def test_export_mix_clips_output(self, exporter, tmp_path):
+        out = str(tmp_path / "mix.wav")
+        exporter.export_mix(out)
+
+        audio, _ = sf.read(out, dtype="float32")
+        assert np.max(audio) <= 1.0
+        assert np.min(audio) >= -1.0
+
+    def test_export_mix_creates_parent_directory(self, exporter, tmp_path):
+        out = str(tmp_path / "nested" / "mix.wav")
+        exporter.export_mix(out)
+        assert os.path.isfile(out)


### PR DESCRIPTION
## What
Implements WAV export for individual stems and custom mixes.

## How
- `StemExporter` class initialized with a dict of stem name -> WAV path
- `export_stem(name, path)` -- copies a single stem to the output path
- `export_mix(path, stem_names, muted_stems)` -- sums selected stems with clipping protection and writes to WAV
- Parent directories created automatically
- MP3 export deferred to Phase 2 (requires ffmpeg, which isn't installed yet)

## Testing
- [x] 12 unit tests covering init, single stem export, mix export (all/subset/muted), error handling, clipping, directory creation
- [x] Full test suite passes (84 tests + 1 hardware, 0 failures)

Fixes #7