### PR TITLE
feat: implement main window layout with UI components

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+"""Entry point for stemma."""
+
+import sys
+
+from src.app import run
+
+sys.exit(run())

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,29 @@
+"""QApplication setup for stemma."""
+
+import sys
+
+from PySide6.QtWidgets import QApplication
+
+from src.library import SongLibrary
+from src.model_manager import ModelManager
+from src.player import MultiTrackPlayer
+from src.ui.main_window import MainWindow
+from src.ui.styles import DARK_STYLESHEET
+
+DATA_DIR = "data"
+
+
+def run() -> int:
+    """Create and run the stemma application. Returns the exit code."""
+    app = QApplication(sys.argv)
+    app.setApplicationName("stemma")
+    app.setStyleSheet(DARK_STYLESHEET)
+
+    library = SongLibrary(data_dir=DATA_DIR)
+    player = MultiTrackPlayer()
+    model_manager = ModelManager(data_dir=DATA_DIR)
+
+    window = MainWindow(library, player, model_manager)
+    window.show()
+
+    return app.exec()

--- a/src/ui/import_dialog.py
+++ b/src/ui/import_dialog.py
@@ -1,0 +1,159 @@
+"""Import song dialog -- file browser, metadata, separation trigger.
+
+Full implementation in ticket #11. This provides the minimal working
+dialog needed for the main window's File > Import action.
+"""
+
+import os
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QProgressBar,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from src.library import SongLibrary
+from src.model_manager import ModelManager
+from src.separator import SeparatorWorker
+
+
+class ImportDialog(QDialog):
+    """Dialog for importing and separating a song."""
+
+    def __init__(
+        self,
+        library: SongLibrary,
+        model_manager: ModelManager,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Import Song")
+        self.setMinimumWidth(500)
+
+        self._library = library
+        self._model_manager = model_manager
+        self._worker: SeparatorWorker | None = None
+        self._selected_path: str = ""
+
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        # File selection row.
+        file_row = QHBoxLayout()
+        self._path_edit = QLineEdit()
+        self._path_edit.setPlaceholderText("Select an audio file...")
+        self._path_edit.setReadOnly(True)
+        file_row.addWidget(self._path_edit)
+
+        browse_btn = QPushButton("Browse...")
+        browse_btn.clicked.connect(self._on_browse)
+        file_row.addWidget(browse_btn)
+        layout.addLayout(file_row)
+
+        # Metadata fields.
+        title_row = QHBoxLayout()
+        title_row.addWidget(QLabel("Title:"))
+        self._title_edit = QLineEdit()
+        title_row.addWidget(self._title_edit)
+        layout.addLayout(title_row)
+
+        artist_row = QHBoxLayout()
+        artist_row.addWidget(QLabel("Artist:"))
+        self._artist_edit = QLineEdit()
+        artist_row.addWidget(self._artist_edit)
+        layout.addLayout(artist_row)
+
+        # Progress.
+        self._progress_bar = QProgressBar()
+        self._progress_bar.setVisible(False)
+        layout.addWidget(self._progress_bar)
+
+        self._status_label = QLabel("")
+        self._status_label.setVisible(False)
+        layout.addWidget(self._status_label)
+
+        # Buttons.
+        self._button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok
+            | QDialogButtonBox.StandardButton.Cancel
+        )
+        self._button_box.button(
+            QDialogButtonBox.StandardButton.Ok
+        ).setText("Import && Separate")
+        self._button_box.accepted.connect(self._on_import)
+        self._button_box.rejected.connect(self.reject)
+        layout.addWidget(self._button_box)
+
+    def _on_browse(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select Audio File",
+            "",
+            "Audio Files (*.mp3 *.wav *.flac);;All Files (*)",
+        )
+        if path:
+            self._selected_path = path
+            self._path_edit.setText(path)
+
+            # Auto-fill title from filename.
+            basename = os.path.splitext(os.path.basename(path))[0]
+            if not self._title_edit.text():
+                self._title_edit.setText(basename)
+
+    def _on_import(self) -> None:
+        if not self._selected_path:
+            return
+
+        title = self._title_edit.text() or "Untitled"
+        artist = self._artist_edit.text() or "Unknown Artist"
+
+        # Add to library (copies the file).
+        song = self._library.add_song(
+            title=title,
+            artist=artist,
+            original_path=self._selected_path,
+        )
+
+        # Start separation.
+        model_path = self._model_manager.model_path(is_6_stem=False)
+
+        if not os.path.isfile(model_path):
+            # Model not downloaded yet -- skip separation for now.
+            self._library.update_song(song.id, model_used="pending")
+            self.accept()
+            return
+
+        self._progress_bar.setVisible(True)
+        self._status_label.setVisible(True)
+        self._button_box.setEnabled(False)
+
+        self._worker = SeparatorWorker(
+            input_path=song.original_path,
+            output_dir=song.stems_path,
+            model_path=model_path,
+            is_6_stem=False,
+        )
+        self._worker.progress.connect(self._on_progress)
+        self._worker.finished.connect(lambda _: self._on_finished(song.id))
+        self._worker.error.connect(self._on_error)
+        self._worker.start()
+
+    def _on_progress(self, percent: int, message: str) -> None:
+        self._progress_bar.setValue(percent)
+        self._status_label.setText(message)
+
+    def _on_finished(self, song_id: str) -> None:
+        self._library.update_song(song_id, model_used="htdemucs")
+        self.accept()
+
+    def _on_error(self, message: str) -> None:
+        self._status_label.setText(f"Error: {message}")
+        self._button_box.setEnabled(True)

--- a/src/ui/library_panel.py
+++ b/src/ui/library_panel.py
@@ -1,0 +1,59 @@
+"""Song library panel -- left sidebar listing imported songs.
+
+Displays the song library as a list and emits a signal when a song is
+selected. Full implementation in ticket #10.
+"""
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import (
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.library import SongLibrary
+
+
+class LibraryPanel(QWidget):
+    """Left sidebar showing the song library.
+
+    Signals:
+        song_selected(str): Emitted with the song ID when a song is clicked.
+    """
+
+    song_selected = Signal(str)
+
+    def __init__(self, library: SongLibrary, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._library = library
+
+        self._setup_ui()
+        self.refresh()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+
+        header = QLabel("Library")
+        header.setObjectName("title-label")
+        layout.addWidget(header)
+
+        self._list = QListWidget()
+        self._list.currentItemChanged.connect(self._on_item_changed)
+        layout.addWidget(self._list)
+
+    def refresh(self) -> None:
+        """Reload the song list from the library."""
+        self._list.clear()
+        for song in self._library.songs:
+            item = QListWidgetItem(f"{song.artist} - {song.title}")
+            item.setData(256, song.id)  # Qt.UserRole = 256
+            self._list.addItem(item)
+
+    def _on_item_changed(self, current: QListWidgetItem | None, _previous) -> None:
+        if current is not None:
+            song_id = current.data(256)
+            if song_id:
+                self.song_selected.emit(song_id)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,0 +1,147 @@
+"""Main application window layout.
+
+Left panel: song library list.
+Center: player controls and stem mixer.
+Menu bar: File > Import / Export.
+"""
+
+import os
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QMainWindow,
+    QMessageBox,
+    QSplitter,
+)
+
+from src.exporter import StemExporter
+from src.library import SongLibrary
+from src.model_manager import ModelManager
+from src.player import MultiTrackPlayer
+from src.ui.library_panel import LibraryPanel
+from src.ui.player_controls import PlayerControls
+
+
+class MainWindow(QMainWindow):
+    """Top-level application window for stemma."""
+
+    def __init__(
+        self,
+        library: SongLibrary,
+        player: MultiTrackPlayer,
+        model_manager: ModelManager,
+    ) -> None:
+        super().__init__()
+        self.setWindowTitle("stemma")
+        self.setMinimumSize(900, 600)
+
+        self._library = library
+        self._player = player
+        self._model_manager = model_manager
+        self._current_song_id: str | None = None
+
+        self._setup_ui()
+        self._setup_menu()
+        self._connect_signals()
+
+    # ------------------------------------------------------------------
+    # UI Setup
+    # ------------------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        """Build the main window layout."""
+        self._library_panel = LibraryPanel(self._library)
+        self._player_controls = PlayerControls(self._player)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+        splitter.addWidget(self._library_panel)
+        splitter.addWidget(self._player_controls)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 3)
+
+        self.setCentralWidget(splitter)
+
+    def _setup_menu(self) -> None:
+        """Create the menu bar."""
+        menu_bar = self.menuBar()
+        file_menu = menu_bar.addMenu("&File")
+
+        import_action = file_menu.addAction("&Import Song...")
+        import_action.triggered.connect(self._on_import)
+
+        export_action = file_menu.addAction("&Export Mix...")
+        export_action.triggered.connect(self._on_export)
+
+        file_menu.addSeparator()
+
+        quit_action = file_menu.addAction("&Quit")
+        quit_action.triggered.connect(self.close)
+
+    def _connect_signals(self) -> None:
+        """Wire up signals between panels."""
+        self._library_panel.song_selected.connect(self._on_song_selected)
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+
+    def _on_song_selected(self, song_id: str) -> None:
+        """Load stems for the selected song into the player."""
+        song = self._library.get_song(song_id)
+        if song is None:
+            return
+
+        stem_names = ("vocals", "drums", "bass", "other", "guitar", "piano")
+        stem_paths = {}
+        for name in stem_names:
+            path = os.path.join(song.stems_path, f"{name}.wav")
+            if os.path.isfile(path):
+                stem_paths[name] = path
+
+        if stem_paths:
+            self._player.stop()
+            self._player.load_stems(stem_paths)
+            self._player_controls.set_stem_names(list(stem_paths.keys()))
+            self._current_song_id = song_id
+
+    def _on_import(self) -> None:
+        """Open the import dialog."""
+        from src.ui.import_dialog import ImportDialog
+
+        dialog = ImportDialog(
+            library=self._library,
+            model_manager=self._model_manager,
+            parent=self,
+        )
+        if dialog.exec():
+            self._library_panel.refresh()
+
+    def _on_export(self) -> None:
+        """Export the current mix as a WAV file."""
+        if not self._player._stems:
+            QMessageBox.information(
+                self, "Export", "No stems loaded. Import and separate a song first."
+            )
+            return
+
+        song = self._library.get_song(self._current_song_id) if self._current_song_id else None
+        if song is None:
+            return
+
+        stem_paths = {}
+        for name in ("vocals", "drums", "bass", "other", "guitar", "piano"):
+            path = os.path.join(song.stems_path, f"{name}.wav")
+            if os.path.isfile(path):
+                stem_paths[name] = path
+
+        if not stem_paths:
+            return
+
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Export Mix", "", "WAV Files (*.wav)"
+        )
+        if path:
+            exporter = StemExporter(stem_paths)
+            exporter.export_mix(path, muted_stems=self._player._muted_stems)
+            QMessageBox.information(self, "Export", f"Mix exported to {path}")

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -1,0 +1,184 @@
+"""Player transport controls and per-stem mute/solo mixer.
+
+Transport: Play/Pause, Stop, seek slider, time display.
+Per-stem row: label, Mute button, Solo button.
+Color-coded stems. Full implementation in ticket #9.
+"""
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSlider,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.player import MultiTrackPlayer
+from src.ui.styles import STEM_COLORS
+
+
+def _format_time(seconds: float) -> str:
+    """Format seconds as mm:ss."""
+    m = int(seconds) // 60
+    s = int(seconds) % 60
+    return f"{m}:{s:02d}"
+
+
+class StemRow(QWidget):
+    """A single stem row with label, mute, and solo buttons."""
+
+    def __init__(self, stem_name: str, player: MultiTrackPlayer,
+                 parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._stem_name = stem_name
+        self._player = player
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 2, 0, 2)
+
+        color = STEM_COLORS.get(stem_name, "#95a5a6")
+
+        self._label = QLabel(stem_name.capitalize())
+        self._label.setFixedWidth(70)
+        self._label.setStyleSheet(f"color: {color}; font-weight: bold;")
+        layout.addWidget(self._label)
+
+        self._mute_btn = QPushButton("M")
+        self._mute_btn.setCheckable(True)
+        self._mute_btn.setFixedSize(32, 28)
+        self._mute_btn.setToolTip(f"Mute {stem_name}")
+        self._mute_btn.toggled.connect(self._on_mute)
+        layout.addWidget(self._mute_btn)
+
+        self._solo_btn = QPushButton("S")
+        self._solo_btn.setCheckable(True)
+        self._solo_btn.setFixedSize(32, 28)
+        self._solo_btn.setToolTip(f"Solo {stem_name}")
+        self._solo_btn.toggled.connect(self._on_solo)
+        layout.addWidget(self._solo_btn)
+
+        layout.addStretch()
+
+    def _on_mute(self, checked: bool) -> None:
+        self._player.set_mute(self._stem_name, checked)
+
+    def _on_solo(self, checked: bool) -> None:
+        self._player.set_solo(self._stem_name, checked)
+
+
+class PlayerControls(QWidget):
+    """Transport controls and stem mixer panel."""
+
+    def __init__(self, player: MultiTrackPlayer,
+                 parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._player = player
+        self._stem_rows: dict[str, StemRow] = {}
+        self._seeking = False
+
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 8, 12, 8)
+
+        # -- Transport bar --
+        transport = QHBoxLayout()
+
+        self._play_btn = QPushButton("Play")
+        self._play_btn.setFixedWidth(70)
+        self._play_btn.clicked.connect(self._on_play_pause)
+        transport.addWidget(self._play_btn)
+
+        self._stop_btn = QPushButton("Stop")
+        self._stop_btn.setFixedWidth(60)
+        self._stop_btn.clicked.connect(self._on_stop)
+        transport.addWidget(self._stop_btn)
+
+        self._time_label = QLabel("0:00 / 0:00")
+        self._time_label.setFixedWidth(100)
+        self._time_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        transport.addWidget(self._time_label)
+
+        self._seek_slider = QSlider(Qt.Orientation.Horizontal)
+        self._seek_slider.setRange(0, 1000)
+        self._seek_slider.sliderPressed.connect(self._on_seek_start)
+        self._seek_slider.sliderReleased.connect(self._on_seek_end)
+        transport.addWidget(self._seek_slider)
+
+        layout.addLayout(transport)
+
+        # -- Stem mixer --
+        self._mixer_label = QLabel("Stems")
+        self._mixer_label.setObjectName("title-label")
+        layout.addWidget(self._mixer_label)
+
+        self._stem_container = QVBoxLayout()
+        layout.addLayout(self._stem_container)
+
+        # Placeholder when no stems are loaded.
+        self._empty_label = QLabel("Import a song to get started.")
+        self._empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._empty_label.setStyleSheet("color: #585b70; padding: 40px;")
+        layout.addWidget(self._empty_label)
+
+        layout.addStretch()
+
+    def _connect_signals(self) -> None:
+        self._player.position_changed.connect(self._on_position_changed)
+        self._player.state_changed.connect(self._on_state_changed)
+        self._player.play_finished.connect(self._on_play_finished)
+
+    def set_stem_names(self, stem_names: list[str]) -> None:
+        """Populate the stem mixer with rows for each stem."""
+        # Clear existing rows.
+        for row in self._stem_rows.values():
+            row.setParent(None)
+            row.deleteLater()
+        self._stem_rows.clear()
+
+        self._empty_label.setVisible(not stem_names)
+
+        for name in stem_names:
+            row = StemRow(name, self._player)
+            self._stem_container.addWidget(row)
+            self._stem_rows[name] = row
+
+    # -- Transport slots --
+
+    def _on_play_pause(self) -> None:
+        if self._player.is_playing:
+            self._player.pause()
+        else:
+            self._player.play()
+
+    def _on_stop(self) -> None:
+        self._player.stop()
+
+    def _on_seek_start(self) -> None:
+        self._seeking = True
+
+    def _on_seek_end(self) -> None:
+        self._seeking = False
+        total = self._player.total_seconds
+        if total > 0:
+            ratio = self._seek_slider.value() / 1000.0
+            self._player.seek(ratio * total)
+
+    def _on_position_changed(self, pos_s: float) -> None:
+        total = self._player.total_seconds
+        self._time_label.setText(
+            f"{_format_time(pos_s)} / {_format_time(total)}"
+        )
+        if not self._seeking and total > 0:
+            self._seek_slider.setValue(int(pos_s / total * 1000))
+
+    def _on_state_changed(self, playing: bool) -> None:
+        self._play_btn.setText("Pause" if playing else "Play")
+
+    def _on_play_finished(self) -> None:
+        self._play_btn.setText("Play")
+        self._seek_slider.setValue(0)

--- a/src/ui/styles.py
+++ b/src/ui/styles.py
@@ -1,0 +1,160 @@
+"""Dark theme stylesheet for stemma.
+
+Applied globally via QApplication.setStyleSheet().
+"""
+
+# Stem color palette used by player_controls.py.
+STEM_COLORS = {
+    "vocals": "#9b59b6",   # Purple
+    "drums": "#e67e22",    # Orange
+    "bass": "#3498db",     # Blue
+    "guitar": "#e74c3c",   # Red
+    "piano": "#2ecc71",    # Green
+    "other": "#95a5a6",    # Gray
+}
+
+DARK_STYLESHEET = """
+QMainWindow, QDialog {
+    background-color: #1e1e2e;
+}
+
+QMenuBar {
+    background-color: #181825;
+    color: #cdd6f4;
+    border-bottom: 1px solid #313244;
+}
+
+QMenuBar::item:selected {
+    background-color: #313244;
+}
+
+QMenu {
+    background-color: #1e1e2e;
+    color: #cdd6f4;
+    border: 1px solid #313244;
+}
+
+QMenu::item:selected {
+    background-color: #313244;
+}
+
+QSplitter::handle {
+    background-color: #313244;
+    width: 2px;
+}
+
+QWidget {
+    background-color: #1e1e2e;
+    color: #cdd6f4;
+    font-family: "Segoe UI", sans-serif;
+    font-size: 13px;
+}
+
+QLabel {
+    color: #cdd6f4;
+}
+
+QLabel#title-label {
+    font-size: 15px;
+    font-weight: bold;
+    color: #cdd6f4;
+}
+
+QPushButton {
+    background-color: #313244;
+    color: #cdd6f4;
+    border: 1px solid #45475a;
+    border-radius: 4px;
+    padding: 6px 14px;
+    min-height: 24px;
+}
+
+QPushButton:hover {
+    background-color: #45475a;
+}
+
+QPushButton:pressed {
+    background-color: #585b70;
+}
+
+QPushButton:checked {
+    background-color: #585b70;
+    border: 1px solid #89b4fa;
+}
+
+QPushButton:disabled {
+    background-color: #1e1e2e;
+    color: #585b70;
+    border-color: #313244;
+}
+
+QSlider::groove:horizontal {
+    background: #313244;
+    height: 6px;
+    border-radius: 3px;
+}
+
+QSlider::handle:horizontal {
+    background: #89b4fa;
+    width: 14px;
+    height: 14px;
+    margin: -4px 0;
+    border-radius: 7px;
+}
+
+QSlider::sub-page:horizontal {
+    background: #89b4fa;
+    border-radius: 3px;
+}
+
+QListWidget {
+    background-color: #181825;
+    border: 1px solid #313244;
+    border-radius: 4px;
+    outline: none;
+}
+
+QListWidget::item {
+    padding: 8px;
+    border-bottom: 1px solid #313244;
+}
+
+QListWidget::item:selected {
+    background-color: #313244;
+    color: #cdd6f4;
+}
+
+QListWidget::item:hover {
+    background-color: #252536;
+}
+
+QProgressBar {
+    background-color: #313244;
+    border: none;
+    border-radius: 3px;
+    height: 8px;
+    text-align: center;
+    color: transparent;
+}
+
+QProgressBar::chunk {
+    background-color: #89b4fa;
+    border-radius: 3px;
+}
+
+QScrollBar:vertical {
+    background: #181825;
+    width: 8px;
+    border: none;
+}
+
+QScrollBar::handle:vertical {
+    background: #45475a;
+    border-radius: 4px;
+    min-height: 20px;
+}
+
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+}
+"""


### PR DESCRIPTION
## What
Implements the full UI shell for stemma -- the app is now launchable with `python main.py`.

<img width="905" height="635" alt="Screenshot 2026-03-20 202407" src="https://github.com/user-attachments/assets/89aba508-d32c-46e0-a799-4f4edcb452be" />

## How
**7 files, 745 lines:**

- **`main.py`** -- entry point
- **`src/app.py`** -- QApplication setup, stylesheet, dependency wiring
- **`src/ui/main_window.py`** -- QMainWindow with horizontal splitter (library left, player center), File menu (Import Song, Export Mix, Quit), song selection loads stems into player
- **`src/ui/library_panel.py`** -- QListWidget displaying songs, emits `song_selected(id)` signal
- **`src/ui/player_controls.py`** -- Transport bar (Play/Pause, Stop, seek slider, mm:ss time display), per-stem StemRow widgets with color-coded labels and M/S toggle buttons
- **`src/ui/import_dialog.py`** -- File browser, title/artist fields, progress bar, runs SeparatorWorker in background
- **`src/ui/styles.py`** -- Dark theme (Catppuccin Mocha-inspired), stem color palette, styled scrollbars/sliders/buttons

**Architecture decisions:**
- MainWindow takes `SongLibrary`, `MultiTrackPlayer`, and `ModelManager` as constructor args (dependency injection, testable)
- ImportDialog lazily imported to avoid circular deps
- Splitter between library and player is user-resizable
- Stem colors match PROJECT.md spec (vocals=purple, drums=orange, bass=blue, guitar=red, piano=green, other=gray)

## Testing
- [x] Window creates without errors (verified programmatically)
- [x] All 80 fast tests pass, no regressions
- [x] App launches with `python main.py`

Fixes #8

Note: This PR also provides working implementations for #9 (player controls), #10 (library panel), #11 (import dialog), and #12 (dark theme). These could be closed alongside #8, or kept open for refinement -- your call.