### PR TITLE
fix: expose public player API, use stem constants

### DIFF
--- a/src/player.py
+++ b/src/player.py
@@ -47,6 +47,11 @@ class MultiTrackPlayer(QObject):
         self._timer.timeout.connect(self._emit_position)
 
     @property
+    def has_stems(self) -> bool:
+        """Return True if any stems are loaded."""
+        return bool(self._stems)
+
+    @property
     def is_playing(self) -> bool:
         """Return True if audio is currently playing."""
         return self._is_playing
@@ -149,6 +154,11 @@ class MultiTrackPlayer(QObject):
             self._muted_stems.add(stem_name)
         else:
             self._muted_stems.discard(stem_name)
+
+    @property
+    def muted_stems(self) -> set[str]:
+        """Return the set of currently muted stem names."""
+        return set(self._muted_stems)
 
     def set_solo(self, stem_name: str, soloed: bool) -> None:
         """Solo or unsolo a specific stem."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -19,8 +19,11 @@ from src.exporter import StemExporter
 from src.library import SongLibrary
 from src.model_manager import ModelManager
 from src.player import MultiTrackPlayer
+from src.separator import STEMS_4, STEMS_6
 from src.ui.library_panel import LibraryPanel
 from src.ui.player_controls import PlayerControls
+
+ALL_STEM_NAMES = STEMS_6  # Superset: try loading all possible stems.
 
 
 class MainWindow(QMainWindow):
@@ -92,7 +95,7 @@ class MainWindow(QMainWindow):
         if song is None:
             return
 
-        stem_names = ("vocals", "drums", "bass", "other", "guitar", "piano")
+        stem_names = ALL_STEM_NAMES
         stem_paths = {}
         for name in stem_names:
             path = os.path.join(song.stems_path, f"{name}.wav")
@@ -119,7 +122,7 @@ class MainWindow(QMainWindow):
 
     def _on_export(self) -> None:
         """Export the current mix as a WAV file."""
-        if not self._player._stems:
+        if not self._player.has_stems:
             QMessageBox.information(
                 self, "Export", "No stems loaded. Import and separate a song first."
             )
@@ -130,7 +133,7 @@ class MainWindow(QMainWindow):
             return
 
         stem_paths = {}
-        for name in ("vocals", "drums", "bass", "other", "guitar", "piano"):
+        for name in ALL_STEM_NAMES:
             path = os.path.join(song.stems_path, f"{name}.wav")
             if os.path.isfile(path):
                 stem_paths[name] = path
@@ -143,5 +146,5 @@ class MainWindow(QMainWindow):
         )
         if path:
             exporter = StemExporter(stem_paths)
-            exporter.export_mix(path, muted_stems=self._player._muted_stems)
+            exporter.export_mix(path, muted_stems=self._player.muted_stems)
             QMessageBox.information(self, "Export", f"Mix exported to {path}")


### PR DESCRIPTION
## Summary
- Add `has_stems` and `muted_stems` public properties to `MultiTrackPlayer` — the UI was reaching into `_stems` and `_muted_stems` directly
- Replace hardcoded `("vocals", "drums", "bass", "other", "guitar", "piano")` tuples in `main_window.py` with `STEMS_6` imported from `separator.py`

## Context
Full codebase audit before starting Phase 2. These were the only real issues found — the backend is solid otherwise. Also closed #9, #10, #11, #12 as already implemented.

## Test plan
- [x] All 80 fast tests pass
- [x] No behavioral changes — purely API hygiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)