### PR TITLE
feat: per-stem volume sliders

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -50,6 +50,7 @@ class StemExporter:
         output_path: str,
         stem_names: list[str] | None = None,
         muted_stems: set[str] | None = None,
+        volumes: dict[str, float] | None = None,
     ) -> None:
         """Export a mix of selected stems to a WAV file.
 
@@ -58,6 +59,8 @@ class StemExporter:
             stem_names: Stems to include. Defaults to all available stems.
             muted_stems: Stems to exclude from the mix. Applied after
                 *stem_names* filtering.
+            volumes: Per-stem gain levels (0.0–2.0). Missing stems
+                default to 1.0.
 
         Raises:
             ValueError: If the resulting stem list is empty.
@@ -71,10 +74,15 @@ class StemExporter:
         if not stem_names:
             raise ValueError("No stems selected for export")
 
-        # Load and sum the selected stems.
+        if volumes is None:
+            volumes = {}
+
+        # Load and sum the selected stems with volume applied.
         mixed = None
         for name in stem_names:
             audio, sr = sf.read(self.stem_paths[name], dtype="float32")
+            gain = volumes.get(name, 1.0)
+            audio = audio * gain
             if mixed is None:
                 mixed = audio.copy()
             else:

--- a/src/player.py
+++ b/src/player.py
@@ -37,6 +37,7 @@ class MultiTrackPlayer(QObject):
         self._is_playing: bool = False
         self._muted_stems: set[str] = set()
         self._soloed_stems: set[str] = set()
+        self._volumes: dict[str, float] = {}  # Per-stem gain, 0.0–2.0
 
         # Hardware stream.
         self._stream: sd.OutputStream | None = None
@@ -73,6 +74,7 @@ class MultiTrackPlayer(QObject):
         self._stems.clear()
         self._muted_stems.clear()
         self._soloed_stems.clear()
+        self._volumes.clear()
 
         max_frames = 0
         sample_rate = 0
@@ -160,6 +162,19 @@ class MultiTrackPlayer(QObject):
         """Return the set of currently muted stem names."""
         return set(self._muted_stems)
 
+    def set_volume(self, stem_name: str, volume: float) -> None:
+        """Set the volume (gain) for a stem.
+
+        Args:
+            stem_name: Name of the stem.
+            volume: Gain from 0.0 (silent) to 2.0 (double). Clamped.
+        """
+        self._volumes[stem_name] = max(0.0, min(volume, 2.0))
+
+    def get_volume(self, stem_name: str) -> float:
+        """Return the current volume for a stem (default 1.0)."""
+        return self._volumes.get(stem_name, 1.0)
+
     def set_solo(self, stem_name: str, soloed: bool) -> None:
         """Solo or unsolo a specific stem."""
         if soloed:
@@ -224,7 +239,8 @@ class MultiTrackPlayer(QObject):
             read_len = stem_end - start
 
             if read_len > 0:
-                outdata[:read_len] += stem_data[start:stem_end]
+                gain = self._volumes.get(name, 1.0)
+                outdata[:read_len] += stem_data[start:stem_end] * gain
 
         self._current_frame += frames_to_read
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -146,5 +146,13 @@ class MainWindow(QMainWindow):
         )
         if path:
             exporter = StemExporter(stem_paths)
-            exporter.export_mix(path, muted_stems=self._player.muted_stems)
+            volumes = {
+                name: self._player.get_volume(name)
+                for name in stem_paths
+            }
+            exporter.export_mix(
+                path,
+                muted_stems=self._player.muted_stems,
+                volumes=volumes,
+            )
             QMessageBox.information(self, "Export", f"Mix exported to {path}")

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -59,6 +59,19 @@ class StemRow(QWidget):
         self._solo_btn.toggled.connect(self._on_solo)
         layout.addWidget(self._solo_btn)
 
+        self._volume_slider = QSlider(Qt.Orientation.Horizontal)
+        self._volume_slider.setRange(0, 100)
+        self._volume_slider.setValue(100)
+        self._volume_slider.setFixedWidth(120)
+        self._volume_slider.setToolTip(f"{stem_name} volume")
+        self._volume_slider.valueChanged.connect(self._on_volume)
+        layout.addWidget(self._volume_slider)
+
+        self._vol_label = QLabel("100%")
+        self._vol_label.setFixedWidth(40)
+        self._vol_label.setAlignment(Qt.AlignmentFlag.AlignRight)
+        layout.addWidget(self._vol_label)
+
         layout.addStretch()
 
     def _on_mute(self, checked: bool) -> None:
@@ -66,6 +79,11 @@ class StemRow(QWidget):
 
     def _on_solo(self, checked: bool) -> None:
         self._player.set_solo(self._stem_name, checked)
+
+    def _on_volume(self, value: int) -> None:
+        gain = value / 100.0
+        self._player.set_volume(self._stem_name, gain)
+        self._vol_label.setText(f"{value}%")
 
 
 class PlayerControls(QWidget):

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -132,3 +132,19 @@ class TestExportMix:
         out = str(tmp_path / "nested" / "mix.wav")
         exporter.export_mix(out)
         assert os.path.isfile(out)
+
+    def test_export_mix_with_volumes(self, exporter, tmp_path):
+        full_out = str(tmp_path / "full.wav")
+        exporter.export_mix(full_out)
+
+        half_out = str(tmp_path / "half.wav")
+        volumes = {"vocals": 0.5, "drums": 0.5, "bass": 0.5, "other": 0.5}
+        exporter.export_mix(half_out, volumes=volumes)
+
+        full, _ = sf.read(full_out, dtype="float32")
+        half, _ = sf.read(half_out, dtype="float32")
+
+        # Half-volume mix should have ~25% the energy of full mix
+        full_energy = np.sum(full ** 2)
+        half_energy = np.sum(half ** 2)
+        assert half_energy < full_energy * 0.5

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -158,3 +158,83 @@ class TestMultiTrackPlayerMixing:
         assert np.allclose(outdata[:10], 0.6, atol=1e-4)
         assert np.allclose(outdata[10:], 0.0)
         assert not player.is_playing # Flag should be flipped to false
+
+
+class TestMultiTrackPlayerVolume:
+    """Test per-stem volume control."""
+
+    def test_default_volume_is_1(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+
+        assert player.get_volume("vocals") == 1.0
+        assert player.get_volume("drums") == 1.0
+
+    def test_set_volume_changes_gain(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+
+        player.set_volume("vocals", 0.5)
+        assert player.get_volume("vocals") == 0.5
+
+    def test_set_volume_clamps_range(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+
+        player.set_volume("vocals", -0.5)
+        assert player.get_volume("vocals") == 0.0
+
+        player.set_volume("vocals", 2.5)
+        assert player.get_volume("vocals") == 2.0
+
+    def test_volume_applied_in_callback(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._is_playing = True
+
+        player.set_volume("vocals", 0.5)  # 0.1 * 0.5 = 0.05
+        player.set_volume("drums", 0.0)   # 0.2 * 0.0 = 0.0
+        # bass stays at 1.0: 0.3 * 1.0 = 0.3
+
+        outdata = np.zeros((100, 2), dtype=np.float32)
+        player._audio_callback(outdata, 100, {}, sd.CallbackFlags())
+
+        # 0.05 + 0.0 + 0.3 = 0.35
+        assert np.allclose(outdata, 0.35, atol=1e-4)
+
+    def test_volume_with_mute(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._is_playing = True
+
+        player.set_volume("vocals", 0.5)
+        player.set_mute("vocals", True)
+
+        outdata = np.zeros((100, 2), dtype=np.float32)
+        player._audio_callback(outdata, 100, {}, sd.CallbackFlags())
+
+        # Muted vocals: 0.0. Drums 0.2 + Bass 0.3 = 0.5
+        assert np.allclose(outdata, 0.5, atol=1e-4)
+
+    def test_volume_with_solo(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._is_playing = True
+
+        player.set_volume("drums", 0.5)
+        player.set_solo("drums", True)
+
+        outdata = np.zeros((100, 2), dtype=np.float32)
+        player._audio_callback(outdata, 100, {}, sd.CallbackFlags())
+
+        # Only drums at half volume: 0.2 * 0.5 = 0.1
+        assert np.allclose(outdata, 0.1, atol=1e-4)
+
+    def test_load_stems_resets_volumes(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player.set_volume("vocals", 0.5)
+
+        # Reload — volumes should reset to 1.0
+        player.load_stems(mock_stems)
+        assert player.get_volume("vocals") == 1.0


### PR DESCRIPTION
## Summary
- Add continuous volume control (0–100%) per stem, replacing binary mute-only mixing
- Volume slider + percentage label in each stem row, between M/S buttons and the stretch
- Gain applied in the real-time audio callback (`_audio_callback`) for zero-latency response
- Export respects volume levels — `export_mix()` now accepts a `volumes` dict
- 7 new unit tests covering volume math, mute/solo interaction, clamping, and reset on reload

Closes #25

## Test plan
- [x] 88 fast tests pass (7 new for volume)
- [ ] Manual: import a song, drag volume sliders during playback, verify smooth gain changes
- [ ] Manual: export mix with adjusted volumes, verify output reflects levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)