### PR TITLE
feat: add MP3 export support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sounddevice>=0.4.6
 soundfile>=0.12.1
 numpy>=1.26.0
 pydub>=0.25.1
+lameenc>=1.7.0
 librosa>=0.10.1
 
 # Development dependencies

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -1,7 +1,8 @@
-"""Export individual stems or custom mixes as WAV files.
+"""Export individual stems or custom mixes as WAV or MP3 files.
 
 Reads stem WAV files from disk and writes either a single stem copy
 or a mixed-down combination of selected stems to a new file.
+Output format is determined by the file extension (.wav or .mp3).
 """
 
 import os
@@ -10,6 +11,68 @@ import numpy as np
 import soundfile as sf
 
 from src.separator import SAMPLE_RATE
+
+# Supported output formats by extension.
+SUPPORTED_FORMATS = (".wav", ".mp3")
+
+
+def _write_audio(path: str, audio: np.ndarray, sample_rate: int) -> None:
+    """Write audio data to a file, choosing format by extension.
+
+    Args:
+        path: Output file path (.wav or .mp3).
+        audio: Audio array of shape (frames, channels), float32 in [-1, 1].
+        sample_rate: Sample rate in Hz.
+
+    Raises:
+        ValueError: If the file extension is not supported.
+    """
+    ext = os.path.splitext(path)[1].lower()
+
+    if ext == ".wav":
+        sf.write(path, audio, sample_rate)
+    elif ext == ".mp3":
+        _write_mp3(path, audio, sample_rate)
+    else:
+        raise ValueError(f"Unsupported format '{ext}'. Use .wav or .mp3.")
+
+
+def _write_mp3(
+    path: str,
+    audio: np.ndarray,
+    sample_rate: int,
+    bitrate: int = 320,
+) -> None:
+    """Encode float32 audio to MP3 using lameenc.
+
+    Args:
+        path: Output file path.
+        audio: Float32 array of shape (frames, channels) in [-1, 1].
+        sample_rate: Sample rate in Hz.
+        bitrate: MP3 bitrate in kbps (default 320).
+    """
+    import lameenc
+
+    # Ensure stereo.
+    if audio.ndim == 1:
+        audio = np.column_stack([audio, audio])
+
+    n_channels = audio.shape[1]
+
+    # Convert float32 [-1, 1] to int16 PCM.
+    pcm = (audio * 32767).clip(-32768, 32767).astype(np.int16)
+
+    encoder = lameenc.Encoder()
+    encoder.set_bit_rate(bitrate)
+    encoder.set_in_sample_rate(sample_rate)
+    encoder.set_channels(n_channels)
+    encoder.set_quality(2)  # 2 = high quality
+
+    mp3_data = encoder.encode(pcm.tobytes())
+    mp3_data += encoder.flush()
+
+    with open(path, "wb") as f:
+        f.write(mp3_data)
 
 
 class StemExporter:
@@ -28,11 +91,11 @@ class StemExporter:
         return list(self.stem_paths.keys())
 
     def export_stem(self, stem_name: str, output_path: str) -> None:
-        """Export a single stem to a WAV file.
+        """Export a single stem to a WAV or MP3 file.
 
         Args:
             stem_name: Name of the stem to export.
-            output_path: Destination file path.
+            output_path: Destination file path (.wav or .mp3).
 
         Raises:
             KeyError: If *stem_name* is not available.
@@ -43,7 +106,7 @@ class StemExporter:
         audio, sr = sf.read(self.stem_paths[stem_name], dtype="float32")
 
         os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
-        sf.write(output_path, audio, sr)
+        _write_audio(output_path, audio, sr)
 
     def export_mix(
         self,
@@ -92,4 +155,4 @@ class StemExporter:
         np.clip(mixed, -1.0, 1.0, out=mixed)
 
         os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
-        sf.write(output_path, mixed, SAMPLE_RATE)
+        _write_audio(output_path, mixed, SAMPLE_RATE)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -209,7 +209,8 @@ class MainWindow(QMainWindow):
             return
 
         path, _ = QFileDialog.getSaveFileName(
-            self, "Export Mix", "", "WAV Files (*.wav)"
+            self, "Export Mix", "",
+            "WAV Files (*.wav);;MP3 Files (*.mp3)"
         )
         if path:
             exporter = StemExporter(stem_paths)

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import soundfile as sf
 
-from src.exporter import StemExporter
+from src.exporter import StemExporter, _write_audio
 from src.separator import SAMPLE_RATE
 
 
@@ -148,3 +148,38 @@ class TestExportMix:
         full_energy = np.sum(full ** 2)
         half_energy = np.sum(half ** 2)
         assert half_energy < full_energy * 0.5
+
+
+class TestMP3Export:
+
+    def test_export_stem_as_mp3(self, exporter, tmp_path):
+        out = str(tmp_path / "vocals.mp3")
+        exporter.export_stem("vocals", out)
+        assert os.path.isfile(out)
+        # MP3 files start with ID3 tag or MPEG sync word (0xff 0xfb/f3/f2).
+        with open(out, "rb") as f:
+            header = f.read(2)
+        assert header == b"ID3" [:2] or header[0:1] == b"\xff"
+
+    def test_export_mix_as_mp3(self, exporter, tmp_path):
+        out = str(tmp_path / "mix.mp3")
+        exporter.export_mix(out)
+        assert os.path.isfile(out)
+        assert os.path.getsize(out) > 1000  # Not trivially empty.
+
+    def test_mp3_file_is_smaller_than_wav(self, exporter, tmp_path):
+        wav_out = str(tmp_path / "mix.wav")
+        mp3_out = str(tmp_path / "mix.mp3")
+        exporter.export_mix(wav_out)
+        exporter.export_mix(mp3_out)
+        assert os.path.getsize(mp3_out) < os.path.getsize(wav_out)
+
+    def test_write_audio_unsupported_format(self, tmp_path):
+        audio = np.zeros((1000, 2), dtype=np.float32)
+        with pytest.raises(ValueError, match="Unsupported format"):
+            _write_audio(str(tmp_path / "out.ogg"), audio, SAMPLE_RATE)
+
+    def test_export_stem_mp3_creates_parent_directory(self, exporter, tmp_path):
+        out = str(tmp_path / "nested" / "deep" / "vocals.mp3")
+        exporter.export_stem("vocals", out)
+        assert os.path.isfile(out)


### PR DESCRIPTION
## Summary
- Add MP3 export via `lameenc` (pure LAME bindings, no ffmpeg needed)
- Export format auto-detected from file extension (.wav or .mp3)
- 320kbps CBR encoding with LAME quality level 2
- Export dialog now offers "WAV Files (*.wav);;MP3 Files (*.mp3)"
- `lameenc` added to requirements.txt

Closes #23

## Test plan
- [x] 93 fast tests pass (5 new MP3-specific tests)
- [x] Tests verify: MP3 header validity, file size < WAV, parent dir creation, unsupported format error
- [ ] Manual: export a mix as .mp3, play it in external player

🤖 Generated with [Claude Code](https://claude.com/claude-code)