### PR TITLE
fix: robustness — JSON recovery, thread cleanup, stream safety

### DIFF
--- a/src/library.py
+++ b/src/library.py
@@ -158,10 +158,19 @@ class SongLibrary:
     # ------------------------------------------------------------------
 
     def _load(self) -> None:
-        """Read the JSON index from disk."""
-        with open(self._json_path, encoding="utf-8") as f:
-            data = json.load(f)
-        self._songs = [Song.from_dict(entry) for entry in data]
+        """Read the JSON index from disk.
+
+        If the file is corrupted or contains malformed entries, starts
+        with an empty library rather than crashing.
+        """
+        try:
+            with open(self._json_path, encoding="utf-8") as f:
+                data = json.load(f)
+            self._songs = [Song.from_dict(entry) for entry in data]
+        except (json.JSONDecodeError, TypeError, KeyError):
+            # Corrupted or malformed — start fresh and overwrite.
+            self._songs = []
+            self._save()
 
     def _save(self) -> None:
         """Write the current song list to the JSON index atomically."""

--- a/src/player.py
+++ b/src/player.py
@@ -115,14 +115,21 @@ class MultiTrackPlayer(QObject):
         if self._current_frame >= self._total_frames:
             self._current_frame = 0
 
-        if self._stream is None:
-            self._stream = sd.OutputStream(
-                samplerate=self._sample_rate,
-                channels=2,
-                callback=self._audio_callback,
-            )
+        try:
+            if self._stream is None:
+                self._stream = sd.OutputStream(
+                    samplerate=self._sample_rate,
+                    channels=2,
+                    callback=self._audio_callback,
+                )
+            self._stream.start()
+        except sd.PortAudioError:
+            # No audio device or device error — clean up and bail.
+            if self._stream is not None:
+                self._stream.close()
+                self._stream = None
+            return
 
-        self._stream.start()
         self._is_playing = True
         self._timer.start()
         self.state_changed.emit(True)

--- a/src/ui/import_dialog.py
+++ b/src/ui/import_dialog.py
@@ -157,3 +157,10 @@ class ImportDialog(QDialog):
     def _on_error(self, message: str) -> None:
         self._status_label.setText(f"Error: {message}")
         self._button_box.setEnabled(True)
+
+    def reject(self) -> None:
+        """Cancel any running separation before closing."""
+        if hasattr(self, "_worker") and self._worker.isRunning():
+            self._worker.cancel()
+            self._worker.wait(5000)
+        super().reject()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -44,6 +44,7 @@ class MainWindow(QMainWindow):
         self._player = player
         self._model_manager = model_manager
         self._current_song_id: str | None = None
+        self._export_worker: ExportWorker | None = None
 
         self._settings = QSettings("stemma", "stemma")
 
@@ -118,12 +119,7 @@ class MainWindow(QMainWindow):
     def _make_mute_toggler(self, stem_name: str):
         """Return a callable that toggles mute for a stem and updates the UI."""
         def toggle():
-            is_muted = stem_name in self._player.muted_stems
-            self._player.set_mute(stem_name, not is_muted)
-            # Sync the UI button state
-            row = self._player_controls._stem_rows.get(stem_name)
-            if row is not None:
-                row._mute_btn.setChecked(not is_muted)
+            self._player_controls.toggle_stem_mute(stem_name)
         return toggle
 
     def _on_shortcut_play_pause(self) -> None:
@@ -143,9 +139,17 @@ class MainWindow(QMainWindow):
             self.restoreState(state)
 
     def closeEvent(self, event) -> None:
-        """Save window geometry and state before closing."""
+        """Save window geometry/state and clean up background threads."""
         self._settings.setValue("window/geometry", self.saveGeometry())
         self._settings.setValue("window/state", self.saveState())
+
+        # Wait for any in-flight export to finish.
+        if self._export_worker is not None and self._export_worker.isRunning():
+            self._export_worker.wait(5000)
+
+        # Stop playback.
+        self._player.stop()
+
         super().closeEvent(event)
 
     def _connect_signals(self) -> None:

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -87,6 +87,10 @@ class StemRow(QWidget):
         self._player.set_volume(self._stem_name, gain)
         self._vol_label.setText(f"{value}%")
 
+    def set_muted(self, muted: bool) -> None:
+        """Programmatically set the mute button state (e.g. from keyboard shortcut)."""
+        self._mute_btn.setChecked(muted)
+
 
 class PlayerControls(QWidget):
     """Transport controls and stem mixer panel."""
@@ -166,6 +170,13 @@ class PlayerControls(QWidget):
             row = StemRow(name, self._player)
             self._stem_container.addWidget(row)
             self._stem_rows[name] = row
+
+    def toggle_stem_mute(self, stem_name: str) -> None:
+        """Toggle the mute state of a stem and update the UI button."""
+        row = self._stem_rows.get(stem_name)
+        if row is not None:
+            is_muted = stem_name in self._player.muted_stems
+            row.set_muted(not is_muted)
 
     # -- Transport slots --
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -116,6 +116,31 @@ class TestSongLibraryInit:
         assert len(lib.songs) == 1
         assert lib.songs[0].title == "Old Song"
 
+    def test_recovers_from_corrupted_json(self, library_dir):
+        """Corrupted library.json should not crash — starts empty instead."""
+        os.makedirs(library_dir, exist_ok=True)
+        json_path = os.path.join(library_dir, "library.json")
+        with open(json_path, "w") as f:
+            f.write("{invalid json content")
+
+        lib = SongLibrary(data_dir=library_dir)
+        assert len(lib.songs) == 0
+
+        # The corrupted file should be overwritten with valid empty JSON.
+        with open(json_path) as f:
+            data = json.load(f)
+        assert data == []
+
+    def test_recovers_from_malformed_entries(self, library_dir):
+        """Entries with missing fields should not crash the library."""
+        os.makedirs(library_dir, exist_ok=True)
+        json_path = os.path.join(library_dir, "library.json")
+        with open(json_path, "w") as f:
+            json.dump([{"bad": "data"}], f)
+
+        lib = SongLibrary(data_dir=library_dir)
+        assert len(lib.songs) == 0
+
 
 class TestSongLibraryCRUD:
 


### PR DESCRIPTION
## Summary
Deep codebase audit uncovered several hidden bugs:

- **Corrupted JSON crashes app at startup** — `library.py` had no exception handling around `json.load()`. Now catches `JSONDecodeError`/`TypeError`/`KeyError` and recovers with empty library.
- **Worker threads not cleaned up on close** — `closeEvent()` now waits for export worker, stops player. Import dialog's `reject()` now cancels separator worker.
- **Player stream leak on device error** — `play()` now catches `PortAudioError` and cleans up the stream.
- **Encapsulation violation** — `main_window.py` was reaching into `_stem_rows._mute_btn` private attributes. Added public `toggle_stem_mute()` and `set_muted()` methods.

## Test plan
- [x] 112 fast tests pass (2 new: corrupted JSON, malformed entries)
- [x] Manually verified: `echo "{bad" > data/library.json && python main.py` no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)