### PR TITLE
docs: restore phase 3 list

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -189,11 +189,11 @@ stemma/
 - [ ] YouTube URL import (yt-dlp)
 - [ ] Tempo change (time-stretch)
 - [ ] Key transposition (pitch-shift)
+- [ ] Waveform visualization
+- [ ] A-B loop repeat
 
 ### Phase 4 — Sandbox
 - [ ] Experimental DSP (phase-aware recombination, model ensembling, transient preservation)
-- [ ] Waveform visualization
-- [ ] A-B loop repeat
 - [ ] General music player features (shuffle, repeat, EQ)
 
 ---


### PR DESCRIPTION
Fixing a markdown typo where Phase 3 items fell into Phase 4.