### PR TITLE
chore: post-merge docs and test cleanup for waveform visualization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ stemma/
       library_panel.py
       import_dialog.py
       styles.py        # Dark theme
-  tests/               # pytest test suite (170 fast + 5 slow + 1 hardware)
+  tests/               # pytest test suite (173 fast + 5 slow + 1 hardware)
     conftest.py        # Shared fixtures
     test_separator.py
     test_model_manager.py
@@ -85,10 +85,11 @@ stemma/
 10. Work deliberately. Plan each feature, implement carefully, test thoroughly.
 11. **Always keep the GitHub Kanban board up to date.** Move issues to In Progress, update subtasks, and close them when PRs merge.
 12. **Dual-Agent Workflow:** We use a builder/reviewer model. The "Builder" agent implements the feature and opens a PR. Do not merge your own PRs. The user will pass the PR to a "Reviewer" agent to audit the code, catch bugs, suggest improvements, and approve it.
+13. **No inline imports.** All imports belong at the top of the file. Do not place `import` statements inside functions or methods.
 
 ## Current Status
 
-Last updated: 2026-03-21
+Last updated: 2026-03-22
 
 ### Phase 1 (MVP) -- Complete
 All core functionality implemented and tested:
@@ -118,7 +119,7 @@ Remaining tickets: experimental DSP (#28)
 ## Test Suite
 
 ```
-pytest                                    # 170 fast tests (~10s)
+pytest                                    # 173 fast tests (~10s)
 pytest -m slow                            # 5 ONNX inference tests (~20s, needs model)
 pytest -m hardware                        # 1 audible playback test (~30s, needs speakers)
 set STEMMA_TEST_SONG=path/to/song.mp3     # Required for slow/hardware tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-03-22 -- Phase 3: Waveform Visualization
+
+### Done
+- Waveform visualization (#43, PR #58)
+  - Custom QPainter widget replacing seek slider
+  - Mirrored waveform bars, playback cursor, A-B loop region shading and markers
+  - Click/drag-to-seek
+  - Waveform recomputes on mute/solo/volume changes
+  - Vectorized peak computation via numpy (compute_peaks + np.maximum.reduceat)
+  - Three review passes; all findings addressed:
+    - Zero-width guards, cursor bounds clamping, redundant repaint removal
+    - Unused import cleanup, stale waveform cleared on empty stems
+  - 19 new tests (9 peak computation + 10 widget)
+- Inline import rule added to project conventions
+
+### Metrics
+- 173 fast tests, 5 slow ONNX tests, 1 hardware playback test (178 total)
+- Phase 3: 3 of 5 tickets complete
+
+---
+
 ## 2026-03-21 -- Phase 3: A-B Loop and YouTube Import
 
 ### Done

--- a/tests/test_waveform_widget.py
+++ b/tests/test_waveform_widget.py
@@ -3,7 +3,8 @@
 import numpy as np
 import pytest
 from unittest.mock import MagicMock, patch
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QEvent, QPointF
+from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QApplication
 
 from src.ui.waveform_widget import WaveformWidget
@@ -68,10 +69,6 @@ class TestWaveformWidget:
 
         received = []
         widget.seek_requested.connect(lambda s: received.append(s))
-
-        from PySide6.QtCore import QEvent
-        from PySide6.QtGui import QMouseEvent
-        from PySide6.QtCore import QPointF
 
         event = QMouseEvent(
             QEvent.Type.MouseButtonPress,


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md with 2026-03-22 waveform session notes
- Bump test count to 173 fast in AGENTS.md, add rule #13 (no inline imports)
- Fix inline imports in tests/test_waveform_widget.py (rule #13 compliance)

## Test plan

- [ ] `pytest tests/test_waveform_widget.py -v` passes
- [ ] `pytest` — all 173 fast tests pass