### PR TITLE
docs: update docs for drag-and-drop import and ffmpeg bundling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ stemma/
       library_panel.py
       import_dialog.py
       styles.py        # Dark theme
-  tests/               # pytest test suite (173 fast + 5 slow + 1 hardware)
+  tests/               # pytest test suite (196 fast + 5 slow + 1 hardware)
     conftest.py        # Shared fixtures
     test_separator.py
     test_model_manager.py
@@ -65,6 +65,7 @@ stemma/
     test_waveform.py
     test_waveform_widget.py
     test_import_dialog.py
+    test_drag_drop.py
     test_integration.py
   data/                # Runtime data (gitignored)
     models/            # Cached ONNX model files
@@ -111,15 +112,24 @@ All core functionality implemented and tested:
 ### Phase 3 (Advanced) -- In Progress
 - [x] A-B loop repeat (#44, PR #48)
 - [x] YouTube URL import (#41, PR #49)
-- [x] Waveform visualization (#43)
+- [x] Waveform visualization (#43, PR #58)
+- [x] Drag-and-drop import (#51, PR #60)
+- [x] Bundled ffmpeg via imageio-ffmpeg (PR #60)
 - Remaining tickets: real-time streaming (#13), tempo/key (#42)
+
+### v1.0 Release -- In Progress
+- [ ] Library search/filter (#54)
+- [ ] Song metadata editing (#52)
+- [ ] Playback speed control (#53)
+- [ ] App icon and branding (#61)
+- [ ] PyInstaller packaging + GitHub Release (#56)
 
 ### Phase 4 (Sandbox) -- Not Started
 Remaining tickets: experimental DSP (#28)
 ## Test Suite
 
 ```
-pytest                                    # 173 fast tests (~10s)
+pytest                                    # 196 fast tests (~10s)
 pytest -m slow                            # 5 ONNX inference tests (~20s, needs model)
 pytest -m hardware                        # 1 audible playback test (~30s, needs speakers)
 set STEMMA_TEST_SONG=path/to/song.mp3     # Required for slow/hardware tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-03-22 -- v1.0: Drag-and-Drop Import + ffmpeg Bundling
+
+### Done
+- Drag-and-drop import (#51, PR #60)
+  - Drop .mp3/.wav/.flac files onto the main window to trigger import
+  - ImportDialog gains `file_path` parameter for pre-fill
+  - Multiple dropped files open sequential import dialogs
+  - dragMoveEvent override for correct drop cursor on Windows/Qt6
+  - Inline import of ImportDialog in main_window.py fixed (rule #13)
+  - 17 new tests (3 prefill + 6 drag-enter + 2 drag-move + 6 drop)
+- Bundled ffmpeg via imageio-ffmpeg (PR #60)
+  - YouTube import now works without ffmpeg on PATH
+  - imageio-ffmpeg ships a static ffmpeg binary as package data
+  - _get_ffmpeg_exe() prefers bundled binary, falls back to PATH
+  - ffmpeg_location passed to yt-dlp options
+  - 4 new tests (3 check_ffmpeg fallback + 1 ffmpeg_location in opts)
+
+### Metrics
+- 196 fast tests, 5 slow ONNX tests, 1 hardware playback test (202 total)
+- Phase 3: 4 of 5 tickets complete; v1.0 roadmap: 5 tickets remaining
+
+---
+
 ## 2026-03-22 -- Phase 3: Waveform Visualization
 
 ### Done


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md with drag-and-drop and ffmpeg session notes
- Bump test count to 196 fast in AGENTS.md
- Add test_drag_drop.py to project structure listing
- Add v1.0 release roadmap section to AGENTS.md
- Mark drag-and-drop and ffmpeg bundling complete in Phase 3

## Test plan

- [x] No code changes, docs only