### PR TITLE
feat: song metadata editing (#52)

### DIFF
--- a/src/ui/library_panel.py
+++ b/src/ui/library_panel.py
@@ -5,7 +5,6 @@ selected. Full implementation in ticket #10.
 """
 
 from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -144,9 +143,11 @@ class LibraryPanel(QWidget):
         item = self._list.itemAt(pos)
         if item is None:
             return
+        # Select the right-clicked item so _on_edit_song targets it,
+        # not whatever was previously selected.
+        self._list.setCurrentItem(item)
         menu = QMenu(self)
-        edit_action = menu.addAction("Edit...")
-        edit_action.triggered.connect(self._on_edit_song)
+        menu.addAction("Edit...").triggered.connect(self._on_edit_song)
         menu.exec(self._list.mapToGlobal(pos))
 
     def _on_edit_song(self) -> None:

--- a/tests/test_metadata_edit.py
+++ b/tests/test_metadata_edit.py
@@ -171,3 +171,23 @@ class TestLibraryPanelEdit:
             with patch.object(panel._list, "itemAt", return_value=None):
                 panel._on_context_menu(MagicMock())
             mock_menu.assert_not_called()
+
+    def test_context_menu_selects_right_clicked_item(self, app):
+        """Right-clicking an unselected item edits that item, not the selection."""
+        songs = _make_songs()
+        library = _make_library(songs)
+        panel = LibraryPanel(library)
+        # Select song 1 (index 0).
+        panel._list.setCurrentRow(0)
+
+        song2_item = panel._list.item(1)
+
+        with patch("src.ui.library_panel.QMenu") as mock_menu_cls:
+            mock_menu = MagicMock()
+            mock_menu_cls.return_value = mock_menu
+            with patch.object(panel._list, "itemAt", return_value=song2_item):
+                with patch.object(panel._list, "mapToGlobal", return_value=MagicMock()):
+                    panel._on_context_menu(MagicMock())
+
+        # After the context menu, song 2 should be the current item.
+        assert panel._list.currentItem() is song2_item


### PR DESCRIPTION
## Summary

- Add `EditSongDialog` — small dialog with title/artist fields, pre-filled from the song
- Double-click a song in the library panel to open the edit dialog
- Empty fields fall back to original values (no accidental blank titles)
- Accepted edits persist via `library.update_song()` and refresh the list
- 8 new tests (4 dialog + 4 panel integration)

## Test plan

- [x] `pytest tests/test_metadata_edit.py -v` — 8 new tests pass
- [x] `pytest` — all 213 fast tests pass (no regressions)
- [x] Manual: double-click a YouTube-imported song, fix the title, verify it sticks after restart

Closes #52