### PR TITLE
docs: update project docs after v1.0 feature merges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ stemma/
       library_panel.py
       import_dialog.py
       styles.py        # Dark theme
-  tests/               # pytest test suite (196 fast + 5 slow + 1 hardware)
+  tests/               # pytest test suite (229 fast + 5 slow + 1 hardware)
     conftest.py        # Shared fixtures
     test_separator.py
     test_model_manager.py
@@ -66,6 +66,9 @@ stemma/
     test_waveform_widget.py
     test_import_dialog.py
     test_drag_drop.py
+    test_library_panel.py
+    test_metadata_edit.py
+    test_speed_control.py
     test_integration.py
   data/                # Runtime data (gitignored)
     models/            # Cached ONNX model files
@@ -118,9 +121,9 @@ All core functionality implemented and tested:
 - Remaining tickets: real-time streaming (#13), tempo/key (#42)
 
 ### v1.0 Release -- In Progress
-- [ ] Library search/filter (#54)
-- [ ] Song metadata editing (#52)
-- [ ] Playback speed control (#53)
+- [x] Library search/filter (#54, PR #63)
+- [x] Song metadata editing (#52, PR #64)
+- [x] Playback speed control (#53, PR #67)
 - [ ] App icon and branding (#61)
 - [ ] PyInstaller packaging + GitHub Release (#56)
 
@@ -129,7 +132,7 @@ Remaining tickets: experimental DSP (#28)
 ## Test Suite
 
 ```
-pytest                                    # 196 fast tests (~10s)
+pytest                                    # 229 fast tests (~10s)
 pytest -m slow                            # 5 ONNX inference tests (~20s, needs model)
 pytest -m hardware                        # 1 audible playback test (~30s, needs speakers)
 set STEMMA_TEST_SONG=path/to/song.mp3     # Required for slow/hardware tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-03-22 -- v1.0: Library Search, Metadata Editing, and Playback Speed
+
+### Done
+- Library search/filter (#54, PR #63)
+  - Search bar with clear button in library panel
+  - Real-time filter hides non-matching songs as you type
+  - Remove button disabled when selection is hidden by filter
+  - 9 new tests
+- Song metadata editing (#52, PR #64)
+  - Double-click a song to edit title/artist
+  - Right-click context menu with Edit option
+  - Right-click selects the item before opening menu (fixes wrong-item bug)
+  - Empty fields fall back to original values
+  - 10 new tests
+- Pitch-preserving playback speed control (#53, PR #67)
+  - librosa.effects.time_stretch pre-stretches stems in background QThread
+  - Speed presets: 0.5x, 0.75x, 0.85x, 1.0x, 1.25x, 1.5x, 2.0x
+  - Keyboard shortcuts: [ (slower) and ] (faster)
+  - Frame index and loop points proportionally adjusted on speed change
+  - Peak normalization after stretch fixes volume reduction from phase vocoder
+  - Worker detach pattern prevents stale signal callbacks
+  - 13 new tests
+
+### Metrics
+- 229 fast tests, 5 slow ONNX tests, 1 hardware playback test (235 total)
+- v1.0 roadmap: 2 tickets remaining (#61 branding, #56 packaging)
+
+---
+
 ## 2026-03-22 -- v1.0: Drag-and-Drop Import + ffmpeg Bundling
 
 ### Done


### PR DESCRIPTION
## Summary
- CHANGELOG: add entries for library search/filter (#54), metadata editing (#52), and playback speed control (#53)
- AGENTS: mark all three v1.0 features as complete, add new test files to project structure, update test count to 229

## Test plan
- [x] Verify docs are accurate (no code changes)