### PR TITLE
feat: PyInstaller packaging + GitHub Release workflow (#56)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Build executable
+        run: pyinstaller stemma.spec
+
+      - name: Verify executable
+        shell: pwsh
+        run: |
+          if (!(Test-Path "dist/stemma.exe")) {
+            throw "Build failed: stemma.exe not found"
+          }
+          $size = (Get-Item "dist/stemma.exe").Length / 1MB
+          Write-Output "stemma.exe size: $([math]::Round($size, 1)) MB"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/stemma.exe
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,10 @@ share/python-wheels/
 MANIFEST
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
+# Keep stemma.spec tracked (negate the generic *.spec rule).
 *.spec
+!stemma.spec
 
 # Installer logs
 pip-log.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+pyinstaller>=6.0

--- a/src/app.py
+++ b/src/app.py
@@ -12,12 +12,13 @@ from src.app_settings import normalize_output_device_setting
 from src.data_paths import resolve_data_dir
 from src.library import SongLibrary
 from src.model_manager import ModelManager
+from src.paths import app_root
 from src.player import MultiTrackPlayer
 from src.ui.main_window import MainWindow
 from src.ui.styles import get_colors, get_stylesheet
 from src.version import __version__
 
-_ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_ROOT_DIR = app_root()
 _ICON_PATH = os.path.join(_ROOT_DIR, "assets", "icons", "stemma.ico")
 
 

--- a/src/paths.py
+++ b/src/paths.py
@@ -1,0 +1,16 @@
+"""Application root directory, aware of PyInstaller frozen builds."""
+
+import os
+import sys
+
+
+def app_root() -> str:
+    """Return the application root directory.
+
+    In a PyInstaller frozen build, returns ``sys._MEIPASS`` (the temp
+    extraction directory where bundled data files are unpacked).  Otherwise
+    returns the repository root (parent of the ``src`` package).
+    """
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        return sys._MEIPASS  # type: ignore[attr-defined]
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -22,12 +22,13 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from src.paths import app_root
 from src.player import SPEED_PRESETS, MultiTrackPlayer
 from src.ui.styles import DARK_COLORS, STEM_COLORS
 from src.ui.waveform_widget import WaveformWidget
 from src.waveform import compute_peaks
 
-_ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_ROOT_DIR = app_root()
 _PEAK_DEBOUNCE_MS = 80
 _ICON_SIZE = 24
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """stemma version string."""
 
-__version__ = "1.0.0-dev"
+__version__ = "1.0.0"

--- a/stemma.spec
+++ b/stemma.spec
@@ -1,0 +1,96 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for stemma — single-file Windows executable."""
+
+from PyInstaller.utils.hooks import collect_all
+
+block_cipher = None
+
+# -- Collect runtime data, binaries, and hidden imports for key packages ------
+
+ort_datas, ort_binaries, ort_hiddenimports = collect_all("onnxruntime")
+sd_datas, sd_binaries, sd_hiddenimports = collect_all("sounddevice")
+sd2_datas, sd2_binaries, sd2_hiddenimports = collect_all("_sounddevice_data")
+ffmpeg_datas, ffmpeg_binaries, ffmpeg_hiddenimports = collect_all(
+    "imageio_ffmpeg"
+)
+svg_datas, svg_binaries, svg_hiddenimports = collect_all("PySide6.QtSvg")
+
+# -- Analysis -----------------------------------------------------------------
+
+a = Analysis(
+    ["main.py"],
+    pathex=[],
+    binaries=(
+        ort_binaries
+        + sd_binaries
+        + sd2_binaries
+        + ffmpeg_binaries
+        + svg_binaries
+    ),
+    datas=[
+        ("assets/icons", "assets/icons"),
+    ]
+    + ort_datas
+    + sd_datas
+    + sd2_datas
+    + ffmpeg_datas
+    + svg_datas,
+    hiddenimports=[
+        # Lazy or dynamic imports that PyInstaller cannot detect.
+        "onnxruntime",
+        "lameenc",
+        "sounddevice",
+        "_sounddevice_data",
+        "imageio_ffmpeg",
+        "PySide6.QtSvg",
+        # librosa pulls scipy/sklearn; these submodules are often missed.
+        "sklearn.utils._typedefs",
+        "sklearn.neighbors._typedefs",
+        "sklearn.neighbors._partition_nodes",
+        "scipy.signal",
+        "scipy._lib.messagestream",
+    ]
+    + ort_hiddenimports
+    + sd_hiddenimports
+    + sd2_hiddenimports
+    + ffmpeg_hiddenimports
+    + svg_hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        # Trim unused PySide6 modules to reduce bundle size.
+        "PySide6.QtWebEngine",
+        "PySide6.QtWebEngineWidgets",
+        "PySide6.QtQuick",
+        "PySide6.QtQml",
+        "PySide6.Qt3DCore",
+        "PySide6.Qt3DRender",
+        "PySide6.QtMultimedia",
+        "PySide6.QtNetwork",
+        # Other large, unused packages.
+        "tkinter",
+        "matplotlib",
+        "IPython",
+        "jupyter",
+        "pytest",
+    ],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="stemma",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,  # UPX can corrupt ONNX Runtime and DirectML DLLs.
+    console=False,
+    icon="assets/icons/stemma.ico",
+)


### PR DESCRIPTION
Closes #56.

## Summary

- **`src/paths.py`**: New `app_root()` helper returns `sys._MEIPASS` in frozen builds, repo root otherwise
- **`stemma.spec`**: One-file windowed build with DirectML, PortAudio, ffmpeg, and QtSvg collected; UPX disabled to avoid corrupting ONNX Runtime DLLs
- **`.github/workflows/release.yml`**: Builds .exe on `v*` tag push, creates GitHub Release via `softprops/action-gh-release@v2`
- **`requirements-dev.txt`**: PyInstaller as dev dependency
- **Version bump**: `1.0.0-dev` -> `1.0.0`

## Local build verification

- `pyinstaller stemma.spec` produces a 202 MB `dist/stemma.exe`
- Exe launches successfully, icon displays correctly
- All 282 fast tests pass

## Test plan

- [x] CI tests pass on this PR
- [x] Local: `pyinstaller stemma.spec` builds without errors
- [x] Local: `dist/stemma.exe` launches, shows UI with icon
- [x] Local: Import a file, verify separation works (model downloads if needed)
- [ ] After merge: push `v1.0.0` tag to trigger release workflow
- [ ] Verify GitHub Release is created with .exe artifact

Generated with [Claude Code](https://claude.com/claude-code)