### PR TITLE
feat: session persistence (#55)

### DIFF
--- a/src/ui/library_panel.py
+++ b/src/ui/library_panel.py
@@ -132,6 +132,18 @@ class LibraryPanel(QWidget):
         if current is None or current.isHidden():
             self._remove_btn.setEnabled(False)
 
+    def select_song(self, song_id: str) -> bool:
+        """Programmatically select a song by its ID.
+
+        Returns True if the song was found and selected, False otherwise.
+        """
+        for i in range(self._list.count()):
+            item = self._list.item(i)
+            if item.data(Qt.ItemDataRole.UserRole) == song_id:
+                self._list.setCurrentItem(item)
+                return True
+        return False
+
     def _on_item_changed(self, current: QListWidgetItem | None, _previous) -> None:
         if current is not None:
             song_id = current.data(Qt.ItemDataRole.UserRole)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -5,6 +5,7 @@ Center: player controls and stem mixer.
 Menu bar: File / Edit / Help; theme toggle in the menu bar corner.
 """
 
+import json
 import os
 
 from PySide6.QtCore import QPointF, QSettings, QSize, Qt, QTimer
@@ -117,6 +118,7 @@ class MainWindow(QMainWindow):
 
         QTimer.singleShot(0, self._maybe_show_data_dir_reset_notice)
         QTimer.singleShot(0, self._maybe_warn_no_audio_output)
+        QTimer.singleShot(0, self._restore_session)
 
     # ------------------------------------------------------------------
     # UI Setup
@@ -351,8 +353,114 @@ class MainWindow(QMainWindow):
         if state is not None:
             self.restoreState(state)
 
+    def _save_session(self) -> None:
+        """Persist current player state so it can be restored on next launch."""
+        self._settings.setValue(
+            "session/song_id", self._current_song_id or ""
+        )
+        self._settings.setValue(
+            "session/position", self._player.current_seconds
+        )
+        self._settings.setValue(
+            "session/muted_stems",
+            json.dumps(sorted(self._player.muted_stems)),
+        )
+        self._settings.setValue(
+            "session/soloed_stems",
+            json.dumps(sorted(self._player.soloed_stems)),
+        )
+        self._settings.setValue(
+            "session/volumes", json.dumps(self._player.volumes)
+        )
+        loop_a = self._player.loop_a
+        loop_b = self._player.loop_b
+        self._settings.setValue("session/loop_a", loop_a if loop_a is not None else -1)
+        self._settings.setValue("session/loop_b", loop_b if loop_b is not None else -1)
+        self._settings.setValue("session/looping", self._player.looping)
+        self._settings.setValue("session/speed", self._player.speed)
+
+    def _restore_session(self) -> None:
+        """Reload the last song and player state from QSettings."""
+        song_id = self._settings.value("session/song_id", "")
+        if not song_id:
+            return
+
+        song = self._library.get_song(song_id)
+        if song is None:
+            return
+
+        if not self._library_panel.select_song(song_id):
+            return
+
+        # Stem mute/solo/volume
+        try:
+            muted = set(json.loads(self._settings.value("session/muted_stems", "[]")))
+        except (json.JSONDecodeError, TypeError):
+            muted = set()
+        try:
+            soloed = set(json.loads(self._settings.value("session/soloed_stems", "[]")))
+        except (json.JSONDecodeError, TypeError):
+            soloed = set()
+        try:
+            volumes = json.loads(self._settings.value("session/volumes", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            volumes = {}
+
+        self._player_controls.restore_stem_state(muted, soloed, volumes)
+
+        # Loop points
+        try:
+            loop_a = float(self._settings.value("session/loop_a", -1))
+        except (TypeError, ValueError):
+            loop_a = -1
+        try:
+            loop_b = float(self._settings.value("session/loop_b", -1))
+        except (TypeError, ValueError):
+            loop_b = -1
+        looping = self._settings.value("session/looping", False)
+        if isinstance(looping, str):
+            looping = looping.lower() == "true"
+
+        self._player_controls.restore_loop_state(
+            loop_a if loop_a >= 0 else None,
+            loop_b if loop_b >= 0 else None,
+            bool(looping),
+        )
+
+        # Speed (async — seek after stretch completes)
+        try:
+            speed = float(self._settings.value("session/speed", 1.0))
+        except (TypeError, ValueError):
+            speed = 1.0
+
+        try:
+            position = float(self._settings.value("session/position", 0.0))
+        except (TypeError, ValueError):
+            position = 0.0
+
+        if speed != 1.0:
+            def _after_speed_applied(_s: float, pos=position) -> None:
+                self._player.speed_changed.disconnect(_after_speed_applied)
+                self._player.seek(pos)
+
+            self._player.speed_changed.connect(_after_speed_applied)
+            self._player_controls._speed_combo.blockSignals(True)
+            label = f"{speed}x"
+            idx = self._player_controls._speed_combo.findText(label)
+            if idx >= 0:
+                self._player_controls._speed_combo.setCurrentIndex(idx)
+            self._player_controls._speed_combo.blockSignals(False)
+            self._player_controls._speed_status.setText("Stretching...")
+            self._player.set_speed(speed)
+        else:
+            self._player.seek(position)
+
     def closeEvent(self, event) -> None:
-        """Save window geometry/state and clean up background threads."""
+        """Save window geometry/state, session, and clean up background threads."""
+        try:
+            self._save_session()
+        except Exception:
+            pass  # Never prevent the window from closing.
         self._settings.setValue("window/geometry", self.saveGeometry())
         self._settings.setValue("window/state", self.saveState())
 

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -169,6 +169,14 @@ class StemRow(QWidget):
         """Programmatically set the mute button state (e.g. from keyboard shortcut)."""
         self._mute_btn.setChecked(muted)
 
+    def set_soloed(self, soloed: bool) -> None:
+        """Programmatically set the solo button state."""
+        self._solo_btn.setChecked(soloed)
+
+    def set_volume_slider(self, value: int) -> None:
+        """Programmatically set the volume slider (0-200)."""
+        self._volume_slider.setValue(value)
+
 
 class PlayerControls(QWidget):
     """Transport controls and stem mixer panel."""
@@ -456,6 +464,39 @@ class PlayerControls(QWidget):
         self._waveform.set_peaks(np.zeros(1, dtype=np.float32))
         self._waveform.set_position(0.0)
         self._time_label.setText("0:00 / 0:00")
+
+    def restore_stem_state(
+        self,
+        muted: set[str],
+        soloed: set[str],
+        volumes: dict[str, float],
+    ) -> None:
+        """Restore per-stem mute/solo/volume state from a saved session.
+
+        Setting the UI widgets triggers the connected player methods, so
+        this also updates the player state.
+        """
+        for name, row in self._stem_rows.items():
+            row.set_muted(name in muted)
+            row.set_soloed(name in soloed)
+            vol = volumes.get(name, 1.0)
+            row.set_volume_slider(round(vol * 100))
+        self._do_recompute_peaks()
+
+    def restore_loop_state(
+        self,
+        loop_a: float | None,
+        loop_b: float | None,
+        looping: bool,
+    ) -> None:
+        """Restore A-B loop state from a saved session."""
+        if loop_a is not None:
+            self._player.set_loop_a(loop_a)
+        if loop_b is not None:
+            self._player.set_loop_b(loop_b)
+        self._loop_toggle_btn.setChecked(looping)
+        self._update_loop_label()
+        self._update_waveform_loop_markers()
 
     def toggle_stem_mute(self, stem_name: str) -> None:
         """Toggle the mute state of a stem and update the UI button."""

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -1,0 +1,233 @@
+"""Tests for session persistence (save/restore player state)."""
+
+import json
+import os
+
+import numpy as np
+import pytest
+import soundfile as sf
+from PySide6.QtCore import QSettings, Qt
+from PySide6.QtWidgets import QApplication
+
+from src.library import SongLibrary
+from src.player import MultiTrackPlayer
+from src.ui.library_panel import LibraryPanel
+from src.ui.player_controls import PlayerControls
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+@pytest.fixture
+def player():
+    return MultiTrackPlayer()
+
+
+@pytest.fixture
+def library(tmp_path):
+    return SongLibrary(str(tmp_path / "data"))
+
+
+@pytest.fixture
+def controls(qapp, player):
+    return PlayerControls(player)
+
+
+@pytest.fixture
+def panel(qapp, library):
+    return LibraryPanel(library)
+
+
+def _make_song_with_stems(library, tmp_path, title="Test Song"):
+    """Create a song with 4-stem WAV files and return it."""
+    audio = tmp_path / f"{title}.wav"
+    sf.write(str(audio), np.zeros((44100 * 5, 2), dtype=np.float32), 44100)
+    song = library.add_song(title, "Artist", str(audio))
+    os.makedirs(song.stems_path, exist_ok=True)
+    for stem in ["vocals", "drums", "bass", "other"]:
+        sf.write(
+            os.path.join(song.stems_path, f"{stem}.wav"),
+            np.zeros((44100, 2), dtype=np.float32),
+            44100,
+        )
+    library.update_song(song.id, model_used="htdemucs")
+    return song
+
+
+# -----------------------------------------------------------------------
+# LibraryPanel.select_song
+# -----------------------------------------------------------------------
+
+
+class TestLibraryPanelSelectSong:
+    def test_select_existing_song(self, panel, library, tmp_path):
+        song = _make_song_with_stems(library, tmp_path)
+        panel.refresh()
+        assert panel.select_song(song.id) is True
+
+    def test_select_nonexistent_returns_false(self, panel):
+        assert panel.select_song("nonexistent") is False
+
+    def test_select_emits_signal(self, panel, library, tmp_path):
+        song = _make_song_with_stems(library, tmp_path)
+        panel.refresh()
+
+        received = []
+        panel.song_selected.connect(received.append)
+        panel.select_song(song.id)
+        assert received == [song.id]
+
+
+# -----------------------------------------------------------------------
+# StemRow helpers
+# -----------------------------------------------------------------------
+
+
+class TestStemRowSetters:
+    def test_set_soloed(self, controls, player, tmp_path):
+        audio = tmp_path / "stem.wav"
+        sf.write(str(audio), np.zeros((44100 * 5, 2), dtype=np.float32), 44100)
+        player.load_stems({"vocals": str(audio)})
+        controls.set_stem_names(["vocals"])
+
+        row = controls._stem_rows["vocals"]
+        row.set_soloed(True)
+        assert "vocals" in player.soloed_stems
+
+    def test_set_volume_slider(self, controls, player, tmp_path):
+        audio = tmp_path / "stem.wav"
+        sf.write(str(audio), np.zeros((44100 * 5, 2), dtype=np.float32), 44100)
+        player.load_stems({"vocals": str(audio)})
+        controls.set_stem_names(["vocals"])
+
+        row = controls._stem_rows["vocals"]
+        row.set_volume_slider(150)
+        assert player.get_volume("vocals") == pytest.approx(1.5, abs=0.05)
+
+
+# -----------------------------------------------------------------------
+# PlayerControls.restore_stem_state
+# -----------------------------------------------------------------------
+
+
+class TestRestoreStemState:
+    def test_restores_mute_solo_volume(self, controls, player, tmp_path):
+        audio = tmp_path / "stem.wav"
+        sf.write(str(audio), np.zeros((44100 * 5, 2), dtype=np.float32), 44100)
+        player.load_stems({"vocals": str(audio), "drums": str(audio)})
+        controls.set_stem_names(["vocals", "drums"])
+
+        controls.restore_stem_state(
+            muted={"vocals"},
+            soloed={"drums"},
+            volumes={"vocals": 0.5, "drums": 1.5},
+        )
+
+        assert "vocals" in player.muted_stems
+        assert "drums" in player.soloed_stems
+        assert player.get_volume("vocals") == pytest.approx(0.5, abs=0.05)
+        assert player.get_volume("drums") == pytest.approx(1.5, abs=0.05)
+
+    def test_ignores_unknown_stems(self, controls, player, tmp_path):
+        audio = tmp_path / "stem.wav"
+        sf.write(str(audio), np.zeros((44100 * 5, 2), dtype=np.float32), 44100)
+        player.load_stems({"vocals": str(audio)})
+        controls.set_stem_names(["vocals"])
+
+        # "guitar" is not in the loaded stems -- should not crash
+        controls.restore_stem_state(
+            muted={"guitar"},
+            soloed=set(),
+            volumes={"guitar": 0.8},
+        )
+        assert "vocals" not in player.muted_stems
+
+
+# -----------------------------------------------------------------------
+# PlayerControls.restore_loop_state
+# -----------------------------------------------------------------------
+
+
+class TestRestoreLoopState:
+    def test_restores_loop_points(self, controls, player, tmp_path):
+        audio = tmp_path / "stem.wav"
+        sf.write(str(audio), np.zeros((44100 * 5, 2), dtype=np.float32), 44100)
+        player.load_stems({"vocals": str(audio)})
+        controls.set_stem_names(["vocals"])
+
+        controls.restore_loop_state(loop_a=1.0, loop_b=2.0, looping=True)
+
+        assert player.loop_a == pytest.approx(1.0, abs=0.05)
+        assert player.loop_b == pytest.approx(2.0, abs=0.05)
+        assert player.looping is True
+
+    def test_none_loop_points_skipped(self, controls, player, tmp_path):
+        audio = tmp_path / "stem.wav"
+        sf.write(str(audio), np.zeros((44100 * 5, 2), dtype=np.float32), 44100)
+        player.load_stems({"vocals": str(audio)})
+        controls.set_stem_names(["vocals"])
+
+        controls.restore_loop_state(loop_a=None, loop_b=None, looping=False)
+
+        assert player.loop_a is None
+        assert player.loop_b is None
+        assert player.looping is False
+
+
+# -----------------------------------------------------------------------
+# Session round-trip: save then restore values
+# -----------------------------------------------------------------------
+
+
+class TestSessionRoundTrip:
+    """Test that session values survive a QSettings write/read cycle."""
+
+    def test_stem_state_roundtrip(self):
+        muted = {"vocals", "drums"}
+        soloed = {"bass"}
+        volumes = {"vocals": 0.5, "drums": 1.5, "bass": 1.0}
+
+        settings = QSettings("stemma", "stemma-test")
+        settings.clear()
+        settings.setValue("session/muted_stems", json.dumps(sorted(muted)))
+        settings.setValue("session/soloed_stems", json.dumps(sorted(soloed)))
+        settings.setValue("session/volumes", json.dumps(volumes))
+
+        restored_muted = set(json.loads(settings.value("session/muted_stems")))
+        restored_soloed = set(json.loads(settings.value("session/soloed_stems")))
+        restored_volumes = json.loads(settings.value("session/volumes"))
+
+        assert restored_muted == muted
+        assert restored_soloed == soloed
+        assert restored_volumes == volumes
+        settings.clear()
+
+    def test_loop_roundtrip(self):
+        settings = QSettings("stemma", "stemma-test")
+        settings.clear()
+        settings.setValue("session/loop_a", 10.5)
+        settings.setValue("session/loop_b", 20.3)
+        settings.setValue("session/looping", True)
+
+        a = float(settings.value("session/loop_a"))
+        b = float(settings.value("session/loop_b"))
+        assert a == pytest.approx(10.5)
+        assert b == pytest.approx(20.3)
+        settings.clear()
+
+    def test_no_loop_roundtrip(self):
+        settings = QSettings("stemma", "stemma-test")
+        settings.clear()
+        settings.setValue("session/loop_a", -1)
+        settings.setValue("session/loop_b", -1)
+
+        a = float(settings.value("session/loop_a"))
+        b = float(settings.value("session/loop_b"))
+        assert a == -1
+        assert b == -1
+        settings.clear()


### PR DESCRIPTION
Closes #55.

## Summary

- **Save on close**: `MainWindow.closeEvent()` writes song ID, playback position, per-stem mute/solo/volume, A-B loop points, looping state, and speed to QSettings
- **Restore on launch**: `_restore_session()` runs via `QTimer.singleShot(0, ...)` after window init; loads the last song, restores all player state, and seeks to the saved position
- **Speed restore**: Handles async librosa stretch — seeks to saved position only after `speed_changed` signal fires
- **New APIs**: `LibraryPanel.select_song(song_id)`, `StemRow.set_soloed()` / `set_volume_slider()`, `PlayerControls.restore_stem_state()` / `restore_loop_state()`
- **Graceful degradation**: Missing songs, corrupted JSON, and invalid values all handled safely without crashing

## Test plan

- [ ] CI passes
- [ ] Launch app, import a song, set some state (mute vocals, solo bass, set loop A/B, change speed to 0.75x)
- [ ] Close and reopen — all state should be restored
- [ ] Remove the song from library, reopen — should start fresh (no crash)
- [ ] First launch with no saved state — no crash

Generated with [Claude Code](https://claude.com/claude-code)