### PR TITLE
docs: sync AGENTS, PROJECT, CHANGELOG after metronome and count-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Runtime library and models default to the per-user folder (e.g. `%LOCALAPPDATA%\
 
 ## Current Status
 
-Last updated: 2026-03-25
+Last updated: 2026-03-26
 
 ### Phase 1 (MVP) -- Complete
 All core functionality implemented and tested:
@@ -159,7 +159,7 @@ Tickets ship as incremental 1.x releases (semver: minor for features, patch for 
 ## Test Suite
 
 ```
-pytest                                    # ~354 fast tests (~10s)
+pytest                                    # ~362 fast tests (~10s)
 pytest -m slow                            # 5 ONNX inference tests (~20s, needs model)
 pytest -m hardware                        # 1 audible playback test (~30s, needs speakers)
 set STEMMA_TEST_SONG=path/to/song.mp3     # Required for slow/hardware tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-03-26 -- Metronome (#57, PR #86) and count-in (#78, PR #87)
+
+### Done
+- **Metronome:** BPM spinbox (20--300), tap tempo, toggle (M), volume slider, click mixed in the audio callback with phase tied to full PortAudio block size; `set_metronome_bpm` rejects non-finite values; `tap_tempo` in `src/metronome.py`.
+- **Count-in:** Optional pre-roll (1--8 beats, default 4) before stems start; uses metronome BPM/volume; optional count-in before each A-B repeat; arms only from position 0 or loop A (not on resume mid-song); `C` shortcut; Help > Keyboard Shortcuts dialog; session keys for count-in state; QCheckBox styling for loop-repeat option.
+- **A-B loop UX:** With looping active and a valid region, Stop jumps to loop A; seek clamps into `[loop_a, loop_b)` (outside snaps to A). Count-in boundary uses the same valid-region check as the callback.
+
+### Metrics
+- 362 fast tests, 5 slow ONNX tests, 1 hardware playback test.
+
+---
+
 ## 2026-03-25 -- Session persistence (#55, PR #85)
 
 ### Done

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -234,11 +234,11 @@ stemma/
 
 ### Post-1.0 Backlog
 Tickets ship as incremental 1.x releases (semver).
-- [ ] Session persistence (#55)
-- [ ] Metronome with BPM entry (#57)
-- [ ] Count-in before playback/loop start (#78)
+- [x] Session persistence (#55, PR #85)
+- [x] Metronome with BPM entry (#57, PR #86)
+- [x] Count-in before playback/loop start (#78, PR #87)
 - [ ] Record audio track (#79)
-- [ ] Key transposition / tempo manipulation (#42)
+- [ ] Tempo/key detection and beat-synced metronome (#42)
 - [ ] Animated startup logo (#76)
 - [ ] MSIX packaging for Microsoft Store (#74)
 - [ ] Real-time streaming stem separation (#13)


### PR DESCRIPTION
Updates backlog checkboxes and test counts in AGENTS.md, aligns PROJECT.md Post-1.0 with shipped work (#55, #57, #78), and adds CHANGELOG entry for PR #86 and PR #87.