### PR TITLE
chore: release v1.1.0 and sync documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ stemma/
     paths.py           # app_root(): frozen-build-aware root dir (sys._MEIPASS)
     version.py         # __version__ string
     import_messages.py # User-facing import / download / separation error text
+    metronome.py       # Tap tempo / BPM helpers for metronome UI
     separator.py       # ONNX stem separation engine
     model_manager.py   # Download/cache ONNX models
     player.py          # Multi-track audio player
@@ -62,7 +63,7 @@ stemma/
       import_dialog.py
       preferences_dialog.py  # Edit > Preferences
       styles.py        # Dark / light themes
-  tests/               # pytest test suite (~286 fast + 5 slow + 1 hardware)
+  tests/               # pytest test suite (~362 fast + 5 slow + 1 hardware)
     conftest.py        # Shared fixtures
     test_separator.py
     test_model_manager.py
@@ -84,6 +85,8 @@ stemma/
     test_theme.py
     test_integration.py
     test_session_persistence.py
+    test_metronome.py
+    test_count_in.py
   data/                # Legacy dev-only folder; packaged app uses OS user dir
     models/            # (when using repo data/) Cached ONNX models
     songs/{song-id}/   # Separated stems per song
@@ -121,7 +124,7 @@ All core functionality implemented and tested:
 
 ### Phase 2 (Polish) -- Complete
 - MP3 export (lameenc, 320kbps)
-- Keyboard shortcuts (Space, S, arrows, 1-6, A/B/L for loop)
+- Keyboard shortcuts (Space, S, arrows, 1-6, A/B/L, [ / ], M, C; Help > Keyboard Shortcuts)
 - Per-stem volume sliders
 - Window state persistence
 - Wiener filter + soft gate post-processing
@@ -145,17 +148,20 @@ All core functionality implemented and tested:
 - [x] User data directory, preferences, single-instance lock (#72, PR #81)
 - [x] PyInstaller packaging + GitHub Release (#56, PR #83)
 
-### Post-1.0 Backlog
-Tickets ship as incremental 1.x releases (semver: minor for features, patch for fixes).
+### v1.1 Release -- Shipped
 - [x] Session persistence (#55, PR #85)
 - [x] Metronome with BPM entry (#57, PR #86)
-- [x] Count-in before playback/loop start (#78)
+- [x] Count-in before playback/loop start (#78, PR #87)
+
+### Post-1.0 Backlog
+Tickets ship as incremental 1.x releases (semver: minor for features, patch for fixes).
 - [ ] Record audio track (#79)
 - [ ] Tempo/key detection and beat-synced metronome (#42)
 - [ ] Animated startup logo (#76)
 - [ ] MSIX packaging (#74)
 - [ ] Experimental DSP (#28)
 - [ ] Real-time streaming (#13)
+
 ## Test Suite
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-03-26 -- v1.1.0 release
+
+Shipped as GitHub Release **v1.1.0** (tag `v1.1.0`). User-facing highlights:
+
+- Metronome with BPM (20--300), tap tempo, toggle and volume (#57, PR #86).
+- Count-in pre-roll (1--8 beats), optional on loop repeats, `C` shortcut (#78, PR #87).
+- Session persistence for song, position, stems, loop, speed, metronome, and count-in (#55, PR #85).
+- A-B loop: while **L** is on, Stop jumps to loop A; seek clamps into the loop region (PR #87).
+- **Help > Keyboard Shortcuts** dialog (PR #87).
+
+`src/version.py` set to **1.1.0**.
+
+---
+
 ## 2026-03-26 -- Metronome (#57, PR #86) and count-in (#78, PR #87)
 
 ### Done

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -81,6 +81,7 @@ stemma/
 │   ├── app_settings.py        # Typed QSettings (audio device, import/export defaults)
 │   ├── data_paths.py          # Per-user data directory resolution
 │   ├── import_messages.py     # User-facing text for import/download failures
+│   ├── metronome.py           # Tap tempo helper for metronome UI
 │   ├── paths.py               # app_root(): frozen-build-aware root dir
 │   ├── version.py             # __version__ string
 │   ├── separator.py           # ONNX Runtime stem separation
@@ -93,8 +94,8 @@ stemma/
 │   ├── waveform.py            # Waveform peak computation (numpy)
 │   └── ui/
 │       ├── __init__.py
-│       ├── main_window.py     # Main window layout, menus, drag-and-drop import
-│       ├── player_controls.py # Transport + waveform + stem mixer
+│       ├── main_window.py     # Main window, session restore, shortcuts, drag-and-drop
+│       ├── player_controls.py # Transport, waveform, metronome, count-in, stem mixer
 │       ├── waveform_widget.py # Waveform display (QPainter)
 │       ├── library_panel.py   # Song list with remove
 │       ├── import_dialog.py   # Import songs + YouTube URL + model download
@@ -104,7 +105,7 @@ stemma/
 │   ├── conftest.py            # Shared fixtures
 │   ├── test_separator.py      # 22 tests
 │   ├── test_model_manager.py  # 9 tests
-│   ├── test_player.py         # 25 tests
+│   ├── test_player.py         # Player, A-B loop, metronome-related behaviour
 │   ├── test_library.py        # 22 tests
 │   ├── test_downloader.py     # 26 tests
 │   ├── test_exporter.py       # 18 tests
@@ -115,6 +116,8 @@ stemma/
 │   ├── test_import_messages.py
 │   ├── test_data_paths.py
 │   ├── test_app_settings.py
+│   ├── test_metronome.py
+│   ├── test_count_in.py
 │   ├── test_theme.py
 │   └── test_integration.py    # includes slow + hardware markers
 └── data/                      # Created at runtime
@@ -152,10 +155,11 @@ stemma/
 
 ### `player.py` — Multi-Track Audio Player
 - Loads stem WAVs as NumPy arrays
-- `sounddevice.OutputStream` callback: reads buffers per stem, applies gain, sums to output
+- `sounddevice.OutputStream` callback: reads buffers per stem, applies gain, sums to output; optional metronome click mix; optional count-in pre-roll before advancing `_current_frame`
 - API: `play()`, `pause()`, `stop()`, `seek()`, `set_mute()`, `set_solo()`, `set_volume()`
 - Per-stem volume control (0.0-2.0)
-- A-B loop: `set_loop_a()`, `set_loop_b()`, `set_looping()`, `clear_loop()`
+- A-B loop: `set_loop_a()`, `set_loop_b()`, `set_looping()`, `clear_loop()`. While looping is on and the region is valid (`B > A`), **Stop** seeks to loop A (not track start); **seek** clamps into `[A, B)` (outside snaps to A)
+- Metronome and count-in settings (BPM, volume, beats, loop-repeat count-in)
 - Tracks playback position for UI sync
 - PortAudioError on open/start: stream cleanup and **`playback_failed`** signal (user-facing message for UI dialogs)
 
@@ -183,8 +187,8 @@ stemma/
 - Respects mute/solo state (same logic as audio callback)
 
 ### UI Modules
-- **`main_window.py`** — Left panel: song library list. Center: player controls + stem mixer. Menu: File / Edit (Preferences) / Help. Keyboard shortcuts. Window state persistence via QSettings. Drag-and-drop audio import. Connects **`playback_failed`** and startup warning when no audio output devices exist.
-- **`player_controls.py`** — Transport (Play/Pause/Stop + time display). Waveform display with click-to-seek, playback cursor, and A-B loop markers. A-B loop controls (Set A/Set B/Loop toggle/Clear). Per-stem row: label + Mute + Solo + volume slider. Color-coded stems (vocals=purple, drums=orange, bass=blue, guitar=red, piano=green, other=gray). Waveform recomputes on mute/solo/volume changes. Playback speed presets.
+- **`main_window.py`** — Left panel: song library list. Center: player controls + stem mixer. Menu: File / Edit (Preferences) / Help (Keyboard Shortcuts, About). Keyboard shortcuts. Window geometry/state and **session persistence** (last song, position, mixer, loop, speed, metronome, count-in) via QSettings. Drag-and-drop audio import. Connects **`playback_failed`** and startup warning when no audio output devices exist.
+- **`player_controls.py`** — Transport (Play/Pause/Stop + time display). Waveform with click-to-seek, cursor, A-B loop markers. A-B loop controls (Set A/Set B/Loop toggle/Clear). Metronome row (BPM, tap, toggle, volume). Count-in row (toggle, beats, loop-repeat option). Per-stem row: label + Mute + Solo + volume slider. Color-coded stems. Waveform recomputes on mute/solo/volume changes. Playback speed presets.
 - **`waveform_widget.py`** — Custom QPainter widget: mirrored waveform bars, playback cursor, loop region shading, loop marker lines. Click/drag-to-seek. Catppuccin Mocha colors.
 - **`library_panel.py`** — Song list with search/filter, selection, remove (with confirmation), metadata edit (double-click / context menu)
 - **`import_dialog.py`** — File browser or YouTube URL, metadata fields, model variant (4/6 stem). If ONNX is missing, downloads model with progress; on any failure before successful import completion, removes the new library row. Large file (100 MiB+) confirmation. **Retry import** after errors. Workers cancelled and rolled back on dialog reject.
@@ -243,6 +247,13 @@ Tickets ship as incremental 1.x releases (semver).
 - [ ] MSIX packaging for Microsoft Store (#74)
 - [ ] Real-time streaming stem separation (#13)
 - [ ] Experimental DSP (#28)
+
+### Release 1.1.0 (shipped)
+- Session persistence across restarts (#55).
+- Metronome: BPM 20--300, tap tempo, mix in callback (#57).
+- Count-in: optional beats before playback; optional before each loop repeat (#78).
+- Loop UX: Stop and seek respect the A-B region while looping is on.
+- Help > Keyboard Shortcuts dialog.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Import a song, separate it into stems (vocals, drums, bass, guitar, piano, other
 - Clear errors and progress when ONNX models download on first use; large-file warning before heavy imports
 - Export individual stems or custom mixes as WAV or MP3
 - Waveform visualization with click-to-seek, playback cursor, and loop markers
-- A-B loop for practice sections; pitch-preserving playback speed presets
-- Keyboard shortcuts for transport, stems, loop, and speed
-- Dark / light Qt themes; window state persistence; configurable data folder and audio device (Edit > Preferences)
+- A-B loop for practice sections (Stop returns to loop A while looping; seek stays inside the loop); pitch-preserving playback speed presets
+- Metronome with BPM entry, tap tempo, mute/solo-friendly click track
+- Optional count-in beats before playback (and optionally before each loop repeat)
+- Session persistence: restore last song, position, mixer, loop, speed, metronome, and count-in after restart
+- Keyboard shortcuts for transport, stems, loop, speed, metronome, and count-in; full list under **Help > Keyboard Shortcuts**
+- Dark / light Qt themes; window geometry/state persistence; configurable data folder and audio device (Edit > Preferences)
 - 100% local processing -- no cloud, no subscriptions
 
 ## Download
@@ -49,7 +52,7 @@ python main.py
 ## Running Tests
 
 ```bash
-# Fast tests (~10 seconds, ~286 tests)
+# Fast tests (~10 seconds, ~360 tests)
 pytest
 
 # Include ONNX inference tests (~20 seconds, needs model file)
@@ -72,6 +75,10 @@ pytest -m hardware
 | B | Set loop end point |
 | L | Toggle A-B loop |
 | [ / ] | Slower / faster playback speed |
+| M | Toggle metronome |
+| C | Toggle count-in |
+
+Use **Help > Keyboard Shortcuts** in the app for the authoritative list (same bindings as above).
 
 ## Project Documentation
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """stemma version string."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"


### PR DESCRIPTION
## Summary
- bump app version to 1.1.0
- sync release docs (README.md, PROJECT.md, AGENTS.md, CHANGELOG.md) with shipped metronome/count-in/session persistence work
- prepare clean v1.1.0 release branch after history rewrite

## Test plan
- [x] run pytest
- [x] verify app starts and shows v1.1.0
- [x] verify release notes/docs are correct