### PR TITLE
docs: update changelog and trackers for v2.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ Runtime library and models default to the per-user folder (e.g. `%LOCALAPPDATA%\
 
 ## Current Status
 
-Last updated: 2026-03-26
+Last updated: 2026-04-03
 
 ### Phase 1 (MVP) -- Complete
 All core functionality implemented and tested:
@@ -193,10 +193,17 @@ All core functionality implemented and tested:
 - [ ] Experimental DSP (#28)
 - [ ] Real-time streaming (#13)
 
+### v2.1.0 Release -- Shipped
+- [x] Metronome beat-sync nudge (±500ms spinbox, all click sources)
+- [x] Count-in controls moved to transport bar
+- [x] Live volume combos (editable, real-time slider sync)
+- [x] Library two-row display with separator lines and teal selection
+- [x] Recording session persistence (nudge/mute/solo/volume per take)
+
 ## Test Suite
 
 ```
-pytest                                    # ~527 fast tests (~17s)
+pytest                                    # ~600 fast tests (~17s)
 pytest -m slow                            # 5 ONNX inference tests (~20s, needs model)
 pytest -m hardware                        # 1 audible playback test (~30s, needs speakers)
 set STEMMA_TEST_SONG=path/to/song.mp3     # Required for slow/hardware tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,19 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
-## 2026-04-02 -- BPM and Key Detection
+## 2026-04-02 -- v2.0.5 Automatic BPM & Key Detection
 
 ### Done
-- **Detection engine:** Added background audio analysis (`src/beat_detector.py`) that detects tempo and musical key after a song loads.
-- **ONNX + Librosa:** Uses the `beat_this` ONNX model for high-accuracy beat tracking, falling back to librosa if the model is absent. Key detection uses Krumhansl-Schmuckler chroma analysis.
-- **UI:** Detected key and BPM are shown as non-intrusive suggestions in the Loop and Metronome bars. Colored confidences (green/yellow/red) follow Catppuccin palette logic.
-- **Memory persistence:** Detected values are persisted in QSettings per-song to avoid re-analysis on every load. Re-detection is supported via double-click on the labels, and dynamically recalculates within A-B loop regions.
-- **Fix:** Used `winsound` as a fallback for logo click audio on Windows to fix silent clicks in MSIX/Store builds.
-- **Polish:** Added 6px vertical padding to QMenu items.
+- **BPM/key detection:** New background analysis engine detects tempo and musical key for every song automatically after it loads. Uses the beat_this ONNX model (MIT, ISMIR 2024, 89–97% F1) for beat tracking with a librosa fallback, and the Krumhansl-Schmuckler algorithm on chroma features for key detection.
+- **Suggestion-only display:** Detected values are shown as read-only labels — "Detected key: A minor" on the loop row and "~98 BPM" on the metronome row — colour-coded by confidence (green/yellow/red). The metronome BPM spinbox is never modified.
+- **Per-song caching:** Results (including confidence level) are stored per-song in settings. Switching back to a previously analysed song restores the cached values instantly without re-running analysis.
+- **A-B region detection:** Setting loop points A and B re-triggers detection within that region only, letting you identify the key/tempo of a specific section. Clearing the loop reverts to full-song analysis.
+- **Double-click to re-detect:** Double-clicking either the key or BPM label forces a fresh analysis for that value individually — useful after the first run or when A-B points change.
+- **Logo sound fix (MS Store):** Logo click sound now uses `winsound` on Windows, matching the proven splash-screen path and fixing silent clicks in MSIX builds.
+- **Menu padding:** QMenu dropdown items now have proper vertical padding for a less cramped look.
 
 ### Metrics
-- 580 tests pass.
-- 31 new tests added for beat and key detection logic.
+- 31 new tests (test_beat_detector.py); 580 total pass, 5 skipped.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-04-03 -- v2.1.0 Metronome Nudge, UI Polish, Library Improvements, Session Persistence
+
+### Done
+- **Metronome beat-sync nudge:** New ±500ms spinbox on the metronome row shifts all click sources (continuous metronome, count-in, beat-synced mode) relative to detected beat positions. Useful for aligning the click to songs with a consistent offset. Offset resets on Stop.
+- **Count-in controls in transport bar:** Beat counter and count-in controls (label, spinbox, repeat checkbox) moved from the metronome row into the transport bar, reducing crowding and keeping the metronome row focused.
+- **Live volume combos:** Stem and metronome volume combo boxes are now editable and update in real time as the slider moves (e.g. "137%"). The combo opens on a click anywhere in the widget, not just the dropdown arrow.
+- **Icon button fix:** On/off and repeat buttons in the metronome/count-in area now render at their correct 36x36 size instead of collapsing to slivers.
+- **Speed combo alignment:** Playback speed combo box is now flush with the right edge of the transport bar.
+- **Library two-row display:** Songs in the library panel now show artist name (bold) on the top line and song title (subdued, smaller) below, with a separator line between items. Selection uses the teal accent colour to match the app theme.
+- **Recording session persistence:** Per-song QSettings now save and restore each recording take's nudge offset, mute, solo, and volume. Values are re-applied after the takes finish loading so they survive song switches and restarts.
+
+### Metrics
+- 600 fast tests pass, 5 skipped (slow ONNX/hardware).
+
+---
+
 ## 2026-04-02 -- v2.0.5 Automatic BPM & Key Detection
 
 ### Done

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Import a song, separate it into stems (vocals, drums, bass, guitar, piano, other
 - Export individual stems or custom mixes as WAV or MP3
 - Waveform visualization with click-to-seek, playback cursor, and loop markers
 - A-B loop for practice sections (Stop returns to loop A while looping; seek stays inside the loop); pitch-preserving playback speed presets
-- Metronome with BPM entry, tap tempo, mute/solo-friendly click track
+- Metronome with BPM entry, tap tempo, mute/solo-friendly click track; automatic tempo/key detection with beat-synced mode
+- Beat-sync nudge: shift metronome clicks ±500ms relative to detected beat positions to align the click with any song
 - Optional count-in beats before playback (and optionally before each loop repeat)
-- Session persistence: restore last song, position, mixer, loop, speed, metronome, and count-in after restart
+- Session persistence: restore last song, position, mixer, loop, speed, metronome, count-in, and recording take state after restart
+- Library panel shows artist and title on separate lines with teal selection highlight
 - Keyboard shortcuts for transport, stems, loop, speed, metronome, and count-in; full list under **Help > Keyboard Shortcuts**
 - Dark / light Qt themes; window geometry/state persistence; configurable data folder and audio device (Edit > Preferences)
 - 100% local processing -- no cloud, no subscriptions

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """stemma version string."""
 
-__version__ = "2.0.4"
+__version__ = "2.1.0"


### PR DESCRIPTION
## Summary

- Prepend `CHANGELOG.md` entry for v2.1.0 (metronome nudge, UI polish, library two-row display, recording session persistence; 600 tests)
- Update `AGENTS.md`: add v2.1.0 shipped block, correct fast test count to ~600, update date to 2026-04-03
- Update `README.md`: add beat-sync nudge bullet, update metronome line, update session persistence line, add library two-row bullet
- Bump `src/version.py` from `2.0.4` to `2.1.0`
- Closed issue #42 (tempo/key detection + beat-synced metronome -- fully resolved)

## Test plan

- [x] Docs-only change; no code logic altered
- [x] Verify CHANGELOG, AGENTS.md, README look correct in rendered form