### PR TITLE
feat: chord detection and beat_this ONNX model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,9 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
-## 2026-04-03 -- v2.1.0 Metronome Nudge, UI Polish, Library Improvements, Session Persistence
-
-### Done
-- **Metronome beat-sync nudge:** New ±500ms spinbox on the metronome row shifts all click sources (continuous metronome, count-in, beat-synced mode) relative to detected beat positions. Useful for aligning the click to songs with a consistent offset. Offset resets on Stop.
-- **Count-in controls in transport bar:** Beat counter and count-in controls (label, spinbox, repeat checkbox) moved from the metronome row into the transport bar, reducing crowding and keeping the metronome row focused.
-- **Live volume combos:** Stem and metronome volume combo boxes are now editable and update in real time as the slider moves (e.g. "137%"). The combo opens on a click anywhere in the widget, not just the dropdown arrow.
-- **Icon button fix:** On/off and repeat buttons in the metronome/count-in area now render at their correct 36x36 size instead of collapsing to slivers.
-- **Speed combo alignment:** Playback speed combo box is now flush with the right edge of the transport bar.
-- **Library two-row display:** Songs in the library panel now show artist name (bold) on the top line and song title (subdued, smaller) below, with a separator line between items. Selection uses the teal accent colour to match the app theme.
-- **Recording session persistence:** Per-song QSettings now save and restore each recording take's nudge offset, mute, solo, and volume. Values are re-applied after the takes finish loading so they survive song switches and restarts.
-
-### Metrics
-- 600 fast tests pass, 5 skipped (slow ONNX/hardware).
-
----
-
 ## 2026-04-02 -- v2.0.5 Automatic BPM & Key Detection
 
 ### Done
-- **Beat-synced metronome:** Added a "Sync" toggle to lock metronome clicks to the detected beat positions instead of a fixed BPM grid. Handles time-stretching correctly via scaled beat frames. Fixed an auditory glitch by properly carrying over click tails that fall across audio chunk playback boundaries.
 - **BPM/key detection:** New background analysis engine detects tempo and musical key for every song automatically after it loads. Uses the beat_this ONNX model (MIT, ISMIR 2024, 89–97% F1) for beat tracking with a librosa fallback, and the Krumhansl-Schmuckler algorithm on chroma features for key detection.
 - **Suggestion-only display:** Detected values are shown as read-only labels — "Detected key: A minor" on the loop row and "~98 BPM" on the metronome row — colour-coded by confidence (green/yellow/red). The metronome BPM spinbox is never modified.
 - **Per-song caching:** Results (including confidence level) are stored per-song in settings. Switching back to a previously analysed song restores the cached values instantly without re-running analysis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,20 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
-## 2026-04-08 -- v2.2.0 Time Signature & Chord Detection
+## 2026-04-14 -- v2.2.0 Chord Detection & beat_this ONNX Model
 
 ### Done
-- **Time signature detection:** Infers time signature (4/4, 3/4, 6/8, etc.) from downbeat analysis using the beat_this ONNX model. Counts beats between consecutive downbeats, takes the median, and maps to standard time signatures.
-- **Chord detection:** Real-time chord display using chromagram template matching with cosine similarity across 84 chord templates (major, minor, 7th, m7, maj7, dim, aug). Viterbi HMM smoothing for temporal stability. Binary search lookup at playback position (O(log n)). Updates at 4 Hz during playback.
-- **Detection badge UI:** All four detection labels (key, tempo, time signature, chord) rendered as styled badges with rich text HTML — white label text with confidence-coloured values on rounded surface0 backgrounds.
+- **Chord detection:** Real-time chord display using chromagram template matching with cosine similarity across 24 chord templates (major, minor). Viterbi HMM smoothing (self_prob=0.99) for temporal stability. Silence gating prevents stale chords. Binary search lookup at playback position (O(log n)). Updates at 4 Hz during playback. Shows "Chord: --" placeholder when stopped or during silence.
+- **beat_this ONNX model:** Auto-downloads the beat_this model (MIT license, ISMIR 2024) for high-accuracy beat/downbeat tracking. Chunked inference with 1500-frame segments and 6-frame border overlap to satisfy rotary position embedding constraints. Falls back to librosa when unavailable.
+- **Detection badge UI:** Three detection labels (key, tempo, chord) rendered as styled badges with rich text HTML — label text with confidence-coloured values on rounded surface0 backgrounds. Theme switching regenerates badge HTML with new theme colours.
+- **QThread crash fix:** Worker orphaning pattern with identity-checked `finished` callback prevents "QThread: Destroyed while thread is still running" crashes when switching songs during detection.
+- **Light mode readability:** Badge labels include explicit `color:` property; dim text uses theme text color for proper contrast in both dark and light modes.
 - **MSIX logo sound fix:** Logo click and splash screen sounds now use `winsound.SND_MEMORY` with daemon thread playback, fixing silent sounds in MSIX sandbox (path virtualization breaks `SND_FILENAME`) and Python's `SND_ASYNC | SND_MEMORY` restriction.
-- **Session backward compatibility:** Forces re-detection when cached sessions lack chord, downbeat, or time signature data. Filters legacy `"--"` time signature values from old cache.
+- **Session backward compatibility:** Schema version 4 forces re-detection when cached sessions have older chord data.
 - **Downbeat sensitivity:** Lowered downbeat peak-picking threshold (0.15 vs 0.3 for beats) to capture weaker downbeat activations from the ONNX model.
 
 ### Metrics
-- 48 fast beat_detector tests pass; 4 slow chord detection tests.
-- 6 player chord tests (verified by code review).
+- 625 tests pass, 5 skipped (slow ONNX/hardware).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,42 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-04-08 -- v2.2.0 Time Signature & Chord Detection
+
+### Done
+- **Time signature detection:** Infers time signature (4/4, 3/4, 6/8, etc.) from downbeat analysis using the beat_this ONNX model. Counts beats between consecutive downbeats, takes the median, and maps to standard time signatures.
+- **Chord detection:** Real-time chord display using chromagram template matching with cosine similarity across 84 chord templates (major, minor, 7th, m7, maj7, dim, aug). Viterbi HMM smoothing for temporal stability. Binary search lookup at playback position (O(log n)). Updates at 4 Hz during playback.
+- **Detection badge UI:** All four detection labels (key, tempo, time signature, chord) rendered as styled badges with rich text HTML — white label text with confidence-coloured values on rounded surface0 backgrounds.
+- **MSIX logo sound fix:** Logo click and splash screen sounds now use `winsound.SND_MEMORY` with daemon thread playback, fixing silent sounds in MSIX sandbox (path virtualization breaks `SND_FILENAME`) and Python's `SND_ASYNC | SND_MEMORY` restriction.
+- **Session backward compatibility:** Forces re-detection when cached sessions lack chord, downbeat, or time signature data. Filters legacy `"--"` time signature values from old cache.
+- **Downbeat sensitivity:** Lowered downbeat peak-picking threshold (0.15 vs 0.3 for beats) to capture weaker downbeat activations from the ONNX model.
+
+### Metrics
+- 48 fast beat_detector tests pass; 4 slow chord detection tests.
+- 6 player chord tests (verified by code review).
+
+---
+
+## 2026-04-03 -- v2.1.0 Metronome Nudge, UI Polish, Library Improvements, Session Persistence
+
+### Done
+- **Metronome beat-sync nudge:** New ±500ms spinbox on the metronome row shifts all click sources (continuous metronome, count-in, beat-synced mode) relative to detected beat positions. Useful for aligning the click to songs with a consistent offset. Offset resets on Stop.
+- **Count-in controls in transport bar:** Beat counter and count-in controls (label, spinbox, repeat checkbox) moved from the metronome row into the transport bar, reducing crowding and keeping the metronome row focused.
+- **Live volume combos:** Stem and metronome volume combo boxes are now editable and update in real time as the slider moves (e.g. "137%"). The combo opens on a click anywhere in the widget, not just the dropdown arrow.
+- **Icon button fix:** On/off and repeat buttons in the metronome/count-in area now render at their correct 36x36 size instead of collapsing to slivers.
+- **Speed combo alignment:** Playback speed combo box is now flush with the right edge of the transport bar.
+- **Library two-row display:** Songs in the library panel now show artist name (bold) on the top line and song title (subdued, smaller) below, with a separator line between items. Selection uses the teal accent colour to match the app theme.
+- **Recording session persistence:** Per-song QSettings now save and restore each recording take's nudge offset, mute, solo, and volume. Values are re-applied after the takes finish loading so they survive song switches and restarts.
+
+### Metrics
+- 600 fast tests pass, 5 skipped (slow ONNX/hardware).
+
+---
+
 ## 2026-04-02 -- v2.0.5 Automatic BPM & Key Detection
 
 ### Done
+- **Beat-synced metronome:** Added a "Sync" toggle to lock metronome clicks to the detected beat positions instead of a fixed BPM grid. Handles time-stretching correctly via scaled beat frames. Fixed an auditory glitch by properly carrying over click tails that fall across audio chunk playback boundaries.
 - **BPM/key detection:** New background analysis engine detects tempo and musical key for every song automatically after it loads. Uses the beat_this ONNX model (MIT, ISMIR 2024, 89–97% F1) for beat tracking with a librosa fallback, and the Krumhansl-Schmuckler algorithm on chroma features for key detection.
 - **Suggestion-only display:** Detected values are shown as read-only labels — "Detected key: A minor" on the loop row and "~98 BPM" on the metronome row — colour-coded by confidence (green/yellow/red). The metronome BPM spinbox is never modified.
 - **Per-song caching:** Results (including confidence level) are stored per-song in settings. Switching back to a previously analysed song restores the cached values instantly without re-running analysis.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -238,7 +238,7 @@ stemma/
 - [x] PyInstaller packaging + GitHub Release workflow (#56)
 
 ### Post-2.0 backlog (see GitHub issues)
-Shipped in 2.x: session persistence (#55), metronome (#57), count-in (#78), recording (#79), animated startup (#76), MSIX / Store (#74), UI redesign and export extras (#92, #97, #98, #99, #100), release tooling (tag-driven `version.py` + manifest sync, CI on tags), automatic BPM/key detection and beat-synced metronome (#42).
+Shipped in 2.x: session persistence (#55), metronome (#57), count-in (#78), recording (#79), animated startup (#76), MSIX / Store (#74), UI redesign and export extras (#92, #97, #98, #99, #100), release tooling (tag-driven `version.py` + manifest sync, CI on tags), automatic BPM/key detection and beat-synced metronome (#42), time signature detection and real-time chord display (#118).
 
 Open (all labeled `v3.0` on GitHub):
 - [ ] Experimental DSP extensions (#28)

--- a/msix/AppxManifest.xml
+++ b/msix/AppxManifest.xml
@@ -7,7 +7,7 @@
   <Identity
     Name="SanttuNyknen.stemma"
     Publisher="CN=B41D15B4-C2B7-498F-920E-E8D2AEA35338"
-    Version="2.0.4.0"
+    Version="2.2.0.0"
     ProcessorArchitecture="x64" />
 
   <Properties>

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -32,6 +32,7 @@ class DetectionResult:
     beat_times: list[float] = dataclasses.field(default_factory=list)
     downbeat_times: list[float] = dataclasses.field(default_factory=list)
     time_signature: str = ""        # e.g. "4/4", "3/4", "" if unknown
+    chord_sequence: list = dataclasses.field(default_factory=list)  # list[tuple[float, str]]
 
 
 # ---------------------------------------------------------------------------
@@ -286,6 +287,153 @@ def _detect_time_signature(
 
 
 # ---------------------------------------------------------------------------
+# Chord detection — chromagram template matching + HMM smoothing
+# ---------------------------------------------------------------------------
+
+_CHORD_NAMES = ["C", "C#", "D", "Eb", "E", "F",
+                "F#", "G", "Ab", "A", "Bb", "B"]
+
+# Template profiles: each row is a 12-semitone chroma pattern.
+# 1 = note present, 0 = absent, fractional = softer harmonic.
+_CHORD_TEMPLATES: list[tuple[str, np.ndarray]] = []
+
+
+def _build_chord_templates() -> list[tuple[str, np.ndarray]]:
+    """Build chord templates for all roots and quality types.
+
+    Returns a list of (label, 12-dim_chroma_vector) tuples.
+    """
+    if _CHORD_TEMPLATES:
+        return _CHORD_TEMPLATES
+
+    # Interval patterns relative to root (semitones from root).
+    quality_intervals: dict[str, list[int]] = {
+        "":     [0, 4, 7],           # major
+        "m":    [0, 3, 7],           # minor
+        "7":    [0, 4, 7, 10],       # dominant 7th
+        "maj7": [0, 4, 7, 11],       # major 7th
+        "m7":   [0, 3, 7, 10],       # minor 7th
+        "dim":  [0, 3, 6],           # diminished
+        "aug":  [0, 4, 8],           # augmented
+    }
+
+    for root_idx, root_name in enumerate(_CHORD_NAMES):
+        for suffix, intervals in quality_intervals.items():
+            template = np.zeros(12, dtype=np.float64)
+            for iv in intervals:
+                template[(root_idx + iv) % 12] = 1.0
+            norm = np.linalg.norm(template)
+            if norm > 0:
+                template /= norm
+            _CHORD_TEMPLATES.append((f"{root_name}{suffix}", template))
+
+    return _CHORD_TEMPLATES
+
+
+def _viterbi_smooth(
+    frame_labels: list[int], n_states: int,
+    self_prob: float = 0.96,
+) -> list[int]:
+    """Viterbi smoothing with a simple self-transition-biased HMM.
+
+    Encourages staying in the same chord state across consecutive frames,
+    reducing noisy frame-by-frame flickering.
+    """
+    n_frames = len(frame_labels)
+    if n_frames == 0:
+        return []
+
+    # Uniform initial probability.
+    log_pi = np.full(n_states, -math.log(n_states))
+
+    # Transition: high self-transition, uniform otherwise.
+    other_prob = (1.0 - self_prob) / max(1, n_states - 1)
+    log_self = math.log(self_prob)
+    log_other = math.log(other_prob) if other_prob > 0 else -1e12
+
+    # Emission: deterministic from the template-matched label.
+    # P(obs=j | state=i) = high if i==j, low otherwise.
+    emit_match = math.log(0.8)
+    emit_miss = math.log(0.2 / max(1, n_states - 1))
+
+    # Viterbi forward pass.
+    viterbi = np.full((n_frames, n_states), -np.inf)
+    backptr = np.zeros((n_frames, n_states), dtype=np.int32)
+
+    obs = frame_labels[0]
+    for s in range(n_states):
+        emit = emit_match if s == obs else emit_miss
+        viterbi[0, s] = log_pi[s] + emit
+
+    for t in range(1, n_frames):
+        obs = frame_labels[t]
+        for s in range(n_states):
+            emit = emit_match if s == obs else emit_miss
+            best_prev = -np.inf
+            best_idx = 0
+            for p in range(n_states):
+                trans = log_self if p == s else log_other
+                score = viterbi[t - 1, p] + trans
+                if score > best_prev:
+                    best_prev = score
+                    best_idx = p
+            viterbi[t, s] = best_prev + emit
+            backptr[t, s] = best_idx
+
+    # Backtrack.
+    path = [0] * n_frames
+    path[-1] = int(np.argmax(viterbi[-1]))
+    for t in range(n_frames - 2, -1, -1):
+        path[t] = int(backptr[t + 1, path[t + 1]])
+
+    return path
+
+
+def _detect_chords(
+    audio_mono: np.ndarray, sr: int,
+    hop_length: int = 2048,
+) -> list[tuple[float, str]]:
+    """Detect chords using chromagram template matching + HMM smoothing.
+
+    Returns a list of (onset_seconds, chord_label) tuples representing
+    consecutive chord segments.
+    """
+    chroma = librosa.feature.chroma_cqt(
+        y=audio_mono, sr=sr, hop_length=hop_length,
+    )  # (12, n_frames)
+    n_frames = chroma.shape[1]
+    if n_frames == 0:
+        return []
+
+    templates = _build_chord_templates()
+    template_matrix = np.array([t[1] for t in templates])  # (n_templates, 12)
+
+    # Normalise each chroma frame.
+    norms = np.linalg.norm(chroma, axis=0, keepdims=True)
+    norms = np.where(norms < 1e-9, 1.0, norms)
+    chroma_norm = chroma / norms  # (12, n_frames)
+
+    # Cosine similarity: (n_templates, n_frames).
+    similarities = template_matrix @ chroma_norm
+    frame_labels = np.argmax(similarities, axis=0).tolist()
+
+    # HMM smoothing.
+    n_states = len(templates)
+    smoothed = _viterbi_smooth(frame_labels, n_states)
+
+    # Merge consecutive same-chord frames into segments.
+    fps = sr / hop_length
+    segments: list[tuple[float, str]] = []
+    prev_label = -1
+    for i, label in enumerate(smoothed):
+        if label != prev_label:
+            segments.append((i / fps, templates[label][0]))
+            prev_label = label
+
+    return segments
+
+
+# ---------------------------------------------------------------------------
 # High-level detection function
 # ---------------------------------------------------------------------------
 
@@ -356,6 +504,9 @@ def detect_bpm_and_key(
     # Time signature (requires downbeats from beat_this ONNX).
     time_sig = _detect_time_signature(beat_times, downbeat_times)
 
+    # Chord detection.
+    chord_sequence = _detect_chords(mono, sample_rate)
+
     return DetectionResult(
         bpm=bpm,
         bpm_confidence=_bpm_confidence(beat_times),
@@ -364,6 +515,7 @@ def detect_bpm_and_key(
         beat_times=beat_times,
         downbeat_times=downbeat_times,
         time_signature=time_sig,
+        chord_sequence=chord_sequence,
     )
 
 

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -117,7 +117,7 @@ def _detect_beats_onnx(
         n_fft=_BT_N_FFT, hop_length=_BT_HOP,
         n_mels=_BT_N_MELS, fmin=_BT_FMIN, fmax=_BT_FMAX,
     )
-    log_mel = np.log1p(mel).astype(np.float32)  # (n_mels, frames)
+    log_mel = np.log1p(1000.0 * mel).astype(np.float32)  # ln(1 + 1000*x)
 
     # Model expects (batch, frames, n_mels).
     spec = log_mel.T[np.newaxis, :, :]  # (1, frames, 128)
@@ -287,62 +287,6 @@ def _detect_time_signature(
     return _TIME_SIG_MAP.get(median_bpb, f"{median_bpb}/4")
 
 
-def _infer_time_signature_from_beats(
-    beat_times: list[float],
-    audio_mono: np.ndarray,
-    sample_rate: int,
-) -> str:
-    """Estimate meter from beat-strength autocorrelation when downbeats unavailable.
-
-    Samples onset strength at each beat position, mean-subtracts, then
-    computes the full autocorrelation and finds the lag in [2..6] with the
-    highest positive value.  That lag gives the number of beats per bar.
-
-    Returns ``""`` when no clear periodicity is found (ambient / atonal
-    material or fewer than 8 beats detected).
-    """
-    if len(beat_times) < 8:
-        return ""
-
-    hop = 512
-    onset_env = librosa.onset.onset_strength(
-        y=audio_mono, sr=sample_rate, hop_length=hop,
-    )
-    n_frames = len(onset_env)
-    raw_frames = librosa.time_to_frames(
-        np.asarray(beat_times), sr=sample_rate, hop_length=hop,
-    ).astype(int)
-    # Peak in a ±3-frame window to handle spectrogram-window latency.
-    window = 3
-    strengths = np.array([
-        onset_env[max(0, f - window): min(n_frames, f + window + 1)].max()
-        for f in raw_frames
-    ], dtype=np.float64)
-
-    # Mean-subtract so autocorrelation measures periodic variation, not
-    # overall level, then compute full autocorrelation.
-    s = strengths - strengths.mean()
-    autocorr = np.correlate(s, s, mode="full")
-    ac = autocorr[len(autocorr) // 2:]   # positive lags: ac[0] = zero-lag energy
-
-    if ac[0] <= 0:
-        return ""
-
-    # Pick the lag in [2..6] with the highest positive autocorrelation.
-    # Lag k means the beat-strength pattern repeats every k beats (bar length).
-    best_lag = max(range(2, 7), key=lambda k: ac[k] if k < len(ac) else -np.inf)
-
-    if ac[best_lag] <= 0:
-        return ""
-
-    # Require the periodic component to be at least 10 % of zero-lag energy.
-    confidence = ac[best_lag] / (ac[0] + 1e-6)
-    if confidence < 0.10:
-        return ""
-
-    return _TIME_SIG_MAP.get(best_lag, f"{best_lag}/4")
-
-
 # ---------------------------------------------------------------------------
 # Chord detection — chromagram template matching + HMM smoothing
 # ---------------------------------------------------------------------------
@@ -350,15 +294,11 @@ def _infer_time_signature_from_beats(
 _CHORD_NAMES = ["C", "C#", "D", "Eb", "E", "F",
                 "F#", "G", "Ab", "A", "Bb", "B"]
 
-# Interval patterns relative to root (semitones from root).
+# Major + minor only — avoids flickering between similar voicings
+# (Am vs Am7 vs Amaj7 etc.) that chroma features cannot distinguish.
 _QUALITY_INTERVALS: dict[str, list[int]] = {
-    "":     [0, 4, 7],           # major
-    "m":    [0, 3, 7],           # minor
-    "7":    [0, 4, 7, 10],       # dominant 7th
-    "maj7": [0, 4, 7, 11],       # major 7th
-    "m7":   [0, 3, 7, 10],       # minor 7th
-    "dim":  [0, 3, 6],           # diminished
-    "aug":  [0, 4, 8],           # augmented
+    "":  [0, 4, 7],   # major triad
+    "m": [0, 3, 7],   # minor triad
 }
 
 
@@ -445,7 +385,7 @@ def _viterbi_smooth(
 
 def _detect_chords(
     audio_mono: np.ndarray, sr: int,
-    hop_length: int = 2048,
+    hop_length: int = 4096,
 ) -> list[tuple[float, str]]:
     """Detect chords using chromagram template matching + HMM smoothing.
 
@@ -462,6 +402,11 @@ def _detect_chords(
     templates = _build_chord_templates()
     template_matrix = np.array([t[1] for t in templates])  # (n_templates, 12)
 
+    # Per-frame energy for silence gating.
+    frame_energy = np.sum(chroma, axis=0)  # (n_frames,)
+    nonzero = frame_energy[frame_energy > 0]
+    energy_thresh = float(np.percentile(nonzero, 10)) * 0.5 if len(nonzero) else 0.0
+
     # Normalise each chroma frame.
     norms = np.linalg.norm(chroma, axis=0, keepdims=True)
     norms = np.where(norms < 1e-9, 1.0, norms)
@@ -471,15 +416,17 @@ def _detect_chords(
     similarities = template_matrix @ chroma_norm
     frame_labels = np.argmax(similarities, axis=0).tolist()
 
-    # HMM smoothing.
+    # HMM smoothing — high self-transition to reduce flickering.
     n_states = len(templates)
-    smoothed = _viterbi_smooth(frame_labels, n_states)
+    smoothed = _viterbi_smooth(frame_labels, n_states, self_prob=0.99)
 
-    # Merge consecutive same-chord frames into segments.
+    # Merge consecutive same-chord frames, holding previous chord in silence.
     fps = sr / hop_length
     segments: list[tuple[float, str]] = []
     prev_label = -1
     for i, label in enumerate(smoothed):
+        if frame_energy[i] < energy_thresh:
+            continue  # hold previous chord during silence
         if label != prev_label:
             segments.append((i / fps, templates[label][0]))
             prev_label = label
@@ -555,14 +502,9 @@ def detect_bpm_and_key(
     if bpm > 0:
         bpm = max(20.0, min(300.0, bpm))
 
-    # Time signature: prefer beat_this downbeats; fall back to onset
-    # periodicity heuristic when the ONNX model is absent or produces
-    # no downbeats (e.g. single-output export).
+    # Time signature from beat_this downbeats (empty when using librosa
+    # fallback, which does not produce downbeats).
     time_sig = _detect_time_signature(beat_times, downbeat_times)
-    if not time_sig and beat_times:
-        time_sig = _infer_time_signature_from_beats(
-            beat_times, mono, sample_rate,
-        )
 
     # Chord detection.
     chord_sequence = _detect_chords(mono, sample_rate)

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -49,7 +49,8 @@ _BT_FMAX = 10000.0
 
 # Peak-picking parameters.
 _BEAT_THRESHOLD = 0.3
-_BEAT_MIN_DIST = 6      # ~120 ms at 50 fps
+_DOWNBEAT_THRESHOLD = 0.15  # Lower: downbeat activations are weaker
+_BEAT_MIN_DIST = 6          # ~120 ms at 50 fps
 
 
 def _create_onnx_session(model_path: str):
@@ -137,7 +138,7 @@ def _detect_beats_onnx(
     # Peak-pick downbeats.
     downbeat_times: list[float] = []
     if downbeat_logits is not None:
-        db_frames = _peak_pick(downbeat_logits, _BEAT_THRESHOLD, _BEAT_MIN_DIST)
+        db_frames = _peak_pick(downbeat_logits, _DOWNBEAT_THRESHOLD, _BEAT_MIN_DIST)
         downbeat_times = [f / fps for f in db_frames]
 
     # Derive BPM from median inter-beat interval.

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -31,6 +31,7 @@ class DetectionResult:
     key_confidence: str = ""        # "high" / "medium" / "low"
     beat_times: list[float] = dataclasses.field(default_factory=list)
     downbeat_times: list[float] = dataclasses.field(default_factory=list)
+    time_signature: str = ""        # e.g. "4/4", "3/4", "" if unknown
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +254,38 @@ def _key_confidence(correlation: float) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Time signature detection
+# ---------------------------------------------------------------------------
+
+_TIME_SIG_MAP = {2: "2/4", 3: "3/4", 4: "4/4", 5: "5/4", 6: "6/8", 7: "7/8"}
+
+
+def _detect_time_signature(
+    beat_times: list[float], downbeat_times: list[float],
+) -> str:
+    """Infer time signature from beats between consecutive downbeats.
+
+    Requires at least two downbeats (one complete bar) produced by the
+    beat_this ONNX model.  Returns e.g. ``"4/4"`` or ``""`` if unknown.
+    """
+    if len(downbeat_times) < 2 or len(beat_times) < 2:
+        return ""
+
+    bt = np.asarray(beat_times)
+    beats_per_bar: list[int] = []
+    for i in range(len(downbeat_times) - 1):
+        count = int(np.sum((bt >= downbeat_times[i]) & (bt < downbeat_times[i + 1])))
+        if count > 0:
+            beats_per_bar.append(count)
+
+    if not beats_per_bar:
+        return ""
+
+    median_bpb = int(round(float(np.median(beats_per_bar))))
+    return _TIME_SIG_MAP.get(median_bpb, f"{median_bpb}/4")
+
+
+# ---------------------------------------------------------------------------
 # High-level detection function
 # ---------------------------------------------------------------------------
 
@@ -320,6 +353,9 @@ def detect_bpm_and_key(
     if bpm > 0:
         bpm = max(20.0, min(300.0, bpm))
 
+    # Time signature (requires downbeats from beat_this ONNX).
+    time_sig = _detect_time_signature(beat_times, downbeat_times)
+
     return DetectionResult(
         bpm=bpm,
         bpm_confidence=_bpm_confidence(beat_times),
@@ -327,6 +363,7 @@ def detect_bpm_and_key(
         key_confidence=_key_confidence(key_corr),
         beat_times=beat_times,
         downbeat_times=downbeat_times,
+        time_signature=time_sig,
     )
 
 

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -350,15 +350,12 @@ def _detect_time_signature(
 _CHORD_NAMES = ["C", "C#", "D", "Eb", "E", "F",
                 "F#", "G", "Ab", "A", "Bb", "B"]
 
-# Chord qualities — major, minor, plus the most chromagram-distinguishable
-# extended chords.  7th chords with tritones (dom7) and wide voicings
-# (maj7, dim) are reliable; m7 is too close to minor in chroma space.
+# Chord qualities — major and minor triads only.  Extended chords (7ths,
+# dim) produce too many false positives in real-world mixes where bass
+# and guitar overtones overlap in chroma space.
 _QUALITY_INTERVALS: dict[str, list[int]] = {
     "":     [0, 4, 7],       # major triad
     "m":    [0, 3, 7],       # minor triad
-    "7":    [0, 4, 7, 10],   # dominant 7th (tritone makes it distinct)
-    "maj7": [0, 4, 7, 11],   # major 7th (wide voicing, distinct from major)
-    "dim":  [0, 3, 6],       # diminished (tritone interval, very distinct)
 }
 
 
@@ -382,7 +379,7 @@ def _build_chord_templates() -> tuple[tuple[str, np.ndarray], ...]:
     return tuple(templates)
 
 
-# Built eagerly at import time — 84 templates, ~8 KB, thread-safe.
+# Built eagerly at import time — 24 templates (12 roots × 2 qualities).
 _CHORD_TEMPLATES = _build_chord_templates()
 
 

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -267,10 +267,10 @@ def _detect_time_signature(
     """Infer time signature from beats between consecutive downbeats.
 
     Requires at least two downbeats (one complete bar) produced by the
-    beat_this ONNX model.  Returns e.g. ``"4/4"`` or ``""`` if unknown.
+    beat_this ONNX model.  Returns e.g. ``"4/4"`` or ``"--"`` if unknown.
     """
     if len(downbeat_times) < 2 or len(beat_times) < 2:
-        return ""
+        return "--"
 
     bt = np.asarray(beat_times)
     beats_per_bar: list[int] = []
@@ -280,7 +280,7 @@ def _detect_time_signature(
             beats_per_bar.append(count)
 
     if not beats_per_bar:
-        return ""
+        return "--"
 
     median_bpb = int(round(float(np.median(beats_per_bar))))
     return _TIME_SIG_MAP.get(median_bpb, f"{median_bpb}/4")
@@ -293,41 +293,40 @@ def _detect_time_signature(
 _CHORD_NAMES = ["C", "C#", "D", "Eb", "E", "F",
                 "F#", "G", "Ab", "A", "Bb", "B"]
 
-# Template profiles: each row is a 12-semitone chroma pattern.
-# 1 = note present, 0 = absent, fractional = softer harmonic.
-_CHORD_TEMPLATES: list[tuple[str, np.ndarray]] = []
+# Interval patterns relative to root (semitones from root).
+_QUALITY_INTERVALS: dict[str, list[int]] = {
+    "":     [0, 4, 7],           # major
+    "m":    [0, 3, 7],           # minor
+    "7":    [0, 4, 7, 10],       # dominant 7th
+    "maj7": [0, 4, 7, 11],       # major 7th
+    "m7":   [0, 3, 7, 10],       # minor 7th
+    "dim":  [0, 3, 6],           # diminished
+    "aug":  [0, 4, 8],           # augmented
+}
 
 
-def _build_chord_templates() -> list[tuple[str, np.ndarray]]:
+def _build_chord_templates() -> tuple[tuple[str, np.ndarray], ...]:
     """Build chord templates for all roots and quality types.
 
-    Returns a list of (label, 12-dim_chroma_vector) tuples.
+    Returns a tuple of (label, 12-dim_chroma_vector) tuples.
+    Built once at module load — thread-safe and immutable.
     """
-    if _CHORD_TEMPLATES:
-        return _CHORD_TEMPLATES
-
-    # Interval patterns relative to root (semitones from root).
-    quality_intervals: dict[str, list[int]] = {
-        "":     [0, 4, 7],           # major
-        "m":    [0, 3, 7],           # minor
-        "7":    [0, 4, 7, 10],       # dominant 7th
-        "maj7": [0, 4, 7, 11],       # major 7th
-        "m7":   [0, 3, 7, 10],       # minor 7th
-        "dim":  [0, 3, 6],           # diminished
-        "aug":  [0, 4, 8],           # augmented
-    }
-
+    templates: list[tuple[str, np.ndarray]] = []
     for root_idx, root_name in enumerate(_CHORD_NAMES):
-        for suffix, intervals in quality_intervals.items():
+        for suffix, intervals in _QUALITY_INTERVALS.items():
             template = np.zeros(12, dtype=np.float64)
             for iv in intervals:
                 template[(root_idx + iv) % 12] = 1.0
             norm = np.linalg.norm(template)
             if norm > 0:
                 template /= norm
-            _CHORD_TEMPLATES.append((f"{root_name}{suffix}", template))
+            template.flags.writeable = False
+            templates.append((f"{root_name}{suffix}", template))
+    return tuple(templates)
 
-    return _CHORD_TEMPLATES
+
+# Built eagerly at import time — 84 templates, ~8 KB, thread-safe.
+_CHORD_TEMPLATES = _build_chord_templates()
 
 
 def _viterbi_smooth(
@@ -338,6 +337,9 @@ def _viterbi_smooth(
 
     Encourages staying in the same chord state across consecutive frames,
     reducing noisy frame-by-frame flickering.
+
+    Vectorised: the inner state loop uses NumPy broadcasting so the
+    Python-level complexity is O(T × N) instead of O(T × N²).
     """
     n_frames = len(frame_labels)
     if n_frames == 0:
@@ -346,39 +348,34 @@ def _viterbi_smooth(
     # Uniform initial probability.
     log_pi = np.full(n_states, -math.log(n_states))
 
-    # Transition: high self-transition, uniform otherwise.
+    # Transition matrix: log_trans[prev, cur].
     other_prob = (1.0 - self_prob) / max(1, n_states - 1)
-    log_self = math.log(self_prob)
     log_other = math.log(other_prob) if other_prob > 0 else -1e12
+    log_trans = np.full((n_states, n_states), log_other)
+    np.fill_diagonal(log_trans, math.log(self_prob))
 
-    # Emission: deterministic from the template-matched label.
-    # P(obs=j | state=i) = high if i==j, low otherwise.
+    # Emission log-probabilities.
     emit_match = math.log(0.8)
     emit_miss = math.log(0.2 / max(1, n_states - 1))
 
-    # Viterbi forward pass.
+    # Viterbi forward pass — fully vectorised inner loop.
     viterbi = np.full((n_frames, n_states), -np.inf)
     backptr = np.zeros((n_frames, n_states), dtype=np.int32)
 
-    obs = frame_labels[0]
-    for s in range(n_states):
-        emit = emit_match if s == obs else emit_miss
-        viterbi[0, s] = log_pi[s] + emit
+    # Initialise t=0.
+    emit_vec = np.full(n_states, emit_miss)
+    emit_vec[frame_labels[0]] = emit_match
+    viterbi[0] = log_pi + emit_vec
 
     for t in range(1, n_frames):
-        obs = frame_labels[t]
-        for s in range(n_states):
-            emit = emit_match if s == obs else emit_miss
-            best_prev = -np.inf
-            best_idx = 0
-            for p in range(n_states):
-                trans = log_self if p == s else log_other
-                score = viterbi[t - 1, p] + trans
-                if score > best_prev:
-                    best_prev = score
-                    best_idx = p
-            viterbi[t, s] = best_prev + emit
-            backptr[t, s] = best_idx
+        # scores[prev, cur] = viterbi[t-1, prev] + log_trans[prev, cur]
+        scores = viterbi[t - 1, :, np.newaxis] + log_trans  # (N, N)
+        backptr[t] = np.argmax(scores, axis=0)               # (N,)
+        best_scores = scores[backptr[t], np.arange(n_states)] # (N,)
+
+        emit_vec = np.full(n_states, emit_miss)
+        emit_vec[frame_labels[t]] = emit_match
+        viterbi[t] = best_scores + emit_vec
 
     # Backtrack.
     path = [0] * n_frames

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -350,11 +350,15 @@ def _detect_time_signature(
 _CHORD_NAMES = ["C", "C#", "D", "Eb", "E", "F",
                 "F#", "G", "Ab", "A", "Bb", "B"]
 
-# Major + minor only — avoids flickering between similar voicings
-# (Am vs Am7 vs Amaj7 etc.) that chroma features cannot distinguish.
+# Chord qualities — major, minor, plus the most chromagram-distinguishable
+# extended chords.  7th chords with tritones (dom7) and wide voicings
+# (maj7, dim) are reliable; m7 is too close to minor in chroma space.
 _QUALITY_INTERVALS: dict[str, list[int]] = {
-    "":  [0, 4, 7],   # major triad
-    "m": [0, 3, 7],   # minor triad
+    "":     [0, 4, 7],       # major triad
+    "m":    [0, 3, 7],       # minor triad
+    "7":    [0, 4, 7, 10],   # dominant 7th (tritone makes it distinct)
+    "maj7": [0, 4, 7, 11],   # major 7th (wide voicing, distinct from major)
+    "dim":  [0, 3, 6],       # diminished (tritone interval, very distinct)
 }
 
 

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -456,7 +456,7 @@ def _detect_chords(
     if n_frames == 0:
         return []
 
-    templates = _build_chord_templates()
+    templates = _CHORD_TEMPLATES
     template_matrix = np.array([t[1] for t in templates])  # (n_templates, 12)
 
     # Per-frame energy for silence gating.

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -267,10 +267,10 @@ def _detect_time_signature(
     """Infer time signature from beats between consecutive downbeats.
 
     Requires at least two downbeats (one complete bar) produced by the
-    beat_this ONNX model.  Returns e.g. ``"4/4"`` or ``"--"`` if unknown.
+    beat_this ONNX model.  Returns e.g. ``"4/4"`` or ``""`` if unknown.
     """
     if len(downbeat_times) < 2 or len(beat_times) < 2:
-        return "--"
+        return ""
 
     bt = np.asarray(beat_times)
     beats_per_bar: list[int] = []
@@ -280,7 +280,7 @@ def _detect_time_signature(
             beats_per_bar.append(count)
 
     if not beats_per_bar:
-        return "--"
+        return ""
 
     median_bpb = int(round(float(np.median(beats_per_bar))))
     return _TIME_SIG_MAP.get(median_bpb, f"{median_bpb}/4")

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -39,13 +39,18 @@ class DetectionResult:
 # Beat detection — beat_this ONNX
 # ---------------------------------------------------------------------------
 
-# Preprocessing constants matching the beat_this model.
+# Preprocessing constants matching the beat_this model (CPJKU/beat_this).
 _BT_SR = 22050
 _BT_N_FFT = 1024
 _BT_HOP = 441          # 50 fps at 22050 Hz
 _BT_N_MELS = 128
 _BT_FMIN = 30.0
-_BT_FMAX = 10000.0
+_BT_FMAX = 11000.0     # official: 11 kHz upper band
+_BT_LOG_MUL = 1000.0   # ln(1 + 1000 * mel)
+
+# Chunked inference — rotary embeddings require fixed-size chunks.
+_BT_CHUNK_SIZE = 1500   # frames (30 s at 50 fps)
+_BT_BORDER = 6          # overlap frames discarded at chunk boundaries
 
 # Peak-picking parameters.
 _BEAT_THRESHOLD = 0.3
@@ -99,49 +104,100 @@ def _peak_pick(logits: np.ndarray, threshold: float,
     return peaks
 
 
+def _bt_spectrogram(audio_mono: np.ndarray) -> np.ndarray:
+    """Compute the log-mel spectrogram expected by beat_this.
+
+    Returns array of shape ``(frames, 128)`` in float32.  Matches the
+    official ``LogMelSpect`` preprocessing: magnitude mel spectrogram
+    (power=1), frame-length normalisation, and ``ln(1 + 1000 * x)``.
+    """
+    mel = librosa.feature.melspectrogram(
+        y=audio_mono, sr=_BT_SR,
+        n_fft=_BT_N_FFT, hop_length=_BT_HOP,
+        n_mels=_BT_N_MELS, fmin=_BT_FMIN, fmax=_BT_FMAX,
+        power=1.0,           # magnitude, not power
+    )
+    # Frame-length normalisation (torchaudio normalized="frame_length").
+    mel = mel / math.sqrt(_BT_N_FFT)
+    log_mel = np.log1p(_BT_LOG_MUL * mel).astype(np.float32)
+    return log_mel.T  # (frames, 128)
+
+
+def _bt_chunked_inference(
+    spec: np.ndarray, session,
+) -> tuple[np.ndarray, np.ndarray | None]:
+    """Run beat_this on *spec* in 1500-frame chunks with border overlap.
+
+    Returns ``(beat_logits, downbeat_logits)`` arrays covering the full
+    spectrogram, or ``(beat_logits, None)`` if the model has only one
+    output.
+    """
+    n_frames = spec.shape[0]
+    input_name = session.get_inputs()[0].name
+    stride = _BT_CHUNK_SIZE - 2 * _BT_BORDER
+
+    beat_parts: list[np.ndarray] = []
+    db_parts: list[np.ndarray] = []
+
+    offset = 0
+    while offset < n_frames:
+        end = min(offset + _BT_CHUNK_SIZE, n_frames)
+        chunk = spec[offset:end]
+
+        # Pad to exactly _BT_CHUNK_SIZE frames.
+        if chunk.shape[0] < _BT_CHUNK_SIZE:
+            pad_width = _BT_CHUNK_SIZE - chunk.shape[0]
+            chunk = np.pad(chunk, ((0, pad_width), (0, 0)))
+
+        outputs = session.run(
+            None, {input_name: chunk[np.newaxis, :, :]},
+        )
+        beat_out = outputs[0][0]  # (chunk_size,)
+        db_out = outputs[1][0] if len(outputs) > 1 else None
+
+        # Trim borders (keep full extent at first/last chunk).
+        actual_len = min(end - offset, _BT_CHUNK_SIZE)
+        lo = 0 if offset == 0 else _BT_BORDER
+        hi = actual_len if end >= n_frames else actual_len - _BT_BORDER
+        beat_parts.append(beat_out[lo:hi])
+        if db_out is not None:
+            db_parts.append(db_out[lo:hi])
+
+        offset += stride
+
+    beat_logits = np.concatenate(beat_parts)[:n_frames]
+    db_logits = np.concatenate(db_parts)[:n_frames] if db_parts else None
+    return beat_logits, db_logits
+
+
 def _detect_beats_onnx(
     audio_mono: np.ndarray, sr: int, model_path: str,
 ) -> tuple[list[float], list[float], float]:
     """Run beat_this ONNX model and return (beat_times, downbeat_times, bpm).
 
-    The model expects a log-mel spectrogram at 22050 Hz with the parameters
-    defined by the ``_BT_*`` constants above.
+    Uses chunked inference (1500-frame segments with 6-frame overlap) to
+    match the official beat_this inference pipeline and avoid shape errors
+    in the rotary-embedding attention layers.
     """
     # Resample to model sample rate.
     if sr != _BT_SR:
         audio_mono = librosa.resample(audio_mono, orig_sr=sr, target_sr=_BT_SR)
 
-    # Compute mel spectrogram (power → log scale).
-    mel = librosa.feature.melspectrogram(
-        y=audio_mono, sr=_BT_SR,
-        n_fft=_BT_N_FFT, hop_length=_BT_HOP,
-        n_mels=_BT_N_MELS, fmin=_BT_FMIN, fmax=_BT_FMAX,
-    )
-    log_mel = np.log1p(1000.0 * mel).astype(np.float32)  # ln(1 + 1000*x)
-
-    # Model expects (batch, frames, n_mels).
-    spec = log_mel.T[np.newaxis, :, :]  # (1, frames, 128)
-
+    spec = _bt_spectrogram(audio_mono)  # (frames, 128)
     session = _create_onnx_session(model_path)
-    input_name = session.get_inputs()[0].name
-    outputs = session.run(None, {input_name: spec})
+    beat_logits, db_logits = _bt_chunked_inference(spec, session)
 
-    # Outputs: beat_logits (1, frames), downbeat_logits (1, frames).
-    beat_logits = _sigmoid(outputs[0][0])
-    downbeat_logits = _sigmoid(outputs[1][0]) if len(outputs) > 1 else None
-
-    # Peak-pick beats.
-    beat_frames = _peak_pick(beat_logits, _BEAT_THRESHOLD, _BEAT_MIN_DIST)
+    beat_probs = _sigmoid(beat_logits)
+    beat_frames = _peak_pick(beat_probs, _BEAT_THRESHOLD, _BEAT_MIN_DIST)
     fps = _BT_SR / _BT_HOP
     beat_times = [f / fps for f in beat_frames]
 
-    # Peak-pick downbeats.
     downbeat_times: list[float] = []
-    if downbeat_logits is not None:
-        db_frames = _peak_pick(downbeat_logits, _DOWNBEAT_THRESHOLD, _BEAT_MIN_DIST)
+    if db_logits is not None:
+        db_probs = _sigmoid(db_logits)
+        db_frames = _peak_pick(db_probs, _DOWNBEAT_THRESHOLD, _BEAT_MIN_DIST)
         downbeat_times = [f / fps for f in db_frames]
 
-    # Derive BPM from median inter-beat interval.
     bpm = 0.0
     if len(beat_times) >= 2:
         intervals = np.diff(beat_times)
@@ -485,11 +541,19 @@ def detect_bpm_and_key(
     if duration < _MIN_DURATION:
         return DetectionResult()
 
-    # Beat detection.
+    # Beat detection — try ONNX model, fall back to librosa on any error.
+    beat_times: list[float] = []
+    downbeat_times: list[float] = []
+    bpm = 0.0
     if model_path and os.path.isfile(model_path):
-        beat_times, downbeat_times, bpm = _detect_beats_onnx(
-            mono, sample_rate, model_path,
-        )
+        try:
+            beat_times, downbeat_times, bpm = _detect_beats_onnx(
+                mono, sample_rate, model_path,
+            )
+        except Exception:
+            beat_times, downbeat_times, bpm = _detect_beats_librosa(
+                mono, sample_rate,
+            )
     else:
         beat_times, downbeat_times, bpm = _detect_beats_librosa(
             mono, sample_rate,

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -287,6 +287,62 @@ def _detect_time_signature(
     return _TIME_SIG_MAP.get(median_bpb, f"{median_bpb}/4")
 
 
+def _infer_time_signature_from_beats(
+    beat_times: list[float],
+    audio_mono: np.ndarray,
+    sample_rate: int,
+) -> str:
+    """Estimate meter from beat-strength autocorrelation when downbeats unavailable.
+
+    Samples onset strength at each beat position, mean-subtracts, then
+    computes the full autocorrelation and finds the lag in [2..6] with the
+    highest positive value.  That lag gives the number of beats per bar.
+
+    Returns ``""`` when no clear periodicity is found (ambient / atonal
+    material or fewer than 8 beats detected).
+    """
+    if len(beat_times) < 8:
+        return ""
+
+    hop = 512
+    onset_env = librosa.onset.onset_strength(
+        y=audio_mono, sr=sample_rate, hop_length=hop,
+    )
+    n_frames = len(onset_env)
+    raw_frames = librosa.time_to_frames(
+        np.asarray(beat_times), sr=sample_rate, hop_length=hop,
+    ).astype(int)
+    # Peak in a ±3-frame window to handle spectrogram-window latency.
+    window = 3
+    strengths = np.array([
+        onset_env[max(0, f - window): min(n_frames, f + window + 1)].max()
+        for f in raw_frames
+    ], dtype=np.float64)
+
+    # Mean-subtract so autocorrelation measures periodic variation, not
+    # overall level, then compute full autocorrelation.
+    s = strengths - strengths.mean()
+    autocorr = np.correlate(s, s, mode="full")
+    ac = autocorr[len(autocorr) // 2:]   # positive lags: ac[0] = zero-lag energy
+
+    if ac[0] <= 0:
+        return ""
+
+    # Pick the lag in [2..6] with the highest positive autocorrelation.
+    # Lag k means the beat-strength pattern repeats every k beats (bar length).
+    best_lag = max(range(2, 7), key=lambda k: ac[k] if k < len(ac) else -np.inf)
+
+    if ac[best_lag] <= 0:
+        return ""
+
+    # Require the periodic component to be at least 10 % of zero-lag energy.
+    confidence = ac[best_lag] / (ac[0] + 1e-6)
+    if confidence < 0.10:
+        return ""
+
+    return _TIME_SIG_MAP.get(best_lag, f"{best_lag}/4")
+
+
 # ---------------------------------------------------------------------------
 # Chord detection — chromagram template matching + HMM smoothing
 # ---------------------------------------------------------------------------
@@ -499,8 +555,14 @@ def detect_bpm_and_key(
     if bpm > 0:
         bpm = max(20.0, min(300.0, bpm))
 
-    # Time signature (requires downbeats from beat_this ONNX).
+    # Time signature: prefer beat_this downbeats; fall back to onset
+    # periodicity heuristic when the ONNX model is absent or produces
+    # no downbeats (e.g. single-output export).
     time_sig = _detect_time_signature(beat_times, downbeat_times)
+    if not time_sig and beat_times:
+        time_sig = _infer_time_signature_from_beats(
+            beat_times, mono, sample_rate,
+        )
 
     # Chord detection.
     chord_sequence = _detect_chords(mono, sample_rate)

--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -1,12 +1,14 @@
 """ONNX model download and cache management.
 
 Manages the HTDemucs v4 ONNX model files that are required for stem
-separation. Models are downloaded from HuggingFace on first run and
-cached locally in the data/models/ directory.
+separation and the beat_this model for beat/downbeat tracking. Models
+are downloaded on first use and cached locally in the data/models/
+directory.
 
-Supported models (each is ``*.onnx`` plus ``*.onnx.data`` from HuggingFace):
-    - htdemucs (4-stem): vocals, drums, bass, other
-    - htdemucs_6s (6-stem): adds guitar + piano
+Supported models:
+    - htdemucs (4-stem): vocals, drums, bass, other (HuggingFace)
+    - htdemucs_6s (6-stem): adds guitar + piano (HuggingFace)
+    - beat_this: beat + downbeat detection (GitHub, MIT license)
 """
 
 import os
@@ -24,6 +26,13 @@ _MODEL_FILES = {
     "htdemucs_6s": ("htdemucs_6s.onnx", "htdemucs_6s.onnx.data"),
 }
 
+# beat_this ONNX model for beat + downbeat tracking (ISMIR 2024, MIT license).
+# Pre-exported by https://github.com/mosynthkey/beat_this_cpp
+_BEAT_THIS_URL = (
+    "https://github.com/mosynthkey/beat_this_cpp/raw/refs/heads/main/onnx/beat_this.onnx"
+)
+_BEAT_THIS_FILE = "beat_this.onnx"
+
 
 class ModelDownloader(QThread):
     """Background thread for downloading an ONNX model file.
@@ -40,11 +49,20 @@ class ModelDownloader(QThread):
     download_complete = Signal(str)
     error = Signal(str)
 
-    def __init__(self, model_name: str, models_dir: str) -> None:
+    def __init__(
+        self,
+        model_name: str,
+        models_dir: str,
+        *,
+        url: str | None = None,
+        file_name: str | None = None,
+    ) -> None:
         super().__init__()
         self.model_name = model_name
         self.models_dir = models_dir
         self._is_cancelled = False
+        self._url = url
+        self._file_name = file_name
 
     def cancel(self) -> None:
         """Request cancellation of the active download."""
@@ -63,6 +81,29 @@ class ModelDownloader(QThread):
     def _download(self) -> None:
         """Core download logic."""
         os.makedirs(self.models_dir, exist_ok=True)
+
+        # Single-file direct-URL mode (used for beat_this.onnx).
+        if self._url and self._file_name:
+            dest = os.path.join(self.models_dir, self._file_name)
+            if os.path.exists(dest):
+                self.progress.emit(100, f"{self._file_name} already cached.")
+                self.download_complete.emit(dest)
+                return
+            self._current_dest_path = dest
+            self.progress.emit(0, f"Downloading {self._file_name}...")
+
+            def _hook(block: int, block_size: int, total: int) -> None:
+                if self._is_cancelled:
+                    raise InterruptedError("Download cancelled by user.")
+                if total > 0:
+                    pct = min(99, int(block * block_size * 100.0 / total))
+                    self.progress.emit(pct, f"Downloading {self._file_name}... {pct}%")
+
+            urllib.request.urlretrieve(self._url, dest, reporthook=_hook)
+            self._current_dest_path = None
+            self.progress.emit(100, "Download complete.")
+            self.download_complete.emit(dest)
+            return
 
         artifacts = _MODEL_FILES[self.model_name]
         n = len(artifacts)
@@ -159,4 +200,20 @@ class ModelManager(QObject):
         """
         name = "htdemucs_6s" if is_6_stem else "htdemucs"
         self._active_downloader = ModelDownloader(name, self.models_dir)
+        return self._active_downloader
+
+    def beat_model_path(self) -> str:
+        """Return the expected local path to the beat_this ONNX model."""
+        return os.path.join(self.models_dir, _BEAT_THIS_FILE)
+
+    def is_beat_model_downloaded(self) -> bool:
+        """Check whether the beat_this ONNX model exists on disk."""
+        return os.path.isfile(self.beat_model_path())
+
+    def download_beat_model(self) -> ModelDownloader:
+        """Create a downloader for the beat_this ONNX model (not started)."""
+        self._active_downloader = ModelDownloader(
+            "beat_this", self.models_dir,
+            url=_BEAT_THIS_URL, file_name=_BEAT_THIS_FILE,
+        )
         return self._active_downloader

--- a/src/player.py
+++ b/src/player.py
@@ -151,6 +151,10 @@ class MultiTrackPlayer(QObject):
         self._beat_sync_nudge_ms: float = 0.0
         self._beat_frames: np.ndarray = np.array([], dtype=np.int64)
 
+        # Chord sequence: list of (onset_seconds, chord_label).
+        self._chord_sequence: list[tuple[float, str]] = []
+        self._chord_times: np.ndarray = np.array([], dtype=np.float64)
+
         # Count-in state.
         self._count_in_enabled: bool = False
         self._count_in_beats: int = 4
@@ -268,6 +272,38 @@ class MultiTrackPlayer(QObject):
         self._beat_times = [float(b) for b in beats]
         self._downbeat_times = [float(b) for b in downbeats]
         self._recompute_beat_frames()
+
+    # -- Chord sequence API -------------------------------------------------
+
+    @property
+    def chord_sequence(self) -> list[tuple[float, str]]:
+        """Chord onsets: list of (time_seconds, chord_label)."""
+        return self._chord_sequence
+
+    def set_chord_sequence(self, chords: list[tuple[float, str]]) -> None:
+        """Store detected chord sequence."""
+        self._chord_sequence = [(float(t), str(c)) for t, c in chords]
+        if self._chord_sequence:
+            self._chord_times = np.array(
+                [t for t, _ in self._chord_sequence], dtype=np.float64,
+            )
+        else:
+            self._chord_times = np.array([], dtype=np.float64)
+
+    def chord_at(self, frame: int) -> str:
+        """Return the chord label active at the given frame index.
+
+        Uses binary search on chord onset times. Returns empty string
+        if no chord data is available.
+        """
+        if len(self._chord_times) == 0 or self._sample_rate == 0:
+            return ""
+        speed = self._playback_speed if self._playback_speed > 0 else 1.0
+        time_sec = frame / self._sample_rate * speed
+        idx = int(np.searchsorted(self._chord_times, time_sec, side="right")) - 1
+        if idx < 0:
+            return ""
+        return self._chord_sequence[idx][1]
 
     # -- Beat-synced metronome API ------------------------------------------
 
@@ -546,6 +582,8 @@ class MultiTrackPlayer(QObject):
         self._beat_sync_enabled = False
         self._beat_sync_nudge_ms = 0.0
         self._beat_frames = np.array([], dtype=np.int64)
+        self._chord_sequence.clear()
+        self._chord_times = np.array([], dtype=np.float64)
         self._loop_a_frame = None
         self._loop_b_frame = None
         self._looping = False

--- a/src/player.py
+++ b/src/player.py
@@ -299,7 +299,10 @@ class MultiTrackPlayer(QObject):
         if len(self._chord_times) == 0 or self._sample_rate == 0:
             return ""
         speed = self._playback_speed if self._playback_speed > 0 else 1.0
-        time_sec = frame / self._sample_rate * speed
+        # Frame is in the stretched timeline; chord onsets are in original
+        # audio time.  Divide by speed to map back (same convention as
+        # _recompute_beat_frames).
+        time_sec = frame / self._sample_rate / speed
         idx = int(np.searchsorted(self._chord_times, time_sec, side="right")) - 1
         if idx < 0:
             return ""

--- a/src/ui/_wav_playback_impl.py
+++ b/src/ui/_wav_playback_impl.py
@@ -42,10 +42,9 @@ def _play_winsound_fallback(path: Path) -> None:
     if not _HAS_WINSOUND:
         return
     try:
-        winsound.PlaySound(
-            str(path),
-            winsound.SND_ASYNC | winsound.SND_FILENAME,
-        )
+        # Use SND_MEMORY to avoid MSIX sandbox path-resolution failures.
+        data = path.read_bytes()
+        winsound.PlaySound(data, winsound.SND_ASYNC | winsound.SND_MEMORY)
     except OSError:
         pass
 

--- a/src/ui/_wav_playback_impl.py
+++ b/src/ui/_wav_playback_impl.py
@@ -18,6 +18,7 @@ status on the GUI thread until ``Ready`` or ``Error`` (avoids duplicate
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
 from PySide6.QtCore import QTimer, QUrl
@@ -43,8 +44,13 @@ def _play_winsound_fallback(path: Path) -> None:
         return
     try:
         # Use SND_MEMORY to avoid MSIX sandbox path-resolution failures.
+        # Play in a daemon thread: Python disallows SND_ASYNC | SND_MEMORY.
         data = path.read_bytes()
-        winsound.PlaySound(data, winsound.SND_ASYNC | winsound.SND_MEMORY)
+        threading.Thread(
+            target=winsound.PlaySound,
+            args=(data, winsound.SND_MEMORY),
+            daemon=True,
+        ).start()
     except OSError:
         pass
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -510,6 +510,10 @@ class MainWindow(QMainWindow):
                 f"{prefix}/beat_nudge_ms",
                 self._player_controls.beat_sync_nudge_ms,
             )
+            self._settings.setValue(
+                f"{prefix}/time_sig",
+                self._player_controls.time_signature,
+            )
 
     def _restore_session(self) -> None:
         """Reload the last song and player state from QSettings."""
@@ -662,6 +666,11 @@ class MainWindow(QMainWindow):
                 self._player_controls.set_detected_bpm_text(
                     str(detected_bpm), bpm_conf,
                 )
+            saved_time_sig = str(
+                self._settings.value(f"{prefix}/time_sig", "") or ""
+            )
+            if saved_time_sig:
+                self._player_controls.set_time_signature(saved_time_sig)
 
     def showEvent(self, event) -> None:  # noqa: N802
         """Play the main logo intro animation on first show."""
@@ -757,6 +766,10 @@ class MainWindow(QMainWindow):
                     f"{prefix}/beat_nudge_ms",
                     self._player_controls.beat_sync_nudge_ms,
                 )
+                self._settings.setValue(
+                    f"{prefix}/time_sig",
+                    self._player_controls.time_signature,
+                )
 
             self._player.stop()
             self._player.load_stems(stem_paths)
@@ -782,6 +795,10 @@ class MainWindow(QMainWindow):
             self._player_controls.set_detected_bpm_text(
                 saved_bpm, saved_bpm_conf,
             )
+            saved_time_sig = str(
+                self._settings.value(f"{prefix}/time_sig", "") or ""
+            )
+            self._player_controls.set_time_signature(saved_time_sig)
 
             try:
                 nudge_str = self._settings.value(f"{prefix}/beat_nudge_ms", 0.0)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -514,6 +514,10 @@ class MainWindow(QMainWindow):
                 f"{prefix}/time_sig",
                 self._player_controls.time_signature,
             )
+            self._settings.setValue(
+                f"{prefix}/chord_sequence",
+                json.dumps(self._player.chord_sequence),
+            )
 
     def _restore_session(self) -> None:
         """Reload the last song and player state from QSettings."""
@@ -672,6 +676,17 @@ class MainWindow(QMainWindow):
             if saved_time_sig:
                 self._player_controls.set_time_signature(saved_time_sig)
 
+            try:
+                cs_str = self._settings.value(
+                    f"{prefix}/chord_sequence", "[]",
+                )
+                chords = json.loads(str(cs_str)) if cs_str else []
+                chords = [(float(t), str(c)) for t, c in chords]
+                if chords:
+                    self._player_controls.restore_chord_sequence(chords)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass
+
     def showEvent(self, event) -> None:  # noqa: N802
         """Play the main logo intro animation on first show."""
         super().showEvent(event)
@@ -770,6 +785,10 @@ class MainWindow(QMainWindow):
                     f"{prefix}/time_sig",
                     self._player_controls.time_signature,
                 )
+                self._settings.setValue(
+                    f"{prefix}/chord_sequence",
+                    json.dumps(self._player.chord_sequence),
+                )
 
             self._player.stop()
             self._player.load_stems(stem_paths)
@@ -811,6 +830,14 @@ class MainWindow(QMainWindow):
                 d_times = json.loads(str(dt_str)) if dt_str else []
                 if b_times:
                     self._player_controls.restore_beat_times(b_times, d_times)
+
+                cs_str = self._settings.value(
+                    f"{prefix}/chord_sequence", "[]",
+                )
+                chords = json.loads(str(cs_str)) if cs_str else []
+                chords = [(float(t), str(c)) for t, c in chords]
+                if chords:
+                    self._player_controls.restore_chord_sequence(chords)
             except (json.JSONDecodeError, TypeError, ValueError):
                 pass
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -510,10 +510,6 @@ class MainWindow(QMainWindow):
                 self._player_controls.beat_sync_nudge_ms,
             )
             self._settings.setValue(
-                f"{prefix}/time_sig",
-                self._player_controls.time_signature,
-            )
-            self._settings.setValue(
                 f"{prefix}/chord_sequence",
                 json.dumps(self._player.chord_sequence),
             )
@@ -670,12 +666,6 @@ class MainWindow(QMainWindow):
                 self._player_controls.set_detected_bpm_text(
                     str(detected_bpm), bpm_conf,
                 )
-            saved_time_sig = str(
-                self._settings.value(f"{prefix}/time_sig", "") or ""
-            )
-            if saved_time_sig:
-                self._player_controls.set_time_signature(saved_time_sig)
-
             # Schema version 3 = beat_this ONNX model + hardened chords.
             # Skip restoring beat/chord data for older sessions so the
             # auto-detect trigger fires once with the new model.
@@ -789,10 +779,6 @@ class MainWindow(QMainWindow):
                     self._player_controls.beat_sync_nudge_ms,
                 )
                 self._settings.setValue(
-                    f"{prefix}/time_sig",
-                    self._player_controls.time_signature,
-                )
-                self._settings.setValue(
                     f"{prefix}/chord_sequence",
                     json.dumps(self._player.chord_sequence),
                 )
@@ -822,11 +808,6 @@ class MainWindow(QMainWindow):
             self._player_controls.set_detected_bpm_text(
                 saved_bpm, saved_bpm_conf,
             )
-            saved_time_sig = str(
-                self._settings.value(f"{prefix}/time_sig", "") or ""
-            )
-            self._player_controls.set_time_signature(saved_time_sig)
-
             # Schema version 3 = beat_this ONNX model + hardened chords.
             # For older sessions, skip restoring beat/chord data so
             # set_stem_names triggers re-detection with the new model.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -513,7 +513,7 @@ class MainWindow(QMainWindow):
                 f"{prefix}/chord_sequence",
                 json.dumps(self._player.chord_sequence),
             )
-            self._settings.setValue(f"{prefix}/det_ver", 3)
+            self._settings.setValue(f"{prefix}/det_ver", 4)
 
     def _restore_session(self) -> None:
         """Reload the last song and player state from QSettings."""
@@ -666,13 +666,13 @@ class MainWindow(QMainWindow):
                 self._player_controls.set_detected_bpm_text(
                     str(detected_bpm), bpm_conf,
                 )
-            # Schema version 3 = beat_this ONNX model + hardened chords.
+            # Schema version 4 = major/minor-only chords (no false 7ths).
             # Skip restoring beat/chord data for older sessions so the
-            # auto-detect trigger fires once with the new model.
+            # auto-detect trigger fires once with the new algorithm.
             det_ver = int(
                 self._settings.value(f"{prefix}/det_ver", 0) or 0
             )
-            if det_ver >= 3:
+            if det_ver >= 4:
                 try:
                     cs_str = self._settings.value(
                         f"{prefix}/chord_sequence", "[]",
@@ -782,7 +782,7 @@ class MainWindow(QMainWindow):
                     f"{prefix}/chord_sequence",
                     json.dumps(self._player.chord_sequence),
                 )
-                self._settings.setValue(f"{prefix}/det_ver", 3)
+                self._settings.setValue(f"{prefix}/det_ver", 4)
 
             self._player.stop()
             self._player.load_stems(stem_paths)
@@ -808,9 +808,9 @@ class MainWindow(QMainWindow):
             self._player_controls.set_detected_bpm_text(
                 saved_bpm, saved_bpm_conf,
             )
-            # Schema version 3 = beat_this ONNX model + hardened chords.
+            # Schema version 4 = major/minor-only chords (no false 7ths).
             # For older sessions, skip restoring beat/chord data so
-            # set_stem_names triggers re-detection with the new model.
+            # set_stem_names triggers re-detection with the new algorithm.
             det_ver = int(
                 self._settings.value(f"{prefix}/det_ver", 0) or 0
             )
@@ -819,7 +819,7 @@ class MainWindow(QMainWindow):
                 nudge = float(nudge_str) if nudge_str else 0.0
                 self._player_controls.set_beat_sync_nudge(nudge)
 
-                if det_ver >= 3:
+                if det_ver >= 4:
                     bt_str = self._settings.value(f"{prefix}/beat_times", "[]")
                     dt_str = self._settings.value(
                         f"{prefix}/downbeat_times", "[]",

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -177,8 +177,7 @@ class MainWindow(QMainWindow):
         """Build the main window layout."""
         self._library_panel = LibraryPanel(self._library)
         self._player_controls = PlayerControls(self._player)
-        beat_model = os.path.join(self._model_manager.models_dir, "beat_this.onnx")
-        self._player_controls.set_beat_model_path(beat_model)
+        self._player_controls.set_model_manager(self._model_manager)
 
         splitter = QSplitter(Qt.Orientation.Horizontal)
         splitter.addWidget(self._library_panel)
@@ -518,7 +517,7 @@ class MainWindow(QMainWindow):
                 f"{prefix}/chord_sequence",
                 json.dumps(self._player.chord_sequence),
             )
-            self._settings.setValue(f"{prefix}/det_ver", 2)
+            self._settings.setValue(f"{prefix}/det_ver", 3)
 
     def _restore_session(self) -> None:
         """Reload the last song and player state from QSettings."""
@@ -677,13 +676,13 @@ class MainWindow(QMainWindow):
             if saved_time_sig:
                 self._player_controls.set_time_signature(saved_time_sig)
 
-            # Schema version 2 = chord + downbeat detection with lower
-            # downbeat threshold.  Skip restoring beat/chord data for
-            # older sessions so the auto-detect trigger fires once.
+            # Schema version 3 = beat_this ONNX model + hardened chords.
+            # Skip restoring beat/chord data for older sessions so the
+            # auto-detect trigger fires once with the new model.
             det_ver = int(
                 self._settings.value(f"{prefix}/det_ver", 0) or 0
             )
-            if det_ver >= 2:
+            if det_ver >= 3:
                 try:
                     cs_str = self._settings.value(
                         f"{prefix}/chord_sequence", "[]",
@@ -797,7 +796,7 @@ class MainWindow(QMainWindow):
                     f"{prefix}/chord_sequence",
                     json.dumps(self._player.chord_sequence),
                 )
-                self._settings.setValue(f"{prefix}/det_ver", 2)
+                self._settings.setValue(f"{prefix}/det_ver", 3)
 
             self._player.stop()
             self._player.load_stems(stem_paths)
@@ -828,9 +827,9 @@ class MainWindow(QMainWindow):
             )
             self._player_controls.set_time_signature(saved_time_sig)
 
-            # Schema version 2 = chord + downbeat detection with lower
-            # downbeat threshold.  For older sessions, skip restoring
-            # beat/chord data so set_stem_names triggers re-detection.
+            # Schema version 3 = beat_this ONNX model + hardened chords.
+            # For older sessions, skip restoring beat/chord data so
+            # set_stem_names triggers re-detection with the new model.
             det_ver = int(
                 self._settings.value(f"{prefix}/det_ver", 0) or 0
             )
@@ -839,7 +838,7 @@ class MainWindow(QMainWindow):
                 nudge = float(nudge_str) if nudge_str else 0.0
                 self._player_controls.set_beat_sync_nudge(nudge)
 
-                if det_ver >= 2:
+                if det_ver >= 3:
                     bt_str = self._settings.value(f"{prefix}/beat_times", "[]")
                     dt_str = self._settings.value(
                         f"{prefix}/downbeat_times", "[]",

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -518,6 +518,7 @@ class MainWindow(QMainWindow):
                 f"{prefix}/chord_sequence",
                 json.dumps(self._player.chord_sequence),
             )
+            self._settings.setValue(f"{prefix}/det_ver", 2)
 
     def _restore_session(self) -> None:
         """Reload the last song and player state from QSettings."""
@@ -676,16 +677,23 @@ class MainWindow(QMainWindow):
             if saved_time_sig:
                 self._player_controls.set_time_signature(saved_time_sig)
 
-            try:
-                cs_str = self._settings.value(
-                    f"{prefix}/chord_sequence", "[]",
-                )
-                chords = json.loads(str(cs_str)) if cs_str else []
-                chords = [(float(t), str(c)) for t, c in chords]
-                if chords:
-                    self._player_controls.restore_chord_sequence(chords)
-            except (json.JSONDecodeError, TypeError, ValueError):
-                pass
+            # Schema version 2 = chord + downbeat detection with lower
+            # downbeat threshold.  Skip restoring beat/chord data for
+            # older sessions so the auto-detect trigger fires once.
+            det_ver = int(
+                self._settings.value(f"{prefix}/det_ver", 0) or 0
+            )
+            if det_ver >= 2:
+                try:
+                    cs_str = self._settings.value(
+                        f"{prefix}/chord_sequence", "[]",
+                    )
+                    chords = json.loads(str(cs_str)) if cs_str else []
+                    chords = [(float(t), str(c)) for t, c in chords]
+                    if chords:
+                        self._player_controls.restore_chord_sequence(chords)
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    pass
 
     def showEvent(self, event) -> None:  # noqa: N802
         """Play the main logo intro animation on first show."""
@@ -789,6 +797,7 @@ class MainWindow(QMainWindow):
                     f"{prefix}/chord_sequence",
                     json.dumps(self._player.chord_sequence),
                 )
+                self._settings.setValue(f"{prefix}/det_ver", 2)
 
             self._player.stop()
             self._player.load_stems(stem_paths)
@@ -819,25 +828,36 @@ class MainWindow(QMainWindow):
             )
             self._player_controls.set_time_signature(saved_time_sig)
 
+            # Schema version 2 = chord + downbeat detection with lower
+            # downbeat threshold.  For older sessions, skip restoring
+            # beat/chord data so set_stem_names triggers re-detection.
+            det_ver = int(
+                self._settings.value(f"{prefix}/det_ver", 0) or 0
+            )
             try:
                 nudge_str = self._settings.value(f"{prefix}/beat_nudge_ms", 0.0)
                 nudge = float(nudge_str) if nudge_str else 0.0
                 self._player_controls.set_beat_sync_nudge(nudge)
 
-                bt_str = self._settings.value(f"{prefix}/beat_times", "[]")
-                dt_str = self._settings.value(f"{prefix}/downbeat_times", "[]")
-                b_times = json.loads(str(bt_str)) if bt_str else []
-                d_times = json.loads(str(dt_str)) if dt_str else []
-                if b_times:
-                    self._player_controls.restore_beat_times(b_times, d_times)
+                if det_ver >= 2:
+                    bt_str = self._settings.value(f"{prefix}/beat_times", "[]")
+                    dt_str = self._settings.value(
+                        f"{prefix}/downbeat_times", "[]",
+                    )
+                    b_times = json.loads(str(bt_str)) if bt_str else []
+                    d_times = json.loads(str(dt_str)) if dt_str else []
+                    if b_times:
+                        self._player_controls.restore_beat_times(
+                            b_times, d_times,
+                        )
 
-                cs_str = self._settings.value(
-                    f"{prefix}/chord_sequence", "[]",
-                )
-                chords = json.loads(str(cs_str)) if cs_str else []
-                chords = [(float(t), str(c)) for t, c in chords]
-                if chords:
-                    self._player_controls.restore_chord_sequence(chords)
+                    cs_str = self._settings.value(
+                        f"{prefix}/chord_sequence", "[]",
+                    )
+                    chords = json.loads(str(cs_str)) if cs_str else []
+                    chords = [(float(t), str(c)) for t, c in chords]
+                    if chords:
+                        self._player_controls.restore_chord_sequence(chords)
             except (json.JSONDecodeError, TypeError, ValueError):
                 pass
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -856,8 +856,9 @@ class MainWindow(QMainWindow):
                     )
                     chords = json.loads(str(cs_str)) if cs_str else []
                     chords = [(float(t), str(c)) for t, c in chords]
-                    if chords:
-                        self._player_controls.restore_chord_sequence(chords)
+                    # Restore even when empty: signals detection ran but
+                    # found no chords (prevents spurious re-detection).
+                    self._player_controls.restore_chord_sequence(chords)
             except (json.JSONDecodeError, TypeError, ValueError):
                 pass
 

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -493,6 +493,9 @@ class PlayerControls(QWidget):
         self._beat_model_path: str | None = None
         self._key_conf: str = ""
         self._bpm_conf: str = ""
+        self._detected_key_raw: str = ""
+        self._detected_bpm_raw: str = ""
+        self._detected_time_sig_raw: str = ""
 
         # Chord display polling timer (~4 Hz).
         self._chord_timer = QTimer(self)
@@ -696,23 +699,23 @@ class PlayerControls(QWidget):
         loop_speed_bar.addWidget(self._loop_label)
 
         self._key_label = QLabel("")
+        self._key_label.setTextFormat(Qt.TextFormat.RichText)
         self._key_label.setToolTip("Detected musical key (double-click to re-detect)")
         self._key_label.setAccessibleName("Detected key")
-        self._key_label.setStyleSheet(f"color: {colors['surface2']};")
         self._key_label.setCursor(Qt.CursorShape.PointingHandCursor)
         self._key_label.installEventFilter(self)
         loop_speed_bar.addWidget(self._key_label)
 
         self._time_sig_label = QLabel("")
+        self._time_sig_label.setTextFormat(Qt.TextFormat.RichText)
         self._time_sig_label.setToolTip("Detected time signature")
         self._time_sig_label.setAccessibleName("Detected time signature")
-        self._time_sig_label.setStyleSheet(f"color: {colors['surface2']};")
         loop_speed_bar.addWidget(self._time_sig_label)
 
         self._chord_label = QLabel("")
+        self._chord_label.setTextFormat(Qt.TextFormat.RichText)
         self._chord_label.setToolTip("Detected chord (suggestion)")
         self._chord_label.setAccessibleName("Detected chord")
-        self._chord_label.setStyleSheet(f"color: {colors['surface2']};")
         loop_speed_bar.addWidget(self._chord_label)
 
         self._speed_status = QLabel("")
@@ -824,11 +827,11 @@ class PlayerControls(QWidget):
         metro_ci_bar.addWidget(self._metronome_vol_combo)
 
         self._detected_bpm_label = QLabel("")
+        self._detected_bpm_label.setTextFormat(Qt.TextFormat.RichText)
         self._detected_bpm_label.setToolTip(
             "Detected tempo — suggestion only (double-click to re-detect)"
         )
         self._detected_bpm_label.setAccessibleName("Detected BPM")
-        self._detected_bpm_label.setStyleSheet(f"color: {colors['surface2']};")
         self._detected_bpm_label.setCursor(Qt.CursorShape.PointingHandCursor)
         self._detected_bpm_label.installEventFilter(self)
         metro_ci_bar.addWidget(self._detected_bpm_label)
@@ -930,23 +933,12 @@ class PlayerControls(QWidget):
         )
         self._loop_label.setStyleSheet(f"color: {colors['surface2']};")
         self._speed_status.setStyleSheet(f"color: {colors['surface2']};")
-        if not self._key_label.text():
-            self._key_label.setStyleSheet(f"color: {colors['surface2']};")
-        else:
-            c = self._conf_color(self._key_conf)
-            if c:
-                self._key_label.setStyleSheet(f"color: {c};")
-
-        self._time_sig_label.setStyleSheet(f"color: {colors['surface2']};")
-        self._chord_label.setStyleSheet(f"color: {colors['surface2']};")
-        if not self._detected_bpm_label.text():
-            self._detected_bpm_label.setStyleSheet(
-                f"color: {colors['surface2']};"
-            )
-        else:
-            c = self._conf_color(self._bpm_conf)
-            if c:
-                self._detected_bpm_label.setStyleSheet(f"color: {c};")
+        # Re-apply badge style on detection labels that have content.
+        badge = self._badge_style()
+        for lbl in (self._key_label, self._time_sig_label,
+                     self._chord_label, self._detected_bpm_label):
+            if lbl.text():
+                lbl.setStyleSheet(badge)
         self._footer_widget.setStyleSheet(
             f"border-top: 1px solid {colors['surface0']};"
         )
@@ -1016,8 +1008,11 @@ class PlayerControls(QWidget):
         self._record_btn.blockSignals(False)
         self.update_record_button_state()
 
-        # Auto-detect if no beat grid is loaded.
-        if has_stems and not self._player.beat_times:
+        # Auto-detect if no beat grid is loaded, or if beat grid exists
+        # but chord data is missing (upgraded from older cached session).
+        if has_stems and (
+            not self._player.beat_times or not self._player.chord_sequence
+        ):
             self.start_detection()
 
         if stem_names:
@@ -1038,16 +1033,23 @@ class PlayerControls(QWidget):
         self._waveform.set_position(0.0)
         self._time_label.setText("0:00 / 0:00")
         self._key_label.setText("")
+        self._key_label.setStyleSheet("")
         self._key_conf = ""
         self._key_label.setToolTip(
             "Detected musical key (double-click to re-detect)"
         )
         self._time_sig_label.setText("")
+        self._time_sig_label.setStyleSheet("")
         self._time_sig_label.setToolTip("Detected time signature")
         self._chord_label.setText("")
+        self._chord_label.setStyleSheet("")
         self._chord_label.setToolTip("Detected chord (suggestion)")
         self._chord_timer.stop()
+        self._detected_key_raw = ""
+        self._detected_bpm_raw = ""
+        self._detected_time_sig_raw = ""
         self._detected_bpm_label.setText("")
+        self._detected_bpm_label.setStyleSheet("")
         self._bpm_conf = ""
         self._detected_bpm_label.setToolTip(
             "Detected tempo — suggestion only (double-click to re-detect)"
@@ -1140,7 +1142,7 @@ class PlayerControls(QWidget):
         frame = int(self._player.current_seconds * self._player.sample_rate)
         chord = self._player.chord_at(frame)
         if chord:
-            self._chord_label.setText(f"Chord: {chord}")
+            self._chord_label.setText(self._badge_html("Chord:", chord))
         else:
             self._chord_label.setText("")
 
@@ -1381,11 +1383,13 @@ class PlayerControls(QWidget):
             self._detection_worker = None
 
         dim = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
-        self._detected_bpm_label.setStyleSheet(
-            f"color: {dim['surface2']};"
+        dim_style = (
+            f"background: {dim['surface0']}; border-radius: 4px; "
+            f"padding: 1px 6px; color: {dim['surface2']};"
         )
+        self._detected_bpm_label.setStyleSheet(dim_style)
         self._detected_bpm_label.setText("detecting...")
-        self._key_label.setStyleSheet(f"color: {dim['surface2']};")
+        self._key_label.setStyleSheet(dim_style)
         self._key_label.setText("detecting...")
 
         worker = DetectionWorker(
@@ -1415,6 +1419,26 @@ class PlayerControls(QWidget):
             return self._CONF_COLORS_LIGHT.get(level, "")
         return self._CONF_COLORS_DARK.get(level, "")
 
+    def _badge_style(self) -> str:
+        """Return the CSS stylesheet for a detection badge label."""
+        colors = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
+        return (
+            f"background: {colors['surface0']}; "
+            f"border-radius: 4px; "
+            f"padding: 1px 6px; "
+            f"margin: 0px 1px;"
+        )
+
+    def _badge_html(self, label: str, value: str, color: str = "") -> str:
+        """Build rich-text HTML for a detection badge: white label, coloured value."""
+        colors = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
+        text_c = colors["text"]
+        val_c = color or text_c
+        return (
+            f'<span style="color:{text_c};">{label} </span>'
+            f'<span style="color:{val_c};">{value}</span>'
+        )
+
     def _update_sync_btn_state(self, has_beats: bool) -> None:
         """Update beat-sync button enabled state."""
         self._beat_sync_btn.setEnabled(has_beats)
@@ -1434,14 +1458,18 @@ class PlayerControls(QWidget):
         has_beats = len(result.beat_times) >= 2
         self._update_sync_btn_state(has_beats)
 
+        badge = self._badge_style()
+
         # Update detected BPM label (suggestion only — does NOT set spinbox).
         if result.bpm > 0:
             bpm_rounded = round(result.bpm)
             self._bpm_conf = result.bpm_confidence
+            self._detected_bpm_raw = f"~{bpm_rounded} BPM"
             bpm_c = self._conf_color(result.bpm_confidence)
-            if bpm_c:
-                self._detected_bpm_label.setStyleSheet(f"color: {bpm_c};")
-            self._detected_bpm_label.setText(f"Detected tempo: ~{bpm_rounded} BPM")
+            self._detected_bpm_label.setStyleSheet(badge)
+            self._detected_bpm_label.setText(
+                self._badge_html("Tempo:", self._detected_bpm_raw, bpm_c)
+            )
             self._detected_bpm_label.setToolTip(
                 f"Detected tempo: {result.bpm:.1f} BPM\n"
                 f"Confidence: {result.bpm_confidence}\n"
@@ -1449,15 +1477,19 @@ class PlayerControls(QWidget):
             )
         else:
             self._detected_bpm_label.setText("")
+            self._detected_bpm_label.setStyleSheet("")
             self._bpm_conf = ""
+            self._detected_bpm_raw = ""
 
         # Update key label.
         if result.key:
             self._key_conf = result.key_confidence
+            self._detected_key_raw = result.key
             key_c = self._conf_color(result.key_confidence)
-            if key_c:
-                self._key_label.setStyleSheet(f"color: {key_c};")
-            self._key_label.setText(f"Detected key: {result.key}")
+            self._key_label.setStyleSheet(badge)
+            self._key_label.setText(
+                self._badge_html("Key:", result.key, key_c)
+            )
             self._key_label.setToolTip(
                 f"Detected key: {result.key}\n"
                 f"Confidence: {result.key_confidence}\n"
@@ -1465,31 +1497,44 @@ class PlayerControls(QWidget):
             )
         else:
             self._key_label.setText("")
+            self._key_label.setStyleSheet("")
             self._key_conf = ""
+            self._detected_key_raw = ""
 
         # Update time signature label.
         if result.time_signature:
-            self._time_sig_label.setText(result.time_signature)
+            self._detected_time_sig_raw = result.time_signature
+            self._time_sig_label.setStyleSheet(badge)
+            self._time_sig_label.setText(
+                self._badge_html("", result.time_signature)
+            )
             self._time_sig_label.setToolTip(
                 f"Detected time signature: {result.time_signature}"
             )
         else:
             self._time_sig_label.setText("")
+            self._time_sig_label.setStyleSheet("")
+            self._detected_time_sig_raw = ""
 
         # Store chord sequence and start polling timer.
         if result.chord_sequence:
             self._player.set_chord_sequence(result.chord_sequence)
+            self._chord_label.setStyleSheet(badge)
             self._chord_timer.start()
         else:
             self._player.set_chord_sequence([])
             self._chord_label.setText("")
+            self._chord_label.setStyleSheet("")
             self._chord_timer.stop()
 
     def _on_detect_error(self, msg: str) -> None:
-        self._key_label.setText("")
-        self._detected_bpm_label.setText("")
-        self._time_sig_label.setText("")
-        self._chord_label.setText("")
+        for lbl in (self._key_label, self._detected_bpm_label,
+                     self._time_sig_label, self._chord_label):
+            lbl.setText("")
+            lbl.setStyleSheet("")
+        self._detected_key_raw = ""
+        self._detected_bpm_raw = ""
+        self._detected_time_sig_raw = ""
         self._chord_timer.stop()
 
     def _on_detect_finished(self) -> None:
@@ -1500,7 +1545,10 @@ class PlayerControls(QWidget):
         if self._detection_worker is not None:
             return  # Already running.
         dim = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
-        self._key_label.setStyleSheet(f"color: {dim['surface2']};")
+        self._key_label.setStyleSheet(
+            f"background: {dim['surface0']}; border-radius: 4px; "
+            f"padding: 1px 6px; color: {dim['surface2']};"
+        )
         self._key_label.setText("detecting...")
 
         worker = DetectionWorker(
@@ -1517,10 +1565,10 @@ class PlayerControls(QWidget):
         """Update only the key label from a re-detection."""
         if result.key:
             self._key_conf = result.key_confidence
+            self._detected_key_raw = result.key
             key_c = self._conf_color(result.key_confidence)
-            if key_c:
-                self._key_label.setStyleSheet(f"color: {key_c};")
-            self._key_label.setText(f"Detected key: {result.key}")
+            self._key_label.setStyleSheet(self._badge_style())
+            self._key_label.setText(self._badge_html("Key:", result.key, key_c))
             self._key_label.setToolTip(
                 f"Detected key: {result.key}\n"
                 f"Confidence: {result.key_confidence}\n"
@@ -1528,7 +1576,9 @@ class PlayerControls(QWidget):
             )
         else:
             self._key_label.setText("")
+            self._key_label.setStyleSheet("")
             self._key_conf = ""
+            self._detected_key_raw = ""
 
     def _redetect_bpm_only(self) -> None:
         """Re-run detection but only update the BPM label."""
@@ -1536,7 +1586,8 @@ class PlayerControls(QWidget):
             return  # Already running.
         dim = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
         self._detected_bpm_label.setStyleSheet(
-            f"color: {dim['surface2']};"
+            f"background: {dim['surface0']}; border-radius: 4px; "
+            f"padding: 1px 6px; color: {dim['surface2']};"
         )
         self._detected_bpm_label.setText("detecting...")
 
@@ -1557,10 +1608,12 @@ class PlayerControls(QWidget):
         if result.bpm > 0:
             bpm_rounded = round(result.bpm)
             self._bpm_conf = result.bpm_confidence
+            self._detected_bpm_raw = f"~{bpm_rounded} BPM"
             bpm_c = self._conf_color(result.bpm_confidence)
-            if bpm_c:
-                self._detected_bpm_label.setStyleSheet(f"color: {bpm_c};")
-            self._detected_bpm_label.setText(f"Detected tempo: ~{bpm_rounded} BPM")
+            self._detected_bpm_label.setStyleSheet(self._badge_style())
+            self._detected_bpm_label.setText(
+                self._badge_html("Tempo:", self._detected_bpm_raw, bpm_c)
+            )
             self._detected_bpm_label.setToolTip(
                 f"Detected tempo: {result.bpm:.1f} BPM\n"
                 f"Confidence: {result.bpm_confidence}\n"
@@ -1568,21 +1621,19 @@ class PlayerControls(QWidget):
             )
         else:
             self._detected_bpm_label.setText("")
+            self._detected_bpm_label.setStyleSheet("")
             self._bpm_conf = ""
+            self._detected_bpm_raw = ""
 
     @property
     def detected_key(self) -> str:
         """Return the raw detected key (e.g. "A minor"), or empty string."""
-        text = self._key_label.text()
-        prefix = "Detected key: "
-        if text.startswith(prefix):
-            return text[len(prefix):]
-        return ""
+        return self._detected_key_raw
 
     @property
     def detected_bpm_text(self) -> str:
-        """Return the currently displayed detected BPM text, or empty."""
-        return self._detected_bpm_label.text()
+        """Return the raw detected BPM text (e.g. '~120 BPM'), or empty."""
+        return self._detected_bpm_raw
 
     @property
     def key_confidence(self) -> str:
@@ -1596,18 +1647,21 @@ class PlayerControls(QWidget):
 
     @property
     def time_signature(self) -> str:
-        """Return the displayed time signature (e.g. '4/4'), or empty."""
-        return self._time_sig_label.text()
+        """Return the detected time signature (e.g. '4/4'), or empty."""
+        return self._detected_time_sig_raw
 
     def set_time_signature(self, sig: str) -> None:
         """Restore a previously detected time signature label."""
+        self._detected_time_sig_raw = sig
         if sig:
-            self._time_sig_label.setText(sig)
+            self._time_sig_label.setStyleSheet(self._badge_style())
+            self._time_sig_label.setText(self._badge_html("", sig))
             self._time_sig_label.setToolTip(
                 f"Detected time signature: {sig}"
             )
         else:
             self._time_sig_label.setText("")
+            self._time_sig_label.setStyleSheet("")
             self._time_sig_label.setToolTip("Detected time signature")
 
     def restore_chord_sequence(
@@ -1616,16 +1670,17 @@ class PlayerControls(QWidget):
         """Restore a previously detected chord sequence from QSettings."""
         self._player.set_chord_sequence(chords)
         if chords and self._player.is_playing:
+            self._chord_label.setStyleSheet(self._badge_style())
             self._chord_timer.start()
 
     def set_detected_key(self, key: str, confidence: str = "") -> None:
         """Restore a previously detected key label with colour and tooltip."""
+        self._detected_key_raw = key
         if key:
-            self._key_label.setText(f"Detected key: {key}")
             self._key_conf = confidence
             c = self._conf_color(confidence) if confidence else ""
-            if c:
-                self._key_label.setStyleSheet(f"color: {c};")
+            self._key_label.setStyleSheet(self._badge_style())
+            self._key_label.setText(self._badge_html("Key:", key, c))
             parts = [f"Detected key: {key}"]
             if confidence:
                 parts.append(f"Confidence: {confidence}")
@@ -1633,6 +1688,7 @@ class PlayerControls(QWidget):
             self._key_label.setToolTip("\n".join(parts))
         else:
             self._key_label.setText("")
+            self._key_label.setStyleSheet("")
             self._key_conf = ""
             self._key_label.setToolTip(
                 "Detected musical key (double-click to re-detect)"
@@ -1643,14 +1699,20 @@ class PlayerControls(QWidget):
     ) -> None:
         """Restore a previously detected BPM suggestion label with colour and tooltip."""
         if text:
-            # Ensure prefix is present (older sessions may lack it).
-            if not text.startswith("Detected tempo:"):
-                text = f"Detected tempo: {text}"
-            self._detected_bpm_label.setText(text)
+            # Strip old "Detected tempo: " prefix from legacy sessions.
+            for prefix in ("Detected tempo: ~", "Detected tempo: "):
+                if text.startswith(prefix):
+                    text = text[len(prefix):]
+                    break
+            if not text.startswith("~"):
+                text = f"~{text}"
+            self._detected_bpm_raw = text
             self._bpm_conf = confidence
             c = self._conf_color(confidence) if confidence else ""
-            if c:
-                self._detected_bpm_label.setStyleSheet(f"color: {c};")
+            self._detected_bpm_label.setStyleSheet(self._badge_style())
+            self._detected_bpm_label.setText(
+                self._badge_html("Tempo:", text, c)
+            )
             parts = [f"Detected tempo: {text}"]
             if confidence:
                 parts.append(f"Confidence: {confidence}")
@@ -1658,7 +1720,9 @@ class PlayerControls(QWidget):
             self._detected_bpm_label.setToolTip("\n".join(parts))
         else:
             self._detected_bpm_label.setText("")
+            self._detected_bpm_label.setStyleSheet("")
             self._bpm_conf = ""
+            self._detected_bpm_raw = ""
             self._detected_bpm_label.setToolTip(
                 "Detected tempo — suggestion only (double-click to re-detect)"
             )

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -490,6 +490,9 @@ class PlayerControls(QWidget):
         self._peak_poll_timer.timeout.connect(self._poll_peak_future)
 
         self._detection_worker: DetectionWorker | None = None
+        # Keep Python refs to old workers until their OS threads finish;
+        # prevents "QThread: Destroyed while thread is still running".
+        self._orphaned_workers: list[DetectionWorker] = []
         self._beat_model_path: str | None = None
         self._key_conf: str = ""
         self._bpm_conf: str = ""
@@ -1008,12 +1011,10 @@ class PlayerControls(QWidget):
         self._record_btn.blockSignals(False)
         self.update_record_button_state()
 
-        # Auto-detect if no beat grid is loaded, or if chord data is
-        # missing (upgraded from an older cached session).
-        if has_stems and (
-            not self._player.beat_times
-            or not self._player.chord_sequence
-        ):
+        # Auto-detect if no beat grid has been loaded yet.
+        # Old sessions are handled by the det_ver gate in main_window:
+        # if det_ver < 2, beat_times are not restored, so this fires.
+        if has_stems and not self._player.beat_times:
             self.start_detection()
 
         if stem_names:
@@ -1380,13 +1381,27 @@ class PlayerControls(QWidget):
         if not self._player.stems:
             return
         if self._detection_worker is not None:
-            # Detach the old worker so its results are silently discarded.
-            # It will clean itself up when the thread finishes.
             old = self._detection_worker
-            old.completed.disconnect()
-            old.error.disconnect()
-            old.finished.disconnect()
-            old.finished.connect(old.deleteLater)
+            # Disconnect our callbacks so stale results are silently
+            # ignored.  Disconnect each signal individually to avoid
+            # RuntimeError if a slot was never connected.
+            for sig, slot in [
+                (old.completed, self._on_detect_completed),
+                (old.error, self._on_detect_error),
+                (old.finished, self._on_detect_finished),
+            ]:
+                try:
+                    sig.disconnect(slot)
+                except RuntimeError:
+                    pass
+            # Store a reference so Python's GC cannot destroy the
+            # QThread wrapper while the OS thread is still running.
+            # The lambda removes it once the thread exits cleanly.
+            self._orphaned_workers.append(old)
+            old.finished.connect(
+                lambda w=old: self._orphaned_workers.remove(w)
+                if w in self._orphaned_workers else None
+            )
             self._detection_worker = None
 
         dim = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
@@ -1444,10 +1459,12 @@ class PlayerControls(QWidget):
         colors = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
         text_c = colors["text"]
         val_c = color or text_c
-        return (
-            f'<span style="color:{text_c};">{label} </span>'
-            f'<span style="color:{val_c};">{value}</span>'
-        )
+        if label:
+            return (
+                f'<span style="color:{text_c};">{label} </span>'
+                f'<span style="color:{val_c};">{value}</span>'
+            )
+        return f'<span style="color:{val_c};">{value}</span>'
 
     def _update_sync_btn_state(self, has_beats: bool) -> None:
         """Update beat-sync button enabled state."""

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -501,8 +501,6 @@ class PlayerControls(QWidget):
         self._bpm_conf: str = ""
         self._detected_key_raw: str = ""
         self._detected_bpm_raw: str = ""
-        self._detected_time_sig_raw: str = ""
-
         # Chord display polling timer (~4 Hz).
         self._chord_timer = QTimer(self)
         self._chord_timer.setInterval(250)
@@ -711,12 +709,6 @@ class PlayerControls(QWidget):
         self._key_label.setCursor(Qt.CursorShape.PointingHandCursor)
         self._key_label.installEventFilter(self)
         loop_speed_bar.addWidget(self._key_label)
-
-        self._time_sig_label = QLabel("")
-        self._time_sig_label.setTextFormat(Qt.TextFormat.RichText)
-        self._time_sig_label.setToolTip("Detected time signature")
-        self._time_sig_label.setAccessibleName("Detected time signature")
-        loop_speed_bar.addWidget(self._time_sig_label)
 
         self._chord_label = QLabel("")
         self._chord_label.setTextFormat(Qt.TextFormat.RichText)
@@ -941,8 +933,8 @@ class PlayerControls(QWidget):
         self._speed_status.setStyleSheet(f"color: {colors['surface2']};")
         # Re-apply badge style on detection labels that have content.
         badge = self._badge_style()
-        for lbl in (self._key_label, self._time_sig_label,
-                     self._chord_label, self._detected_bpm_label):
+        for lbl in (self._key_label, self._chord_label,
+                     self._detected_bpm_label):
             if lbl.text():
                 lbl.setStyleSheet(badge)
         self._footer_widget.setStyleSheet(
@@ -1032,6 +1024,7 @@ class PlayerControls(QWidget):
 
     def clear_song(self) -> None:
         """Return to the empty logo state."""
+        self._detach_detection_worker()
         self.set_stem_names([])
         self._waveform.set_loading(False)
         self._waveform.set_peaks(np.zeros(1, dtype=np.float32))
@@ -1043,16 +1036,12 @@ class PlayerControls(QWidget):
         self._key_label.setToolTip(
             "Detected musical key (double-click to re-detect)"
         )
-        self._time_sig_label.setText("")
-        self._time_sig_label.setStyleSheet("")
-        self._time_sig_label.setToolTip("Detected time signature")
         self._chord_label.setText("")
         self._chord_label.setStyleSheet("")
         self._chord_label.setToolTip("Detected chord (suggestion)")
         self._chord_timer.stop()
         self._detected_key_raw = ""
         self._detected_bpm_raw = ""
-        self._detected_time_sig_raw = ""
         self._detected_bpm_label.setText("")
         self._detected_bpm_label.setStyleSheet("")
         self._bpm_conf = ""
@@ -1428,7 +1417,7 @@ class PlayerControls(QWidget):
             f"background: {dim['surface0']}; "
             f"border: 1px solid {dim['surface1']}; "
             f"border-radius: 4px; "
-            f"padding: 1px 6px; color: {dim['surface2']};"
+            f"padding: 1px 6px; color: {dim['text']};"
         )
         self._detected_bpm_label.setStyleSheet(dim_style)
         self._detected_bpm_label.setText("downloading model...")
@@ -1467,7 +1456,7 @@ class PlayerControls(QWidget):
             f"background: {dim['surface0']}; "
             f"border: 1px solid {dim['surface1']}; "
             f"border-radius: 4px; "
-            f"padding: 1px 6px; color: {dim['surface2']};"
+            f"padding: 1px 6px; color: {dim['text']};"
         )
         self._detected_bpm_label.setStyleSheet(dim_style)
         self._detected_bpm_label.setText("detecting...")
@@ -1506,6 +1495,7 @@ class PlayerControls(QWidget):
         colors = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
         return (
             f"background: {colors['surface0']}; "
+            f"color: {colors['text']}; "
             f"border: 1px solid {colors['surface1']}; "
             f"border-radius: 4px; "
             f"padding: 1px 6px; "
@@ -1586,21 +1576,6 @@ class PlayerControls(QWidget):
             self._key_conf = ""
             self._detected_key_raw = ""
 
-        # Update time signature label.
-        if result.time_signature:
-            self._detected_time_sig_raw = result.time_signature
-            self._time_sig_label.setStyleSheet(badge)
-            self._time_sig_label.setText(
-                self._badge_html("", result.time_signature)
-            )
-            self._time_sig_label.setToolTip(
-                f"Detected time signature: {result.time_signature}"
-            )
-        else:
-            self._time_sig_label.setText("")
-            self._time_sig_label.setStyleSheet("")
-            self._detected_time_sig_raw = ""
-
         # Store chord sequence and start polling timer.
         if result.chord_sequence:
             self._player.set_chord_sequence(result.chord_sequence)
@@ -1614,16 +1589,18 @@ class PlayerControls(QWidget):
 
     def _on_detect_error(self, msg: str) -> None:
         for lbl in (self._key_label, self._detected_bpm_label,
-                     self._time_sig_label, self._chord_label):
+                     self._chord_label):
             lbl.setText("")
             lbl.setStyleSheet("")
         self._detected_key_raw = ""
         self._detected_bpm_raw = ""
-        self._detected_time_sig_raw = ""
         self._chord_timer.stop()
 
     def _on_detect_finished(self) -> None:
-        self._detection_worker = None
+        # Only clear the reference if the sender is the active worker;
+        # orphaned workers must not null out a newer worker's reference.
+        if self.sender() is self._detection_worker:
+            self._detection_worker = None
 
     def _redetect_key_only(self) -> None:
         """Re-run detection but only update the key label."""
@@ -1634,7 +1611,7 @@ class PlayerControls(QWidget):
             f"background: {dim['surface0']}; "
             f"border: 1px solid {dim['surface1']}; "
             f"border-radius: 4px; "
-            f"padding: 1px 6px; color: {dim['surface2']};"
+            f"padding: 1px 6px; color: {dim['text']};"
         )
         self._key_label.setText("detecting...")
 
@@ -1676,7 +1653,7 @@ class PlayerControls(QWidget):
             f"background: {dim['surface0']}; "
             f"border: 1px solid {dim['surface1']}; "
             f"border-radius: 4px; "
-            f"padding: 1px 6px; color: {dim['surface2']};"
+            f"padding: 1px 6px; color: {dim['text']};"
         )
         self._detected_bpm_label.setText("detecting...")
 
@@ -1733,27 +1710,6 @@ class PlayerControls(QWidget):
     def bpm_confidence(self) -> str:
         """Return the last BPM confidence level, or empty string."""
         return self._bpm_conf
-
-    @property
-    def time_signature(self) -> str:
-        """Return the detected time signature (e.g. '4/4'), or empty."""
-        return self._detected_time_sig_raw
-
-    def set_time_signature(self, sig: str) -> None:
-        """Restore a previously detected time signature label."""
-        if sig == "--":
-            sig = ""  # Legacy cached value; treat as unknown.
-        self._detected_time_sig_raw = sig
-        if sig:
-            self._time_sig_label.setStyleSheet(self._badge_style())
-            self._time_sig_label.setText(self._badge_html("", sig))
-            self._time_sig_label.setToolTip(
-                f"Detected time signature: {sig}"
-            )
-        else:
-            self._time_sig_label.setText("")
-            self._time_sig_label.setStyleSheet("")
-            self._time_sig_label.setToolTip("Detected time signature")
 
     def restore_chord_sequence(
         self, chords: list[tuple[float, str]],

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -1008,12 +1008,11 @@ class PlayerControls(QWidget):
         self._record_btn.blockSignals(False)
         self.update_record_button_state()
 
-        # Auto-detect if no beat grid is loaded, or if the session is
-        # missing newer detection fields (chord/downbeat data).
+        # Auto-detect if no beat grid is loaded, or if chord data is
+        # missing (upgraded from an older cached session).
         if has_stems and (
             not self._player.beat_times
             or not self._player.chord_sequence
-            or not self._player.downbeat_times
         ):
             self.start_detection()
 
@@ -1381,12 +1380,20 @@ class PlayerControls(QWidget):
         if not self._player.stems:
             return
         if self._detection_worker is not None:
-            self._detection_worker.wait(2000)
+            # Detach the old worker so its results are silently discarded.
+            # It will clean itself up when the thread finishes.
+            old = self._detection_worker
+            old.completed.disconnect()
+            old.error.disconnect()
+            old.finished.disconnect()
+            old.finished.connect(old.deleteLater)
             self._detection_worker = None
 
         dim = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
         dim_style = (
-            f"background: {dim['surface0']}; border-radius: 4px; "
+            f"background: {dim['surface0']}; "
+            f"border: 1px solid {dim['surface1']}; "
+            f"border-radius: 4px; "
             f"padding: 1px 6px; color: {dim['surface2']};"
         )
         self._detected_bpm_label.setStyleSheet(dim_style)
@@ -1426,6 +1433,7 @@ class PlayerControls(QWidget):
         colors = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
         return (
             f"background: {colors['surface0']}; "
+            f"border: 1px solid {colors['surface1']}; "
             f"border-radius: 4px; "
             f"padding: 1px 6px; "
             f"margin: 0px 1px;"
@@ -1548,7 +1556,9 @@ class PlayerControls(QWidget):
             return  # Already running.
         dim = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
         self._key_label.setStyleSheet(
-            f"background: {dim['surface0']}; border-radius: 4px; "
+            f"background: {dim['surface0']}; "
+            f"border: 1px solid {dim['surface1']}; "
+            f"border-radius: 4px; "
             f"padding: 1px 6px; color: {dim['surface2']};"
         )
         self._key_label.setText("detecting...")
@@ -1588,7 +1598,9 @@ class PlayerControls(QWidget):
             return  # Already running.
         dim = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
         self._detected_bpm_label.setStyleSheet(
-            f"background: {dim['surface0']}; border-radius: 4px; "
+            f"background: {dim['surface0']}; "
+            f"border: 1px solid {dim['surface1']}; "
+            f"border-radius: 4px; "
             f"padding: 1px 6px; color: {dim['surface2']};"
         )
         self._detected_bpm_label.setText("detecting...")

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -493,7 +493,10 @@ class PlayerControls(QWidget):
         # Keep Python refs to old workers until their OS threads finish;
         # prevents "QThread: Destroyed while thread is still running".
         self._orphaned_workers: list[DetectionWorker] = []
+        self._model_manager = None  # set via set_model_manager()
         self._beat_model_path: str | None = None
+        self._beat_model_downloader = None
+        self._pending_detect_args: tuple | None = None
         self._key_conf: str = ""
         self._bpm_conf: str = ""
         self._detected_key_raw: str = ""
@@ -1363,9 +1366,10 @@ class PlayerControls(QWidget):
                 return True
         return super().eventFilter(obj, event)
 
-    def set_beat_model_path(self, path: str) -> None:
-        """Set the path to the beat_this ONNX model file."""
-        self._beat_model_path = path
+    def set_model_manager(self, manager) -> None:
+        """Store the ModelManager and derive the beat model path."""
+        self._model_manager = manager
+        self._beat_model_path = manager.beat_model_path()
 
     def start_detection(
         self,
@@ -1377,33 +1381,87 @@ class PlayerControls(QWidget):
         Called automatically when stems load and when A-B loop points
         change.  Results are shown as suggestions only — the metronome
         BPM spinbox is *not* modified.
+
+        If the beat_this ONNX model has not been downloaded yet, it is
+        fetched first and detection resumes on completion.
         """
         if not self._player.stems:
             return
-        if self._detection_worker is not None:
-            old = self._detection_worker
-            # Disconnect our callbacks so stale results are silently
-            # ignored.  Disconnect each signal individually to avoid
-            # RuntimeError if a slot was never connected.
-            for sig, slot in [
-                (old.completed, self._on_detect_completed),
-                (old.error, self._on_detect_error),
-                (old.finished, self._on_detect_finished),
-            ]:
-                try:
-                    sig.disconnect(slot)
-                except RuntimeError:
-                    pass
-            # Store a reference so Python's GC cannot destroy the
-            # QThread wrapper while the OS thread is still running.
-            # The lambda removes it once the thread exits cleanly.
-            self._orphaned_workers.append(old)
-            old.finished.connect(
-                lambda w=old: self._orphaned_workers.remove(w)
-                if w in self._orphaned_workers else None
-            )
-            self._detection_worker = None
+        self._detach_detection_worker()
 
+        # Ensure beat_this model is available.
+        if (self._model_manager
+                and not self._model_manager.is_beat_model_downloaded()):
+            self._pending_detect_args = (start_sec, end_sec)
+            self._start_beat_model_download()
+            return
+
+        self._run_detection(start_sec, end_sec)
+
+    def _detach_detection_worker(self) -> None:
+        """Disconnect and orphan the current detection worker, if any."""
+        if self._detection_worker is None:
+            return
+        old = self._detection_worker
+        for sig, slot in [
+            (old.completed, self._on_detect_completed),
+            (old.error, self._on_detect_error),
+            (old.finished, self._on_detect_finished),
+        ]:
+            try:
+                sig.disconnect(slot)
+            except RuntimeError:
+                pass
+        self._orphaned_workers.append(old)
+        old.finished.connect(
+            lambda w=old: self._orphaned_workers.remove(w)
+            if w in self._orphaned_workers else None
+        )
+        self._detection_worker = None
+
+    def _start_beat_model_download(self) -> None:
+        """Download beat_this.onnx, then resume detection."""
+        if self._beat_model_downloader is not None:
+            return  # already downloading
+        dim = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
+        dim_style = (
+            f"background: {dim['surface0']}; "
+            f"border: 1px solid {dim['surface1']}; "
+            f"border-radius: 4px; "
+            f"padding: 1px 6px; color: {dim['surface2']};"
+        )
+        self._detected_bpm_label.setStyleSheet(dim_style)
+        self._detected_bpm_label.setText("downloading model...")
+        self._key_label.setStyleSheet(dim_style)
+        self._key_label.setText("downloading model...")
+
+        dl = self._model_manager.download_beat_model()
+        dl.download_complete.connect(self._on_beat_model_ready)
+        dl.error.connect(self._on_beat_model_error)
+        self._beat_model_downloader = dl
+        dl.start()
+
+    def _on_beat_model_ready(self, path: str) -> None:
+        self._beat_model_downloader = None
+        self._beat_model_path = path
+        args = self._pending_detect_args or (None, None)
+        self._pending_detect_args = None
+        self._run_detection(*args)
+
+    def _on_beat_model_error(self, msg: str) -> None:
+        self._beat_model_downloader = None
+        # Fall through without the model — librosa fallback.
+        self._beat_model_path = None
+        args = self._pending_detect_args or (None, None)
+        self._pending_detect_args = None
+        self._run_detection(*args)
+
+    def _run_detection(
+        self,
+        start_sec: float | None = None,
+        end_sec: float | None = None,
+    ) -> None:
+        """Launch the DetectionWorker with the current model path."""
         dim = LIGHT_COLORS if self._theme == "light" else DARK_COLORS
         dim_style = (
             f"background: {dim['surface0']}; "

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -1008,10 +1008,12 @@ class PlayerControls(QWidget):
         self._record_btn.blockSignals(False)
         self.update_record_button_state()
 
-        # Auto-detect if no beat grid is loaded, or if beat grid exists
-        # but chord data is missing (upgraded from older cached session).
+        # Auto-detect if no beat grid is loaded, or if the session is
+        # missing newer detection fields (chord/downbeat data).
         if has_stems and (
-            not self._player.beat_times or not self._player.chord_sequence
+            not self._player.beat_times
+            or not self._player.chord_sequence
+            or not self._player.downbeat_times
         ):
             self.start_detection()
 
@@ -1652,6 +1654,8 @@ class PlayerControls(QWidget):
 
     def set_time_signature(self, sig: str) -> None:
         """Restore a previously detected time signature label."""
+        if sig == "--":
+            sig = ""  # Legacy cached value; treat as unknown.
         self._detected_time_sig_raw = sig
         if sig:
             self._time_sig_label.setStyleSheet(self._badge_style())

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -494,6 +494,11 @@ class PlayerControls(QWidget):
         self._key_conf: str = ""
         self._bpm_conf: str = ""
 
+        # Chord display polling timer (~4 Hz).
+        self._chord_timer = QTimer(self)
+        self._chord_timer.setInterval(250)
+        self._chord_timer.timeout.connect(self._update_chord_label)
+
         self._setup_ui()
         self._connect_signals()
 
@@ -703,6 +708,12 @@ class PlayerControls(QWidget):
         self._time_sig_label.setAccessibleName("Detected time signature")
         self._time_sig_label.setStyleSheet(f"color: {colors['surface2']};")
         loop_speed_bar.addWidget(self._time_sig_label)
+
+        self._chord_label = QLabel("")
+        self._chord_label.setToolTip("Detected chord (suggestion)")
+        self._chord_label.setAccessibleName("Detected chord")
+        self._chord_label.setStyleSheet(f"color: {colors['surface2']};")
+        loop_speed_bar.addWidget(self._chord_label)
 
         self._speed_status = QLabel("")
         self._speed_status.setStyleSheet(f"color: {colors['surface2']};")
@@ -927,6 +938,7 @@ class PlayerControls(QWidget):
                 self._key_label.setStyleSheet(f"color: {c};")
 
         self._time_sig_label.setStyleSheet(f"color: {colors['surface2']};")
+        self._chord_label.setStyleSheet(f"color: {colors['surface2']};")
         if not self._detected_bpm_label.text():
             self._detected_bpm_label.setStyleSheet(
                 f"color: {colors['surface2']};"
@@ -1032,6 +1044,9 @@ class PlayerControls(QWidget):
         )
         self._time_sig_label.setText("")
         self._time_sig_label.setToolTip("Detected time signature")
+        self._chord_label.setText("")
+        self._chord_label.setToolTip("Detected chord (suggestion)")
+        self._chord_timer.stop()
         self._detected_bpm_label.setText("")
         self._bpm_conf = ""
         self._detected_bpm_label.setToolTip(
@@ -1118,15 +1133,29 @@ class PlayerControls(QWidget):
                 self._bpm_spin.setValue(max(20, min(300, round(ibpm))))
                 self._bpm_spin.blockSignals(False)
 
+    def _update_chord_label(self) -> None:
+        """Poll the player for the current chord and update the label."""
+        if not self._player.is_playing:
+            return
+        frame = int(self._player.current_seconds * self._player.sample_rate)
+        chord = self._player.chord_at(frame)
+        if chord:
+            self._chord_label.setText(f"Chord: {chord}")
+        else:
+            self._chord_label.setText("")
+
     def _on_state_changed(self, playing: bool) -> None:
         self._play_btn.setIcon(self._pause_icon if playing else self._play_icon)
         self._play_btn.setAccessibleName("Pause" if playing else "Play")
         if not playing:
             self._count_in_label.setText("")
+            self._chord_timer.stop()
             if not self._player.recording_armed:
                 self._record_btn.blockSignals(True)
                 self._record_btn.setChecked(False)
                 self._record_btn.blockSignals(False)
+        elif self._player.chord_sequence:
+            self._chord_timer.start()
 
     def _on_play_finished(self) -> None:
         self._play_btn.setIcon(self._play_icon)
@@ -1447,10 +1476,21 @@ class PlayerControls(QWidget):
         else:
             self._time_sig_label.setText("")
 
+        # Store chord sequence and start polling timer.
+        if result.chord_sequence:
+            self._player.set_chord_sequence(result.chord_sequence)
+            self._chord_timer.start()
+        else:
+            self._player.set_chord_sequence([])
+            self._chord_label.setText("")
+            self._chord_timer.stop()
+
     def _on_detect_error(self, msg: str) -> None:
         self._key_label.setText("")
         self._detected_bpm_label.setText("")
         self._time_sig_label.setText("")
+        self._chord_label.setText("")
+        self._chord_timer.stop()
 
     def _on_detect_finished(self) -> None:
         self._detection_worker = None
@@ -1569,6 +1609,14 @@ class PlayerControls(QWidget):
         else:
             self._time_sig_label.setText("")
             self._time_sig_label.setToolTip("Detected time signature")
+
+    def restore_chord_sequence(
+        self, chords: list[tuple[float, str]],
+    ) -> None:
+        """Restore a previously detected chord sequence from QSettings."""
+        self._player.set_chord_sequence(chords)
+        if chords:
+            self._chord_timer.start()
 
     def set_detected_key(self, key: str, confidence: str = "") -> None:
         """Restore a previously detected key label with colour and tooltip."""

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -698,6 +698,12 @@ class PlayerControls(QWidget):
         self._key_label.installEventFilter(self)
         loop_speed_bar.addWidget(self._key_label)
 
+        self._time_sig_label = QLabel("")
+        self._time_sig_label.setToolTip("Detected time signature")
+        self._time_sig_label.setAccessibleName("Detected time signature")
+        self._time_sig_label.setStyleSheet(f"color: {colors['surface2']};")
+        loop_speed_bar.addWidget(self._time_sig_label)
+
         self._speed_status = QLabel("")
         self._speed_status.setStyleSheet(f"color: {colors['surface2']};")
         loop_speed_bar.addWidget(self._speed_status)
@@ -920,6 +926,7 @@ class PlayerControls(QWidget):
             if c:
                 self._key_label.setStyleSheet(f"color: {c};")
 
+        self._time_sig_label.setStyleSheet(f"color: {colors['surface2']};")
         if not self._detected_bpm_label.text():
             self._detected_bpm_label.setStyleSheet(
                 f"color: {colors['surface2']};"
@@ -1023,6 +1030,8 @@ class PlayerControls(QWidget):
         self._key_label.setToolTip(
             "Detected musical key (double-click to re-detect)"
         )
+        self._time_sig_label.setText("")
+        self._time_sig_label.setToolTip("Detected time signature")
         self._detected_bpm_label.setText("")
         self._bpm_conf = ""
         self._detected_bpm_label.setToolTip(
@@ -1429,9 +1438,19 @@ class PlayerControls(QWidget):
             self._key_label.setText("")
             self._key_conf = ""
 
+        # Update time signature label.
+        if result.time_signature:
+            self._time_sig_label.setText(result.time_signature)
+            self._time_sig_label.setToolTip(
+                f"Detected time signature: {result.time_signature}"
+            )
+        else:
+            self._time_sig_label.setText("")
+
     def _on_detect_error(self, msg: str) -> None:
         self._key_label.setText("")
         self._detected_bpm_label.setText("")
+        self._time_sig_label.setText("")
 
     def _on_detect_finished(self) -> None:
         self._detection_worker = None
@@ -1534,6 +1553,22 @@ class PlayerControls(QWidget):
     def bpm_confidence(self) -> str:
         """Return the last BPM confidence level, or empty string."""
         return self._bpm_conf
+
+    @property
+    def time_signature(self) -> str:
+        """Return the displayed time signature (e.g. '4/4'), or empty."""
+        return self._time_sig_label.text()
+
+    def set_time_signature(self, sig: str) -> None:
+        """Restore a previously detected time signature label."""
+        if sig:
+            self._time_sig_label.setText(sig)
+            self._time_sig_label.setToolTip(
+                f"Detected time signature: {sig}"
+            )
+        else:
+            self._time_sig_label.setText("")
+            self._time_sig_label.setToolTip("Detected time signature")
 
     def set_detected_key(self, key: str, confidence: str = "") -> None:
         """Restore a previously detected key label with colour and tooltip."""

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -931,12 +931,33 @@ class PlayerControls(QWidget):
         )
         self._loop_label.setStyleSheet(f"color: {colors['surface2']};")
         self._speed_status.setStyleSheet(f"color: {colors['surface2']};")
-        # Re-apply badge style on detection labels that have content.
+        # Re-apply badge style and regenerate inline HTML colours for
+        # detection labels — the old Rich Text contains hardcoded colour
+        # spans from the previous theme.
         badge = self._badge_style()
-        for lbl in (self._key_label, self._chord_label,
-                     self._detected_bpm_label):
-            if lbl.text():
-                lbl.setStyleSheet(badge)
+        if self._detected_key_raw:
+            key_c = self._conf_color(self._key_conf) if self._key_conf else ""
+            self._key_label.setStyleSheet(badge)
+            self._key_label.setText(
+                self._badge_html("Key:", self._detected_key_raw, key_c)
+            )
+        if self._detected_bpm_raw:
+            bpm_c = self._conf_color(self._bpm_conf) if self._bpm_conf else ""
+            self._detected_bpm_label.setStyleSheet(badge)
+            self._detected_bpm_label.setText(
+                self._badge_html("Tempo:", self._detected_bpm_raw, bpm_c)
+            )
+        if self._player.chord_sequence:
+            self._chord_label.setStyleSheet(badge)
+            # Refresh the chord text with current theme colours.
+            frame = int(
+                self._player.current_seconds * self._player.sample_rate
+            )
+            chord = self._player.chord_at(frame)
+            if chord:
+                self._chord_label.setText(
+                    self._badge_html("Chord:", chord)
+                )
         self._footer_widget.setStyleSheet(
             f"border-top: 1px solid {colors['surface0']};"
         )
@@ -1135,10 +1156,9 @@ class PlayerControls(QWidget):
             return
         frame = int(self._player.current_seconds * self._player.sample_rate)
         chord = self._player.chord_at(frame)
-        if chord:
-            self._chord_label.setText(self._badge_html("Chord:", chord))
-        else:
-            self._chord_label.setText("")
+        self._chord_label.setText(
+            self._badge_html("Chord:", chord if chord else "--")
+        )
 
     def _on_state_changed(self, playing: bool) -> None:
         self._play_btn.setIcon(self._pause_icon if playing else self._play_icon)
@@ -1146,6 +1166,9 @@ class PlayerControls(QWidget):
         if not playing:
             self._count_in_label.setText("")
             self._chord_timer.stop()
+            # Show placeholder instead of the last detected chord.
+            if self._player.chord_sequence:
+                self._chord_label.setText(self._badge_html("Chord:", "--"))
             if not self._player.recording_armed:
                 self._record_btn.blockSignals(True)
                 self._record_btn.setChecked(False)
@@ -1156,6 +1179,8 @@ class PlayerControls(QWidget):
     def _on_play_finished(self) -> None:
         self._play_btn.setIcon(self._play_icon)
         self._play_btn.setAccessibleName("Play")
+        if self._player.chord_sequence:
+            self._chord_label.setText(self._badge_html("Chord:", "--"))
         total = self._player.total_seconds
         if total > 0:
             self._waveform.set_position(
@@ -1580,7 +1605,9 @@ class PlayerControls(QWidget):
         if result.chord_sequence:
             self._player.set_chord_sequence(result.chord_sequence)
             self._chord_label.setStyleSheet(badge)
-            self._chord_timer.start()
+            self._chord_label.setText(self._badge_html("Chord:", "--"))
+            if self._player.is_playing:
+                self._chord_timer.start()
         else:
             self._player.set_chord_sequence([])
             self._chord_label.setText("")
@@ -1716,9 +1743,13 @@ class PlayerControls(QWidget):
     ) -> None:
         """Restore a previously detected chord sequence from QSettings."""
         self._player.set_chord_sequence(chords)
-        if chords and self._player.is_playing:
+        if chords:
+            # Always apply badge style so the outline is visible even
+            # before playback starts (fixes missing badge on app launch).
             self._chord_label.setStyleSheet(self._badge_style())
-            self._chord_timer.start()
+            self._chord_label.setText(self._badge_html("Chord:", "--"))
+            if self._player.is_playing:
+                self._chord_timer.start()
 
     def set_detected_key(self, key: str, confidence: str = "") -> None:
         """Restore a previously detected key label with colour and tooltip."""

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -954,10 +954,9 @@ class PlayerControls(QWidget):
                 self._player.current_seconds * self._player.sample_rate
             )
             chord = self._player.chord_at(frame)
-            if chord:
-                self._chord_label.setText(
-                    self._badge_html("Chord:", chord)
-                )
+            self._chord_label.setText(
+                self._badge_html("Chord:", chord if chord else "--")
+            )
         self._footer_widget.setStyleSheet(
             f"border-top: 1px solid {colors['surface0']};"
         )
@@ -1029,7 +1028,7 @@ class PlayerControls(QWidget):
 
         # Auto-detect if no beat grid has been loaded yet.
         # Old sessions are handled by the det_ver gate in main_window:
-        # if det_ver < 2, beat_times are not restored, so this fires.
+        # if det_ver < 4, beat_times are not restored, so this fires.
         if has_stems and not self._player.beat_times:
             self.start_detection()
 
@@ -1179,6 +1178,7 @@ class PlayerControls(QWidget):
     def _on_play_finished(self) -> None:
         self._play_btn.setIcon(self._play_icon)
         self._play_btn.setAccessibleName("Play")
+        self._chord_timer.stop()
         if self._player.chord_sequence:
             self._chord_label.setText(self._badge_html("Chord:", "--"))
         total = self._player.total_seconds

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -1615,7 +1615,7 @@ class PlayerControls(QWidget):
     ) -> None:
         """Restore a previously detected chord sequence from QSettings."""
         self._player.set_chord_sequence(chords)
-        if chords:
+        if chords and self._player.is_playing:
             self._chord_timer.start()
 
     def set_detected_key(self, key: str, confidence: str = "") -> None:

--- a/src/ui/splash_screen.py
+++ b/src/ui/splash_screen.py
@@ -234,9 +234,9 @@ class SplashScreen(QWidget):
             and os.path.isfile(self._audio_path)
         ):
             if elapsed <= _SOUND_DEFER_IF_FRAME2_AFTER_MS:
+                data = open(self._audio_path, "rb").read()  # noqa: SIM115
                 winsound.PlaySound(
-                    self._audio_path,
-                    winsound.SND_ASYNC | winsound.SND_FILENAME,
+                    data, winsound.SND_ASYNC | winsound.SND_MEMORY,
                 )
                 self._sound_played_on_frame2 = True
 
@@ -306,9 +306,9 @@ class SplashScreen(QWidget):
             and self._audio_path
             and os.path.isfile(self._audio_path)
         ):
+            data = open(self._audio_path, "rb").read()  # noqa: SIM115
             winsound.PlaySound(
-                self._audio_path,
-                winsound.SND_ASYNC | winsound.SND_FILENAME,
+                data, winsound.SND_ASYNC | winsound.SND_MEMORY,
             )
 
     # -- helpers --------------------------------------------------------

--- a/src/ui/splash_screen.py
+++ b/src/ui/splash_screen.py
@@ -8,6 +8,7 @@ immediate feedback.
 
 import math
 import os
+import threading
 
 from PySide6.QtCore import (
     QByteArray,
@@ -235,9 +236,11 @@ class SplashScreen(QWidget):
         ):
             if elapsed <= _SOUND_DEFER_IF_FRAME2_AFTER_MS:
                 data = open(self._audio_path, "rb").read()  # noqa: SIM115
-                winsound.PlaySound(
-                    data, winsound.SND_ASYNC | winsound.SND_MEMORY,
-                )
+                threading.Thread(
+                    target=winsound.PlaySound,
+                    args=(data, winsound.SND_MEMORY),
+                    daemon=True,
+                ).start()
                 self._sound_played_on_frame2 = True
 
     def paintEvent(self, event) -> None:  # noqa: N802
@@ -307,9 +310,11 @@ class SplashScreen(QWidget):
             and os.path.isfile(self._audio_path)
         ):
             data = open(self._audio_path, "rb").read()  # noqa: SIM115
-            winsound.PlaySound(
-                data, winsound.SND_ASYNC | winsound.SND_MEMORY,
-            )
+            threading.Thread(
+                target=winsound.PlaySound,
+                args=(data, winsound.SND_MEMORY),
+                daemon=True,
+            ).start()
 
     # -- helpers --------------------------------------------------------
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """stemma version string."""
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/tests/test_beat_detector.py
+++ b/tests/test_beat_detector.py
@@ -370,9 +370,9 @@ class TestDetectionWorker:
 
 class TestBuildChordTemplates:
     def test_template_count(self):
-        """12 roots x 2 qualities (major + minor) = 24 templates."""
+        """12 roots x 5 qualities = 60 templates."""
         templates = _build_chord_templates()
-        assert len(templates) == 24
+        assert len(templates) == 60
 
     def test_templates_normalised(self):
         """Every template should be unit-normalised."""

--- a/tests/test_beat_detector.py
+++ b/tests/test_beat_detector.py
@@ -96,15 +96,15 @@ class TestDetectTimeSignature:
 
     def test_no_downbeats(self):
         """No downbeats -> empty string (librosa fallback)."""
-        assert _detect_time_signature([0.0, 0.5, 1.0], []) == ""
+        assert _detect_time_signature([0.0, 0.5, 1.0], []) == "--"
 
     def test_single_downbeat(self):
         """Only one downbeat -> not enough to measure a bar."""
-        assert _detect_time_signature([0.0, 0.5, 1.0], [0.0]) == ""
+        assert _detect_time_signature([0.0, 0.5, 1.0], [0.0]) == "--"
 
     def test_no_beats(self):
         """No beats at all."""
-        assert _detect_time_signature([], [0.0, 2.0]) == ""
+        assert _detect_time_signature([], [0.0, 2.0]) == "--"
 
     def test_unusual_meter(self):
         """5 beats per bar -> 5/4."""

--- a/tests/test_beat_detector.py
+++ b/tests/test_beat_detector.py
@@ -370,9 +370,9 @@ class TestDetectionWorker:
 
 class TestBuildChordTemplates:
     def test_template_count(self):
-        """12 roots x 5 qualities = 60 templates."""
+        """12 roots x 2 qualities = 24 templates."""
         templates = _build_chord_templates()
-        assert len(templates) == 60
+        assert len(templates) == 24
 
     def test_templates_normalised(self):
         """Every template should be unit-normalised."""

--- a/tests/test_beat_detector.py
+++ b/tests/test_beat_detector.py
@@ -11,6 +11,7 @@ from src.beat_detector import (
     _bpm_confidence,
     _detect_beats_librosa,
     _detect_key,
+    _detect_time_signature,
     _key_confidence,
     _peak_pick,
     _sigmoid,
@@ -57,12 +58,73 @@ class TestDetectionResult:
         assert r.bpm == 0.0
         assert r.key == ""
         assert r.beat_times == []
+        assert r.time_signature == ""
 
     def test_fields(self):
         r = DetectionResult(bpm=120.0, key="C major", bpm_confidence="high")
         assert r.bpm == 120.0
         assert r.key == "C major"
         assert r.bpm_confidence == "high"
+
+
+# ---------------------------------------------------------------------------
+# Time signature detection
+# ---------------------------------------------------------------------------
+
+class TestDetectTimeSignature:
+    def test_four_four(self):
+        """4 beats per bar -> 4/4."""
+        downbeats = [0.0, 2.0, 4.0, 6.0]
+        beats = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5,
+                 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5]
+        assert _detect_time_signature(beats, downbeats) == "4/4"
+
+    def test_three_four(self):
+        """3 beats per bar -> 3/4."""
+        downbeats = [0.0, 1.5, 3.0, 4.5]
+        beats = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5]
+        assert _detect_time_signature(beats, downbeats) == "3/4"
+
+    def test_six_eight(self):
+        """6 beats per bar -> 6/8."""
+        downbeats = [0.0, 3.0, 6.0]
+        beats = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5]
+        assert _detect_time_signature(beats, downbeats) == "6/8"
+
+    def test_no_downbeats(self):
+        """No downbeats -> empty string (librosa fallback)."""
+        assert _detect_time_signature([0.0, 0.5, 1.0], []) == ""
+
+    def test_single_downbeat(self):
+        """Only one downbeat -> not enough to measure a bar."""
+        assert _detect_time_signature([0.0, 0.5, 1.0], [0.0]) == ""
+
+    def test_no_beats(self):
+        """No beats at all."""
+        assert _detect_time_signature([], [0.0, 2.0]) == ""
+
+    def test_unusual_meter(self):
+        """5 beats per bar -> 5/4."""
+        downbeats = [0.0, 2.5, 5.0]
+        beats = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5]
+        assert _detect_time_signature(beats, downbeats) == "5/4"
+
+    def test_unmapped_meter_fallback(self):
+        """Meter not in the standard map falls back to N/4."""
+        downbeats = [0.0, 4.0, 8.0]
+        beats = [float(i) * 0.5 for i in range(16)]  # 8 beats per bar
+        assert _detect_time_signature(beats, downbeats) == "8/4"
+
+    def test_robust_to_outlier_bars(self):
+        """Median ignores outlier bars (e.g. partial last bar)."""
+        # 3 bars of 4/4 plus a partial bar of 2 beats
+        downbeats = [0.0, 2.0, 4.0, 6.0, 7.0]
+        beats = [0.0, 0.5, 1.0, 1.5,
+                 2.0, 2.5, 3.0, 3.5,
+                 4.0, 4.5, 5.0, 5.5,
+                 6.0, 6.5,
+                 7.0, 7.5]
+        assert _detect_time_signature(beats, downbeats) == "4/4"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_beat_detector.py
+++ b/tests/test_beat_detector.py
@@ -96,15 +96,15 @@ class TestDetectTimeSignature:
 
     def test_no_downbeats(self):
         """No downbeats -> empty string (librosa fallback)."""
-        assert _detect_time_signature([0.0, 0.5, 1.0], []) == "--"
+        assert _detect_time_signature([0.0, 0.5, 1.0], []) == ""
 
     def test_single_downbeat(self):
         """Only one downbeat -> not enough to measure a bar."""
-        assert _detect_time_signature([0.0, 0.5, 1.0], [0.0]) == "--"
+        assert _detect_time_signature([0.0, 0.5, 1.0], [0.0]) == ""
 
     def test_no_beats(self):
         """No beats at all."""
-        assert _detect_time_signature([], [0.0, 2.0]) == "--"
+        assert _detect_time_signature([], [0.0, 2.0]) == ""
 
     def test_unusual_meter(self):
         """5 beats per bar -> 5/4."""

--- a/tests/test_beat_detector.py
+++ b/tests/test_beat_detector.py
@@ -15,6 +15,7 @@ from src.beat_detector import (
     _detect_key,
     _detect_time_signature,
     _key_confidence,
+    _infer_time_signature_from_beats,
     _peak_pick,
     _sigmoid,
     _viterbi_smooth,
@@ -128,6 +129,52 @@ class TestDetectTimeSignature:
                  6.0, 6.5,
                  7.0, 7.5]
         assert _detect_time_signature(beats, downbeats) == "4/4"
+
+
+# ---------------------------------------------------------------------------
+# _infer_time_signature_from_beats
+# ---------------------------------------------------------------------------
+
+class TestInferTimeSignatureFromBeats:
+    SR = 22050
+
+    def _make_audio_with_strong_beat1(self, n_beats: int, bpb: int) -> tuple:
+        """Build a simple tone where beat 1 of each bar is louder."""
+        beat_dur = 0.5  # seconds per beat
+        sr = self.SR
+        beat_times = [i * beat_dur for i in range(n_beats)]
+        total = int(n_beats * beat_dur * sr) + sr
+        audio = np.zeros(total, dtype=np.float32)
+        for i, bt in enumerate(beat_times):
+            amp = 0.8 if (i % bpb == 0) else 0.2
+            start = int(bt * sr)
+            end = min(start + int(0.05 * sr), total)
+            audio[start:end] = amp * np.sin(
+                2 * np.pi * 440 * np.arange(end - start) / sr
+            )
+        return beat_times, audio
+
+    def test_4_4_meter(self):
+        beat_times, audio = self._make_audio_with_strong_beat1(32, 4)
+        result = _infer_time_signature_from_beats(beat_times, audio, self.SR)
+        assert result == "4/4"
+
+    def test_3_4_meter(self):
+        beat_times, audio = self._make_audio_with_strong_beat1(30, 3)
+        result = _infer_time_signature_from_beats(beat_times, audio, self.SR)
+        assert result == "3/4"
+
+    def test_too_few_beats_returns_empty(self):
+        beat_times, audio = self._make_audio_with_strong_beat1(4, 4)
+        result = _infer_time_signature_from_beats(beat_times, audio, self.SR)
+        assert result == ""
+
+    def test_flat_audio_returns_empty(self):
+        """Uniform onset strength → no clear meter → empty string."""
+        beat_times = [i * 0.5 for i in range(32)]
+        audio = np.zeros(int(32 * 0.5 * self.SR) + self.SR, dtype=np.float32)
+        result = _infer_time_signature_from_beats(beat_times, audio, self.SR)
+        assert result == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_beat_detector.py
+++ b/tests/test_beat_detector.py
@@ -9,12 +9,15 @@ from src.beat_detector import (
     DetectionResult,
     DetectionWorker,
     _bpm_confidence,
+    _build_chord_templates,
     _detect_beats_librosa,
+    _detect_chords,
     _detect_key,
     _detect_time_signature,
     _key_confidence,
     _peak_pick,
     _sigmoid,
+    _viterbi_smooth,
     detect_bpm_and_key,
 )
 
@@ -359,3 +362,109 @@ class TestDetectionWorker:
         # Empty stems should return an empty result, not an error.
         assert len(results) == 1
         assert results[0].bpm == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Chord templates
+# ---------------------------------------------------------------------------
+
+class TestBuildChordTemplates:
+    def test_template_count(self):
+        """12 roots x 7 qualities = 84 templates."""
+        templates = _build_chord_templates()
+        assert len(templates) == 84
+
+    def test_templates_normalised(self):
+        """Every template should be unit-normalised."""
+        for label, vec in _build_chord_templates():
+            norm = float(np.linalg.norm(vec))
+            assert abs(norm - 1.0) < 1e-6, f"{label}: norm={norm}"
+
+    def test_c_major_template(self):
+        """C major template should have energy on C, E, G (indices 0, 4, 7)."""
+        templates = _build_chord_templates()
+        c_major = [v for l, v in templates if l == "C"][0]
+        assert c_major[0] > 0   # C
+        assert c_major[4] > 0   # E
+        assert c_major[7] > 0   # G
+        assert c_major[1] == 0  # C#
+
+    def test_am7_template(self):
+        """Am7 = A(9) + C(0) + E(4) + G(7)."""
+        templates = _build_chord_templates()
+        am7 = [v for l, v in templates if l == "Am7"][0]
+        assert am7[9] > 0   # A
+        assert am7[0] > 0   # C
+        assert am7[4] > 0   # E
+        assert am7[7] > 0   # G
+
+
+# ---------------------------------------------------------------------------
+# Viterbi smoothing
+# ---------------------------------------------------------------------------
+
+class TestViterbiSmooth:
+    def test_empty(self):
+        assert _viterbi_smooth([], 10) == []
+
+    def test_stable_sequence(self):
+        """Already-stable sequence should remain unchanged."""
+        labels = [0] * 10 + [1] * 10
+        smoothed = _viterbi_smooth(labels, 5)
+        assert smoothed == labels
+
+    def test_removes_isolated_spike(self):
+        """A single-frame spike should be smoothed away."""
+        labels = [0] * 5 + [3] + [0] * 5
+        smoothed = _viterbi_smooth(labels, 5)
+        assert smoothed[5] == 0  # spike removed
+
+    def test_preserves_real_change(self):
+        """A sustained change should be preserved."""
+        labels = [0] * 20 + [2] * 20
+        smoothed = _viterbi_smooth(labels, 5)
+        # The bulk of each segment should match.
+        assert smoothed[5] == 0
+        assert smoothed[35] == 2
+
+
+# ---------------------------------------------------------------------------
+# Chord detection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+class TestDetectChords:
+    def test_c_major_chord(self):
+        """A sustained C major chord should be detected as C or C-related."""
+        audio = _chord([261.63, 329.63, 392.00], duration=5.0)
+        chords = _detect_chords(audio, sr=44100)
+        assert len(chords) >= 1
+        # First chord should be C-something.
+        assert chords[0][1].startswith("C")
+
+    def test_chord_segments_sorted(self):
+        """Chord onsets should be in ascending time order."""
+        audio = _chord([261.63, 329.63, 392.00], duration=5.0)
+        chords = _detect_chords(audio, sr=44100)
+        times = [t for t, _ in chords]
+        assert times == sorted(times)
+
+    def test_silence_returns_chords(self):
+        """Even silence should produce some output (possibly a single chord)."""
+        audio = np.zeros(44100 * 4, dtype=np.float32)
+        chords = _detect_chords(audio, sr=44100)
+        # Should not crash; may return empty or a single dim chord.
+        assert isinstance(chords, list)
+
+    def test_two_chord_sequence(self):
+        """Two distinct chords played sequentially should produce at least 2 segments."""
+        sr = 44100
+        c_major = _chord([261.63, 329.63, 392.00], duration=3.0, sr=sr)
+        a_minor = _chord([220.00, 261.63, 329.63], duration=3.0, sr=sr)
+        audio = np.concatenate([c_major, a_minor])
+        chords = _detect_chords(audio, sr=sr)
+        # Should detect at least a chord change somewhere.
+        assert len(chords) >= 2
+        labels = [c for _, c in chords]
+        # The set of unique labels should have more than 1 entry.
+        assert len(set(labels)) >= 2

--- a/tests/test_beat_detector.py
+++ b/tests/test_beat_detector.py
@@ -15,7 +15,6 @@ from src.beat_detector import (
     _detect_key,
     _detect_time_signature,
     _key_confidence,
-    _infer_time_signature_from_beats,
     _peak_pick,
     _sigmoid,
     _viterbi_smooth,
@@ -129,52 +128,6 @@ class TestDetectTimeSignature:
                  6.0, 6.5,
                  7.0, 7.5]
         assert _detect_time_signature(beats, downbeats) == "4/4"
-
-
-# ---------------------------------------------------------------------------
-# _infer_time_signature_from_beats
-# ---------------------------------------------------------------------------
-
-class TestInferTimeSignatureFromBeats:
-    SR = 22050
-
-    def _make_audio_with_strong_beat1(self, n_beats: int, bpb: int) -> tuple:
-        """Build a simple tone where beat 1 of each bar is louder."""
-        beat_dur = 0.5  # seconds per beat
-        sr = self.SR
-        beat_times = [i * beat_dur for i in range(n_beats)]
-        total = int(n_beats * beat_dur * sr) + sr
-        audio = np.zeros(total, dtype=np.float32)
-        for i, bt in enumerate(beat_times):
-            amp = 0.8 if (i % bpb == 0) else 0.2
-            start = int(bt * sr)
-            end = min(start + int(0.05 * sr), total)
-            audio[start:end] = amp * np.sin(
-                2 * np.pi * 440 * np.arange(end - start) / sr
-            )
-        return beat_times, audio
-
-    def test_4_4_meter(self):
-        beat_times, audio = self._make_audio_with_strong_beat1(32, 4)
-        result = _infer_time_signature_from_beats(beat_times, audio, self.SR)
-        assert result == "4/4"
-
-    def test_3_4_meter(self):
-        beat_times, audio = self._make_audio_with_strong_beat1(30, 3)
-        result = _infer_time_signature_from_beats(beat_times, audio, self.SR)
-        assert result == "3/4"
-
-    def test_too_few_beats_returns_empty(self):
-        beat_times, audio = self._make_audio_with_strong_beat1(4, 4)
-        result = _infer_time_signature_from_beats(beat_times, audio, self.SR)
-        assert result == ""
-
-    def test_flat_audio_returns_empty(self):
-        """Uniform onset strength → no clear meter → empty string."""
-        beat_times = [i * 0.5 for i in range(32)]
-        audio = np.zeros(int(32 * 0.5 * self.SR) + self.SR, dtype=np.float32)
-        result = _infer_time_signature_from_beats(beat_times, audio, self.SR)
-        assert result == ""
 
 
 # ---------------------------------------------------------------------------
@@ -417,9 +370,9 @@ class TestDetectionWorker:
 
 class TestBuildChordTemplates:
     def test_template_count(self):
-        """12 roots x 7 qualities = 84 templates."""
+        """12 roots x 2 qualities (major + minor) = 24 templates."""
         templates = _build_chord_templates()
-        assert len(templates) == 84
+        assert len(templates) == 24
 
     def test_templates_normalised(self):
         """Every template should be unit-normalised."""
@@ -435,15 +388,6 @@ class TestBuildChordTemplates:
         assert c_major[4] > 0   # E
         assert c_major[7] > 0   # G
         assert c_major[1] == 0  # C#
-
-    def test_am7_template(self):
-        """Am7 = A(9) + C(0) + E(4) + G(7)."""
-        templates = _build_chord_templates()
-        am7 = [v for l, v in templates if l == "Am7"][0]
-        assert am7[9] > 0   # A
-        assert am7[0] > 0   # C
-        assert am7[4] > 0   # E
-        assert am7[7] > 0   # G
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -49,6 +49,27 @@ class TestModelManager:
         downloader = manager.download_model(is_6_stem=False)
         assert isinstance(downloader, ModelDownloader)
 
+    def test_beat_model_path(self, tmp_dir):
+        manager = ModelManager(data_dir=tmp_dir)
+        assert manager.beat_model_path().endswith("beat_this.onnx")
+
+    def test_is_beat_model_downloaded_false(self, tmp_dir):
+        manager = ModelManager(data_dir=tmp_dir)
+        assert not manager.is_beat_model_downloaded()
+
+    def test_is_beat_model_downloaded_true(self, tmp_dir):
+        manager = ModelManager(data_dir=tmp_dir)
+        models_dir = os.path.join(tmp_dir, "models")
+        os.makedirs(models_dir, exist_ok=True)
+        with open(os.path.join(models_dir, "beat_this.onnx"), "wb") as f:
+            f.write(b"dummy")
+        assert manager.is_beat_model_downloaded()
+
+    def test_download_beat_model_returns_downloader(self, tmp_dir):
+        manager = ModelManager(data_dir=tmp_dir)
+        downloader = manager.download_beat_model()
+        assert isinstance(downloader, ModelDownloader)
+
 
 class TestModelDownloader:
     """Verify ModelDownloader initialization and cancellation."""

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1016,3 +1016,55 @@ class TestNudgeStem:
 
         player.remove_recording_stem("take1")
         assert player.get_nudge_ms("take1") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Chord sequence
+# ---------------------------------------------------------------------------
+
+class TestChordSequence:
+    def test_default_empty(self):
+        player = MultiTrackPlayer()
+        assert player.chord_sequence == []
+        assert player.chord_at(0) == ""
+
+    def test_set_chord_sequence(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        chords = [(0.0, "Am"), (2.3, "G"), (3.8, "C")]
+        player.set_chord_sequence(chords)
+        assert len(player.chord_sequence) == 3
+        assert player.chord_sequence[0] == (0.0, "Am")
+
+    def test_chord_at_returns_correct_chord(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        chords = [(0.0, "Am"), (0.5, "G")]
+        player.set_chord_sequence(chords)
+        sr = player.sample_rate
+        # Frame at t=0.25s should be in "Am" region.
+        assert player.chord_at(int(0.25 * sr)) == "Am"
+        # Frame at t=0.75s should be in "G" region.
+        assert player.chord_at(int(0.75 * sr)) == "G"
+
+    def test_chord_at_before_first_onset(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        chords = [(1.0, "Am")]
+        player.set_chord_sequence(chords)
+        # Before the first chord onset, should return empty.
+        assert player.chord_at(0) == ""
+
+    def test_chord_at_empty_sequence(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player.set_chord_sequence([])
+        assert player.chord_at(22050) == ""
+
+    def test_load_stems_clears_chords(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player.set_chord_sequence([(0.0, "Am")])
+        assert len(player.chord_sequence) == 1
+        player.load_stems(mock_stems)
+        assert player.chord_sequence == []

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -1,6 +1,6 @@
 """Tests for the animated splash screen."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 from PySide6.QtCore import QSettings
@@ -279,6 +279,7 @@ class TestSoundSync:
         splash.close()
 
     @patch("src.ui.splash_screen.os.path.isfile", return_value=True)
+    @patch("builtins.open", mock_open(read_data=b"RIFF...."))
     @patch("src.ui.splash_screen.winsound.PlaySound")
     def test_sound_plays_when_frame2_is_prompt(self, mock_play, _isfile, app):
         splash = SplashScreen(


### PR DESCRIPTION
## Summary
- **Chord detection** — chromagram template matching (major/minor triads) with Viterbi HMM smoothing and silence gating. Displays current chord as a real-time badge during playback.
- **beat_this ONNX model** — auto-downloads the beat_this model (MIT license, ISMIR 2024) for high-accuracy beat/downbeat tracking with chunked inference. Falls back to librosa when unavailable.
- **QThread crash fix** — worker orphaning pattern with identity-checked `finished` callback prevents "Destroyed while thread is still running" crashes when switching songs.
- **Light mode readability** — badge labels include explicit `color:` property; dim text uses theme `text` color for proper contrast.
- **Theme switching** — badge HTML is regenerated with new theme colours on toggle (not just the stylesheet).
- **Chord placeholder** — shows "Chord: --" when stopped or during silence instead of stale data.
- **Schema version 4** — forces one-time re-detection for all cached songs.

## Test plan
- [x] Manual test: load a song, verify chord badge shows "Chord: --" before playback
- [x] Play song, verify chord updates in real-time (major/minor only, no false 7ths)
- [x] Pause/stop, verify chord shows "--" placeholder
- [x] Silent sections should show "--" not stale chord
- [x] Switch light→dark and dark→light, verify all badges have correct colours
- [x] Switch songs while detection is running — no crash
- [x] Delete beat_this.onnx, load a song — model auto-downloads, detection runs
- [x] Run full test suite: 625 passed