### PR TITLE
feat: v2.3.0 — library, polish & shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-04-17 -- v2.3.0 Library, Polish & Shortcuts
+
+### Done
+- **Library playback controls:** Repeat (off / all / one), shuffle with randomized queue, previous/next buttons. Autoplay on track end respects the repeat mode. Now-playing indicator (accent bar) on the currently loaded song in the list.
+- **Keyboard shortcuts overhaul (#119):** YouTube-style controls, layout-independent. Zero symbol keys — works on Nordic/Finnish and all layouts. `0-9` jumps to 0%-90% position, `Left/Right` seek ±5s, `Home/End` start/end, `Up/Down` master volume ±5%, `Shift+Up/Down` speed cycle (replaces `[`/`]`), `Ctrl+1-6` stem mute toggle (replaces bare `1-6`), `N/P` next/previous song, `F1` shortcuts dialog. Focus guard prevents shortcuts firing while typing in the search box or spinboxes.
+- **Master volume:** New gain multiplier on `MultiTrackPlayer`, applied in the audio callback alongside per-stem volumes. Persisted in session. Changes show a toast overlay.
+- **UI polish pass:** Centralised styling via QSS objectName selectors (`card-frame`, `icon-btn`, `subtle-label`, `footer`, `copyright`, `QSpinBox`). Removed ~20 hardcoded `setStyleSheet` calls. Transport buttons (play/stop/record) share `icon-btn` styling with stem buttons. Confidence colours and delegate defaults moved to `styles.py`.
+- **Teal contrast fix:** Introduced `styles.ON_ACCENT = "#11111b"` (near-black) as the foreground token for anything on the teal accent fill. Fixes poor contrast in light mode (previously used theme.base, which is near-white in light mode). Applied to checked toggle buttons, selected library rows, repeat/shuffle icons on teal, and stem mute/solo icons.
+- **Shortcuts dialog refresh:** Grouped by category with accent-coloured section headers and hairline dividers.
+- **Session persistence:** `repeat_mode`, `shuffle_enabled`, and `master_volume` save and restore across app restarts.
+
+### Metrics
+- 670 tests pass, 5 skipped (slow ONNX/hardware).
+
+---
+
 ## 2026-04-14 -- v2.2.0 Chord Detection & beat_this ONNX Model
 
 ### Done

--- a/src/player.py
+++ b/src/player.py
@@ -124,6 +124,7 @@ class MultiTrackPlayer(QObject):
         self._muted_stems: set[str] = set()
         self._soloed_stems: set[str] = set()
         self._volumes: dict[str, float] = {}  # Per-stem gain, 0.0–2.0
+        self._master_volume: float = 1.0     # Master gain, 0.0–2.0
         self._applied_gains: dict[str, float] = {}  # Last gain per stem (for ramping)
         self._active_stems_cache: list[str] | None = None
 
@@ -804,6 +805,19 @@ class MultiTrackPlayer(QObject):
         """Return the sample rate of loaded audio."""
         return self._sample_rate
 
+    @property
+    def master_volume(self) -> float:
+        """Return the master volume (0.0–2.0)."""
+        return self._master_volume
+
+    def set_master_volume(self, volume: float) -> None:
+        """Set the master volume (gain multiplier for all stems).
+
+        Args:
+            volume: Gain from 0.0 (silent) to 2.0 (double). Clamped.
+        """
+        self._master_volume = max(0.0, min(volume, 2.0))
+
     def set_volume(self, stem_name: str, volume: float) -> None:
         """Set the volume (gain) for a stem.
 
@@ -1213,7 +1227,7 @@ class MultiTrackPlayer(QObject):
 
                 active_set = set(active_stems)
                 for name, stem_data in self._stems.items():
-                    target = (self._volumes.get(name, 1.0)
+                    target = (self._volumes.get(name, 1.0) * self._master_volume
                               if name in active_set else 0.0)
                     prev = self._applied_gains.get(name, target)
                     if target == 0.0 and prev == 0.0:

--- a/src/ui/library_panel.py
+++ b/src/ui/library_panel.py
@@ -1,11 +1,23 @@
 """Song library panel -- left sidebar listing imported songs.
 
 Displays the song library as a list and emits a signal when a song is
-selected. Full implementation in ticket #10.
+selected. Includes repeat/shuffle/prev/next playback controls and a
+"now playing" indicator. Full implementation in ticket #10.
 """
 
-from PySide6.QtCore import QSize, Qt, Signal
-from PySide6.QtGui import QColor, QFont, QFontMetrics, QPen
+import math
+
+from PySide6.QtCore import QPointF, QRectF, QSize, Qt, Signal
+from PySide6.QtGui import (
+    QColor,
+    QFont,
+    QFontMetrics,
+    QIcon,
+    QPainter,
+    QPen,
+    QPixmap,
+    QPolygonF,
+)
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -25,24 +37,172 @@ from PySide6.QtWidgets import (
 )
 
 from src.library import Song, SongLibrary
+from src.ui.styles import DARK_COLORS
 
 # Custom data roles for two-line display.
 _ARTIST_ROLE = Qt.ItemDataRole.UserRole + 1
 _TITLE_ROLE = Qt.ItemDataRole.UserRole + 2
 
+_CTRL_ICON = 18  # Icon size for library control buttons.
+_CTRL_BTN = 28   # Button size for library control buttons.
+
+
+# ---------------------------------------------------------------------------
+# QPainter icon draw helpers
+# ---------------------------------------------------------------------------
+
+def _make_icon(draw_fn, color: QColor, size: int = _CTRL_ICON) -> QIcon:
+    """Create a QIcon by painting with *draw_fn(painter, size)*."""
+    pixmap = QPixmap(QSize(size, size))
+    pixmap.fill(Qt.GlobalColor.transparent)
+    p = QPainter(pixmap)
+    p.setRenderHint(QPainter.RenderHint.Antialiasing)
+    p.setPen(Qt.PenStyle.NoPen)
+    p.setBrush(color)
+    draw_fn(p, size)
+    p.end()
+    return QIcon(pixmap)
+
+
+def _make_toggle_icon(draw_fn, normal_color: QColor,
+                      size: int = _CTRL_ICON) -> QIcon:
+    """Icon with distinct normal and checked pixmaps."""
+    checked_color = QColor("#1e1e2e")
+    icon = QIcon()
+    for color, state in [
+        (normal_color, QIcon.State.Off),
+        (checked_color, QIcon.State.On),
+    ]:
+        pixmap = QPixmap(QSize(size, size))
+        pixmap.fill(Qt.GlobalColor.transparent)
+        p = QPainter(pixmap)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing)
+        p.setPen(Qt.PenStyle.NoPen)
+        p.setBrush(color)
+        draw_fn(p, size)
+        p.end()
+        icon.addPixmap(pixmap, QIcon.Mode.Normal, state)
+    return icon
+
+
+def _draw_repeat(p: QPainter, s: int) -> None:
+    """Cycle/repeat arrows icon (repeat-all)."""
+    cx = s / 2.0
+    m = s * 0.20
+    r = (s - 2 * m) / 2.0
+    pen = QPen(p.brush().color(), s * 0.09)
+    pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+    p.setPen(pen)
+    arc_rect = QRectF(m, m, s - 2 * m, s - 2 * m)
+    p.drawArc(arc_rect, 20 * 16, 140 * 16)
+    p.drawArc(arc_rect, 200 * 16, 140 * 16)
+    p.setPen(Qt.PenStyle.NoPen)
+    a1 = math.radians(20)
+    ax1 = cx + r * math.cos(a1)
+    ay1 = cx - r * math.sin(a1)
+    ah = s * 0.12
+    p.drawPolygon(QPolygonF([
+        QPointF(ax1 + ah, ay1 - ah * 0.6),
+        QPointF(ax1 - ah * 0.3, ay1 - ah * 0.8),
+        QPointF(ax1, ay1 + ah * 0.5),
+    ]))
+    a2 = math.radians(200)
+    ax2 = cx + r * math.cos(a2)
+    ay2 = cx - r * math.sin(a2)
+    p.drawPolygon(QPolygonF([
+        QPointF(ax2 - ah, ay2 + ah * 0.6),
+        QPointF(ax2 + ah * 0.3, ay2 + ah * 0.8),
+        QPointF(ax2, ay2 - ah * 0.5),
+    ]))
+
+
+def _draw_repeat_one(p: QPainter, s: int) -> None:
+    """Repeat-one icon: repeat arrows with a '1' in the center."""
+    _draw_repeat(p, s)
+    # Draw "1" in the center.
+    font = p.font()
+    font.setPixelSize(max(6, int(s * 0.38)))
+    font.setBold(True)
+    p.setFont(font)
+    p.setPen(p.brush().color())
+    p.drawText(QRectF(0, 0, s, s), Qt.AlignmentFlag.AlignCenter, "1")
+    p.setPen(Qt.PenStyle.NoPen)
+
+
+def _draw_shuffle(p: QPainter, s: int) -> None:
+    """Two crossed arrows — shuffle icon."""
+    m = s * 0.18
+    pen = QPen(p.brush().color(), s * 0.09)
+    pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+    p.setPen(pen)
+    # Two crossing lines.
+    p.drawLine(QPointF(m, s * 0.35), QPointF(s - m, s * 0.65))
+    p.drawLine(QPointF(m, s * 0.65), QPointF(s - m, s * 0.35))
+    p.setPen(Qt.PenStyle.NoPen)
+    # Arrowhead at top-right.
+    ah = s * 0.12
+    tip_x = s - m
+    tip_y = s * 0.35
+    p.drawPolygon(QPolygonF([
+        QPointF(tip_x + ah * 0.3, tip_y - ah * 0.3),
+        QPointF(tip_x - ah, tip_y - ah * 0.3),
+        QPointF(tip_x, tip_y + ah * 0.7),
+    ]))
+    # Arrowhead at bottom-right.
+    tip_y2 = s * 0.65
+    p.drawPolygon(QPolygonF([
+        QPointF(tip_x + ah * 0.3, tip_y2 + ah * 0.3),
+        QPointF(tip_x - ah, tip_y2 + ah * 0.3),
+        QPointF(tip_x, tip_y2 - ah * 0.7),
+    ]))
+
+
+def _draw_prev(p: QPainter, s: int) -> None:
+    """Previous track icon: bar + left-pointing triangle."""
+    m = s * 0.22
+    bar_w = s * 0.1
+    # Vertical bar on left.
+    p.drawRect(QRectF(m, m, bar_w, s - 2 * m))
+    # Left-pointing triangle.
+    p.drawPolygon(QPolygonF([
+        QPointF(s - m, m),
+        QPointF(m + bar_w + 2, s / 2.0),
+        QPointF(s - m, s - m),
+    ]))
+
+
+def _draw_next(p: QPainter, s: int) -> None:
+    """Next track icon: right-pointing triangle + bar."""
+    m = s * 0.22
+    bar_w = s * 0.1
+    # Right-pointing triangle.
+    p.drawPolygon(QPolygonF([
+        QPointF(m, m),
+        QPointF(s - m - bar_w - 2, s / 2.0),
+        QPointF(m, s - m),
+    ]))
+    # Vertical bar on right.
+    p.drawRect(QRectF(s - m - bar_w, m, bar_w, s - 2 * m))
+
+
+# ---------------------------------------------------------------------------
+# Song delegate
+# ---------------------------------------------------------------------------
 
 class _SongDelegate(QStyledItemDelegate):
     """Two-line delegate: artist (bold) on top, title (subdued) below."""
 
     _V_PADDING = 4
+    _PLAYING_BAR_WIDTH = 3
 
     def __init__(
-        self, parent=None, separator_color: str = "#45475a",
-        accent_color: str = "#4fb8b8",
+        self, parent=None, separator_color: str = DARK_COLORS["surface1"],
+        accent_color: str = DARK_COLORS["accent"],
     ):
         super().__init__(parent)
         self._separator_color = QColor(separator_color)
         self._accent_color = QColor(accent_color)
+        self._playing_song_id: str | None = None
 
     def set_separator_color(self, color: str) -> None:
         self._separator_color = QColor(color)
@@ -50,9 +210,16 @@ class _SongDelegate(QStyledItemDelegate):
     def set_accent_color(self, color: str) -> None:
         self._accent_color = QColor(color)
 
+    def set_playing_song(self, song_id: str | None) -> None:
+        """Set the currently playing song ID for the 'now playing' indicator."""
+        self._playing_song_id = song_id
+
     def paint(self, painter, option, index):  # noqa: D401
         self.initStyleOption(option, index)
         painter.save()
+
+        song_id = index.data(Qt.ItemDataRole.UserRole)
+        is_playing = song_id and song_id == self._playing_song_id
 
         # Draw selection / hover background.
         selected = bool(option.state & QStyle.StateFlag.State_Selected)
@@ -67,9 +234,21 @@ class _SongDelegate(QStyledItemDelegate):
             sub_color = QColor(text_color)
             sub_color.setAlphaF(0.6)
 
+        # "Now playing" indicator — accent bar on the left edge.
+        left_inset = 6
+        if is_playing and not selected:
+            bar_rect = QRectF(
+                option.rect.left(),
+                option.rect.top() + self._V_PADDING,
+                self._PLAYING_BAR_WIDTH,
+                option.rect.height() - 2 * self._V_PADDING,
+            )
+            painter.fillRect(bar_rect, self._accent_color)
+            left_inset = self._PLAYING_BAR_WIDTH + 6
+
         artist = index.data(_ARTIST_ROLE) or ""
         title = index.data(_TITLE_ROLE) or ""
-        rect = option.rect.adjusted(6, self._V_PADDING, -4, -self._V_PADDING)
+        rect = option.rect.adjusted(left_inset, self._V_PADDING, -4, -self._V_PADDING)
 
         # Artist line (bold).
         bold_font = QFont(option.font)
@@ -149,18 +328,38 @@ class EditSongDialog(QDialog):
         return self._artist_edit.text().strip() or self._song.artist
 
 
+# ---------------------------------------------------------------------------
+# Repeat modes
+# ---------------------------------------------------------------------------
+
+REPEAT_OFF = "off"
+REPEAT_ALL = "all"
+REPEAT_ONE = "one"
+_REPEAT_CYCLE = [REPEAT_OFF, REPEAT_ALL, REPEAT_ONE]
+
+
 class LibraryPanel(QWidget):
     """Left sidebar showing the song library.
 
     Signals:
         song_selected(str): Emitted with the song ID when a song is clicked.
+        repeat_mode_changed(str): Emitted when repeat mode cycles.
+        shuffle_toggled(bool): Emitted when shuffle is toggled.
+        previous_requested(): Emitted when the user clicks Previous.
+        next_requested(): Emitted when the user clicks Next.
     """
 
     song_selected = Signal(str)
+    repeat_mode_changed = Signal(str)
+    shuffle_toggled = Signal(bool)
+    previous_requested = Signal()
+    next_requested = Signal()
 
     def __init__(self, library: SongLibrary, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._library = library
+        self._repeat_mode: str = REPEAT_OFF
+        self._shuffle_enabled: bool = False
 
         self._setup_ui()
         self.refresh()
@@ -191,6 +390,68 @@ class LibraryPanel(QWidget):
         self._list.customContextMenuRequested.connect(self._on_context_menu)
         layout.addWidget(self._list)
 
+        # -- Playback control bar --
+        ctrl_bar = QHBoxLayout()
+        ctrl_bar.setSpacing(4)
+
+        icon_color = QColor(DARK_COLORS["text"])
+
+        # Repeat (cycles: off → all → one)
+        self._repeat_btn = QPushButton()
+        self._repeat_btn.setObjectName("icon-btn")
+        self._repeat_btn.setFixedSize(_CTRL_BTN, _CTRL_BTN)
+        self._repeat_btn.setToolTip("Repeat: off")
+        self._repeat_btn.setAccessibleName("Repeat")
+        self._repeat_btn.clicked.connect(self._on_repeat_clicked)
+        self._repeat_icons = {
+            REPEAT_OFF: _make_icon(_draw_repeat, icon_color),
+            REPEAT_ALL: _make_icon(_draw_repeat, icon_color),
+            REPEAT_ONE: _make_icon(_draw_repeat_one, icon_color),
+        }
+        self._repeat_btn.setIcon(self._repeat_icons[REPEAT_OFF])
+        self._repeat_btn.setIconSize(QSize(_CTRL_ICON, _CTRL_ICON))
+        ctrl_bar.addWidget(self._repeat_btn)
+
+        # Shuffle (toggle)
+        self._shuffle_btn = QPushButton()
+        self._shuffle_btn.setObjectName("icon-btn")
+        self._shuffle_btn.setCheckable(True)
+        self._shuffle_btn.setFixedSize(_CTRL_BTN, _CTRL_BTN)
+        self._shuffle_btn.setToolTip("Shuffle: off")
+        self._shuffle_btn.setAccessibleName("Shuffle")
+        self._shuffle_btn.setIcon(
+            _make_toggle_icon(_draw_shuffle, icon_color)
+        )
+        self._shuffle_btn.setIconSize(QSize(_CTRL_ICON, _CTRL_ICON))
+        self._shuffle_btn.toggled.connect(self._on_shuffle_toggled)
+        ctrl_bar.addWidget(self._shuffle_btn)
+
+        ctrl_bar.addStretch()
+
+        # Previous
+        self._prev_btn = QPushButton()
+        self._prev_btn.setObjectName("icon-btn")
+        self._prev_btn.setFixedSize(_CTRL_BTN, _CTRL_BTN)
+        self._prev_btn.setToolTip("Previous song (P)")
+        self._prev_btn.setAccessibleName("Previous song")
+        self._prev_btn.setIcon(_make_icon(_draw_prev, icon_color))
+        self._prev_btn.setIconSize(QSize(_CTRL_ICON, _CTRL_ICON))
+        self._prev_btn.clicked.connect(self.previous_requested)
+        ctrl_bar.addWidget(self._prev_btn)
+
+        # Next
+        self._next_btn = QPushButton()
+        self._next_btn.setObjectName("icon-btn")
+        self._next_btn.setFixedSize(_CTRL_BTN, _CTRL_BTN)
+        self._next_btn.setToolTip("Next song (N)")
+        self._next_btn.setAccessibleName("Next song")
+        self._next_btn.setIcon(_make_icon(_draw_next, icon_color))
+        self._next_btn.setIconSize(QSize(_CTRL_ICON, _CTRL_ICON))
+        self._next_btn.clicked.connect(self.next_requested)
+        ctrl_bar.addWidget(self._next_btn)
+
+        layout.addLayout(ctrl_bar)
+
         self._remove_btn = QPushButton("Remove Selected")
         self._remove_btn.setEnabled(False)
         self._remove_btn.setToolTip("Remove selected song from library")
@@ -198,11 +459,98 @@ class LibraryPanel(QWidget):
         self._remove_btn.clicked.connect(self._on_remove_clicked)
         layout.addWidget(self._remove_btn)
 
+    # ------------------------------------------------------------------
+    # Repeat / Shuffle
+    # ------------------------------------------------------------------
+
+    @property
+    def repeat_mode(self) -> str:
+        return self._repeat_mode
+
+    @property
+    def shuffle_enabled(self) -> bool:
+        return self._shuffle_enabled
+
+    def set_repeat_mode(self, mode: str) -> None:
+        """Set repeat mode without emitting the signal (for session restore)."""
+        if mode not in _REPEAT_CYCLE:
+            mode = REPEAT_OFF
+        self._repeat_mode = mode
+        self._update_repeat_ui()
+
+    def set_shuffle_enabled(self, enabled: bool) -> None:
+        """Set shuffle state without emitting the signal (for session restore)."""
+        self._shuffle_enabled = enabled
+        self._shuffle_btn.blockSignals(True)
+        self._shuffle_btn.setChecked(enabled)
+        self._shuffle_btn.blockSignals(False)
+        self._update_shuffle_ui()
+
+    def _on_repeat_clicked(self) -> None:
+        idx = _REPEAT_CYCLE.index(self._repeat_mode)
+        self._repeat_mode = _REPEAT_CYCLE[(idx + 1) % len(_REPEAT_CYCLE)]
+        self._update_repeat_ui()
+        self.repeat_mode_changed.emit(self._repeat_mode)
+
+    def _on_shuffle_toggled(self, checked: bool) -> None:
+        self._shuffle_enabled = checked
+        self._update_shuffle_ui()
+        self.shuffle_toggled.emit(checked)
+
+    def _update_repeat_ui(self) -> None:
+        self._repeat_btn.setIcon(self._repeat_icons[self._repeat_mode])
+        labels = {REPEAT_OFF: "off", REPEAT_ALL: "all", REPEAT_ONE: "one"}
+        tip = f"Repeat: {labels[self._repeat_mode]}"
+        self._repeat_btn.setToolTip(tip)
+        # Visual: when active (all/one), show as "checked" style.
+        self._repeat_btn.setStyleSheet(
+            "" if self._repeat_mode == REPEAT_OFF else ""
+        )
+        # Use the checked property to style active state via QSS.
+        self._repeat_btn.setCheckable(True)
+        self._repeat_btn.setChecked(self._repeat_mode != REPEAT_OFF)
+        self._repeat_btn.setCheckable(False)  # Prevent toggle on next click.
+
+    def _update_shuffle_ui(self) -> None:
+        tip = f"Shuffle: {'on' if self._shuffle_enabled else 'off'}"
+        self._shuffle_btn.setToolTip(tip)
+
+    # ------------------------------------------------------------------
+    # Now-playing indicator
+    # ------------------------------------------------------------------
+
+    def set_playing_song(self, song_id: str | None) -> None:
+        """Mark a song as 'now playing' with a visual indicator."""
+        self._song_delegate.set_playing_song(song_id)
+        self._list.viewport().update()
+
+    # ------------------------------------------------------------------
+    # Theme
+    # ------------------------------------------------------------------
+
     def apply_theme(self, theme: str, colors: dict[str, str]) -> None:
-        """Update delegate colors for the current theme."""
+        """Update delegate colors and control icons for the current theme."""
         self._song_delegate.set_separator_color(colors["surface1"])
         self._song_delegate.set_accent_color(colors["accent"])
+
+        icon_color = QColor(colors["text"])
+        self._repeat_icons = {
+            REPEAT_OFF: _make_icon(_draw_repeat, icon_color),
+            REPEAT_ALL: _make_icon(_draw_repeat, icon_color),
+            REPEAT_ONE: _make_icon(_draw_repeat_one, icon_color),
+        }
+        self._update_repeat_ui()
+        self._shuffle_btn.setIcon(
+            _make_toggle_icon(_draw_shuffle, icon_color)
+        )
+        self._prev_btn.setIcon(_make_icon(_draw_prev, icon_color))
+        self._next_btn.setIcon(_make_icon(_draw_next, icon_color))
+
         self._list.viewport().update()
+
+    # ------------------------------------------------------------------
+    # Song list management
+    # ------------------------------------------------------------------
 
     def refresh(self) -> None:
         """Reload the song list from the library."""
@@ -215,6 +563,14 @@ class LibraryPanel(QWidget):
             item.setData(_TITLE_ROLE, song.title)
             self._list.addItem(item)
         self._apply_filter(self._search_edit.text())
+
+    def song_count(self) -> int:
+        """Return the number of songs in the library."""
+        return len(self._library.songs)
+
+    def song_ids_in_order(self) -> list[str]:
+        """Return song IDs in current library display order."""
+        return [s.id for s in self._library.songs]
 
     def _apply_filter(self, query: str) -> None:
         """Show only items matching *query* (case-insensitive substring)."""

--- a/src/ui/library_panel.py
+++ b/src/ui/library_panel.py
@@ -65,9 +65,15 @@ def _make_icon(draw_fn, color: QColor, size: int = _CTRL_ICON) -> QIcon:
 
 
 def _make_toggle_icon(draw_fn, normal_color: QColor,
+                      checked_color: QColor | None = None,
                       size: int = _CTRL_ICON) -> QIcon:
-    """Icon with distinct normal and checked pixmaps."""
-    checked_color = QColor("#1e1e2e")
+    """Icon with distinct normal and checked pixmaps.
+
+    *checked_color*: color used when the button is in checked state.
+    Defaults to the theme base color (dark text on the accent fill).
+    """
+    if checked_color is None:
+        checked_color = QColor(DARK_COLORS["base"])
     icon = QIcon()
     for color, state in [
         (normal_color, QIcon.State.Off),
@@ -198,10 +204,12 @@ class _SongDelegate(QStyledItemDelegate):
     def __init__(
         self, parent=None, separator_color: str = DARK_COLORS["surface1"],
         accent_color: str = DARK_COLORS["accent"],
+        selected_text_color: str = DARK_COLORS["base"],
     ):
         super().__init__(parent)
         self._separator_color = QColor(separator_color)
         self._accent_color = QColor(accent_color)
+        self._selected_text_color = QColor(selected_text_color)
         self._playing_song_id: str | None = None
 
     def set_separator_color(self, color: str) -> None:
@@ -209,6 +217,9 @@ class _SongDelegate(QStyledItemDelegate):
 
     def set_accent_color(self, color: str) -> None:
         self._accent_color = QColor(color)
+
+    def set_selected_text_color(self, color: str) -> None:
+        self._selected_text_color = QColor(color)
 
     def set_playing_song(self, song_id: str | None) -> None:
         """Set the currently playing song ID for the 'now playing' indicator."""
@@ -225,7 +236,7 @@ class _SongDelegate(QStyledItemDelegate):
         selected = bool(option.state & QStyle.StateFlag.State_Selected)
         if selected:
             painter.fillRect(option.rect, self._accent_color)
-            text_color = QColor("#1e1e2e")  # Dark text on accent.
+            text_color = QColor(self._selected_text_color)
             sub_color = QColor(text_color)
             sub_color.setAlphaF(0.7)
         else:
@@ -335,7 +346,7 @@ class EditSongDialog(QDialog):
 REPEAT_OFF = "off"
 REPEAT_ALL = "all"
 REPEAT_ONE = "one"
-_REPEAT_CYCLE = [REPEAT_OFF, REPEAT_ALL, REPEAT_ONE]
+_REPEAT_CYCLE = (REPEAT_OFF, REPEAT_ALL, REPEAT_ONE)
 
 
 class LibraryPanel(QWidget):
@@ -395,6 +406,7 @@ class LibraryPanel(QWidget):
         ctrl_bar.setSpacing(4)
 
         icon_color = QColor(DARK_COLORS["text"])
+        checked_icon_color = QColor(DARK_COLORS["base"])
 
         # Repeat (cycles: off → all → one)
         self._repeat_btn = QPushButton()
@@ -420,7 +432,7 @@ class LibraryPanel(QWidget):
         self._shuffle_btn.setToolTip("Shuffle: off")
         self._shuffle_btn.setAccessibleName("Shuffle")
         self._shuffle_btn.setIcon(
-            _make_toggle_icon(_draw_shuffle, icon_color)
+            _make_toggle_icon(_draw_shuffle, icon_color, checked_icon_color)
         )
         self._shuffle_btn.setIconSize(QSize(_CTRL_ICON, _CTRL_ICON))
         self._shuffle_btn.toggled.connect(self._on_shuffle_toggled)
@@ -500,16 +512,13 @@ class LibraryPanel(QWidget):
     def _update_repeat_ui(self) -> None:
         self._repeat_btn.setIcon(self._repeat_icons[self._repeat_mode])
         labels = {REPEAT_OFF: "off", REPEAT_ALL: "all", REPEAT_ONE: "one"}
-        tip = f"Repeat: {labels[self._repeat_mode]}"
-        self._repeat_btn.setToolTip(tip)
-        # Visual: when active (all/one), show as "checked" style.
-        self._repeat_btn.setStyleSheet(
-            "" if self._repeat_mode == REPEAT_OFF else ""
-        )
-        # Use the checked property to style active state via QSS.
+        self._repeat_btn.setToolTip(f"Repeat: {labels[self._repeat_mode]}")
+        # Use the checked property to style active state via QSS, but
+        # keep the button non-checkable so each click cycles modes
+        # instead of toggling.
         self._repeat_btn.setCheckable(True)
         self._repeat_btn.setChecked(self._repeat_mode != REPEAT_OFF)
-        self._repeat_btn.setCheckable(False)  # Prevent toggle on next click.
+        self._repeat_btn.setCheckable(False)
 
     def _update_shuffle_ui(self) -> None:
         tip = f"Shuffle: {'on' if self._shuffle_enabled else 'off'}"
@@ -532,8 +541,10 @@ class LibraryPanel(QWidget):
         """Update delegate colors and control icons for the current theme."""
         self._song_delegate.set_separator_color(colors["surface1"])
         self._song_delegate.set_accent_color(colors["accent"])
+        self._song_delegate.set_selected_text_color(colors["base"])
 
         icon_color = QColor(colors["text"])
+        checked_icon_color = QColor(colors["base"])
         self._repeat_icons = {
             REPEAT_OFF: _make_icon(_draw_repeat, icon_color),
             REPEAT_ALL: _make_icon(_draw_repeat, icon_color),
@@ -541,7 +552,7 @@ class LibraryPanel(QWidget):
         }
         self._update_repeat_ui()
         self._shuffle_btn.setIcon(
-            _make_toggle_icon(_draw_shuffle, icon_color)
+            _make_toggle_icon(_draw_shuffle, icon_color, checked_icon_color)
         )
         self._prev_btn.setIcon(_make_icon(_draw_prev, icon_color))
         self._next_btn.setIcon(_make_icon(_draw_next, icon_color))

--- a/src/ui/library_panel.py
+++ b/src/ui/library_panel.py
@@ -371,6 +371,7 @@ class LibraryPanel(QWidget):
         self._library = library
         self._repeat_mode: str = REPEAT_OFF
         self._shuffle_enabled: bool = False
+        self._ctrl_accent: str = DARK_COLORS["accent"]
 
         self._setup_ui()
         self.refresh()
@@ -513,12 +514,18 @@ class LibraryPanel(QWidget):
         self._repeat_btn.setIcon(self._repeat_icons[self._repeat_mode])
         labels = {REPEAT_OFF: "off", REPEAT_ALL: "all", REPEAT_ONE: "one"}
         self._repeat_btn.setToolTip(f"Repeat: {labels[self._repeat_mode]}")
-        # Use the checked property to style active state via QSS, but
-        # keep the button non-checkable so each click cycles modes
-        # instead of toggling.
-        self._repeat_btn.setCheckable(True)
-        self._repeat_btn.setChecked(self._repeat_mode != REPEAT_OFF)
-        self._repeat_btn.setCheckable(False)
+        # Apply teal background when active. The :checked pseudo-class is
+        # unreliable here because setCheckable(False) resets the checked
+        # state before Qt renders it, so we set the style directly.
+        if self._repeat_mode != REPEAT_OFF:
+            self._repeat_btn.setStyleSheet(
+                f"QPushButton#icon-btn {{"
+                f"background-color: {self._ctrl_accent};"
+                f"border: 1px solid {self._ctrl_accent};"
+                f"}}"
+            )
+        else:
+            self._repeat_btn.setStyleSheet("")
 
     def _update_shuffle_ui(self) -> None:
         tip = f"Shuffle: {'on' if self._shuffle_enabled else 'off'}"
@@ -542,6 +549,8 @@ class LibraryPanel(QWidget):
         self._song_delegate.set_separator_color(colors["surface1"])
         self._song_delegate.set_accent_color(colors["accent"])
         self._song_delegate.set_selected_text_color(colors["base"])
+        self._ctrl_accent = colors["accent"]
+        self._update_repeat_ui()  # Refresh button color with new accent.
 
         icon_color = QColor(colors["text"])
         checked_icon_color = QColor(colors["base"])

--- a/src/ui/library_panel.py
+++ b/src/ui/library_panel.py
@@ -37,7 +37,7 @@ from PySide6.QtWidgets import (
 )
 
 from src.library import Song, SongLibrary
-from src.ui.styles import DARK_COLORS
+from src.ui.styles import DARK_COLORS, ON_ACCENT
 
 # Custom data roles for two-line display.
 _ARTIST_ROLE = Qt.ItemDataRole.UserRole + 1
@@ -70,10 +70,11 @@ def _make_toggle_icon(draw_fn, normal_color: QColor,
     """Icon with distinct normal and checked pixmaps.
 
     *checked_color*: color used when the button is in checked state.
-    Defaults to the theme base color (dark text on the accent fill).
+    Defaults to ON_ACCENT (near-black) for readability on the teal accent
+    fill — works in both dark and light themes.
     """
     if checked_color is None:
-        checked_color = QColor(DARK_COLORS["base"])
+        checked_color = QColor(ON_ACCENT)
     icon = QIcon()
     for color, state in [
         (normal_color, QIcon.State.Off),
@@ -204,7 +205,7 @@ class _SongDelegate(QStyledItemDelegate):
     def __init__(
         self, parent=None, separator_color: str = DARK_COLORS["surface1"],
         accent_color: str = DARK_COLORS["accent"],
-        selected_text_color: str = DARK_COLORS["base"],
+        selected_text_color: str = ON_ACCENT,
     ):
         super().__init__(parent)
         self._separator_color = QColor(separator_color)
@@ -548,20 +549,26 @@ class LibraryPanel(QWidget):
         """Update delegate colors and control icons for the current theme."""
         self._song_delegate.set_separator_color(colors["surface1"])
         self._song_delegate.set_accent_color(colors["accent"])
-        self._song_delegate.set_selected_text_color(colors["base"])
+        # Selected rows use the teal accent fill, so the text must be
+        # readable on teal in BOTH themes -- use ON_ACCENT (near-black).
+        self._song_delegate.set_selected_text_color(ON_ACCENT)
         self._ctrl_accent = colors["accent"]
         self._update_repeat_ui()  # Refresh button color with new accent.
 
         icon_color = QColor(colors["text"])
-        checked_icon_color = QColor(colors["base"])
+        # When a button sits on the teal accent fill, use ON_ACCENT (fixed
+        # near-black) so the icon stays readable in both themes.
+        on_accent_color = QColor(ON_ACCENT)
         self._repeat_icons = {
+            # REPEAT_OFF has a neutral (grey) background — use theme text color.
             REPEAT_OFF: _make_icon(_draw_repeat, icon_color),
-            REPEAT_ALL: _make_icon(_draw_repeat, icon_color),
-            REPEAT_ONE: _make_icon(_draw_repeat_one, icon_color),
+            # REPEAT_ALL / REPEAT_ONE paint on the teal background — use on-accent.
+            REPEAT_ALL: _make_icon(_draw_repeat, on_accent_color),
+            REPEAT_ONE: _make_icon(_draw_repeat_one, on_accent_color),
         }
         self._update_repeat_ui()
         self._shuffle_btn.setIcon(
-            _make_toggle_icon(_draw_shuffle, icon_color, checked_icon_color)
+            _make_toggle_icon(_draw_shuffle, icon_color, on_accent_color)
         )
         self._prev_btn.setIcon(_make_icon(_draw_prev, icon_color))
         self._next_btn.setIcon(_make_icon(_draw_next, icon_color))

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -21,13 +21,16 @@ from PySide6.QtGui import (
     QShortcut,
 )
 from PySide6.QtWidgets import (
+    QAbstractSpinBox,
     QApplication,
     QCheckBox,
+    QComboBox,
     QDialog,
     QDialogButtonBox,
     QFileDialog,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QMainWindow,
     QMessageBox,
     QPushButton,
@@ -113,6 +116,8 @@ class MainWindow(QMainWindow):
         self._current_song_id: str | None = None
         self._export_worker: ExportWorker | None = None
         self._shuffle_queue: list[str] = []
+        self._volume_toast: QLabel | None = None
+        self._volume_toast_timer: QTimer | None = None
 
         self._settings = QSettings("stemma", "stemma")
         self._theme = self._settings.value("theme", "dark")
@@ -244,30 +249,28 @@ class MainWindow(QMainWindow):
 
         All shortcuts use letters, numbers, arrows, modifiers, or F-keys
         only — no symbol keys that vary across keyboard layouts.
+
+        Shortcuts are guarded: they don't fire when the user is typing
+        into a text field, spinbox, or editable combobox. Modifier
+        combos (Ctrl+1-6, Shift+Up/Down) and F-keys bypass the guard
+        since they can't collide with normal text entry.
         """
+        g = self._guarded_shortcut  # Guarded: skipped when text input focused.
+        u = self._unguarded_shortcut  # Unguarded: always fires.
+
         # -- Playback --
-        QShortcut(QKeySequence(Qt.Key.Key_Space), self).activated.connect(
-            self._on_shortcut_play_pause
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_S), self).activated.connect(
-            self._player.stop
-        )
+        g(Qt.Key.Key_Space, self._on_shortcut_play_pause)
+        g(Qt.Key.Key_S, self._player.stop)
 
         # -- Navigation --
-        QShortcut(QKeySequence(Qt.Key.Key_Left), self).activated.connect(
-            lambda: self._player.seek(
-                max(0.0, self._player.current_seconds - 5.0)
-            )
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_Right), self).activated.connect(
-            lambda: self._player.seek(self._player.current_seconds + 5.0)
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_Home), self).activated.connect(
-            lambda: self._player.seek(0.0)
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_End), self).activated.connect(
-            lambda: self._player.seek(self._player.total_seconds)
-        )
+        g(Qt.Key.Key_Left, lambda: self._player.seek(
+            max(0.0, self._player.current_seconds - 5.0)
+        ))
+        g(Qt.Key.Key_Right, lambda: self._player.seek(
+            self._player.current_seconds + 5.0
+        ))
+        g(Qt.Key.Key_Home, lambda: self._player.seek(0.0))
+        g(Qt.Key.Key_End, lambda: self._player.seek(self._player.total_seconds))
 
         # 0-9: Jump to percentage position (YouTube-style).
         for digit, key in enumerate([
@@ -275,77 +278,68 @@ class MainWindow(QMainWindow):
             Qt.Key.Key_4, Qt.Key.Key_5, Qt.Key.Key_6, Qt.Key.Key_7,
             Qt.Key.Key_8, Qt.Key.Key_9,
         ]):
-            frac = digit / 10.0
-            QShortcut(QKeySequence(key), self).activated.connect(
-                self._make_position_jumper(frac)
-            )
+            g(key, self._make_position_jumper(digit / 10.0))
 
         # -- Volume --
-        QShortcut(QKeySequence(Qt.Key.Key_Up), self).activated.connect(
-            lambda: self._adjust_master_volume(0.05)
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_Down), self).activated.connect(
-            lambda: self._adjust_master_volume(-0.05)
-        )
+        g(Qt.Key.Key_Up, lambda: self._adjust_master_volume(0.05))
+        g(Qt.Key.Key_Down, lambda: self._adjust_master_volume(-0.05))
 
-        # -- Speed (Shift+Up/Down) --
-        QShortcut(
-            QKeySequence(Qt.Modifier.SHIFT | Qt.Key.Key_Up), self
-        ).activated.connect(
-            lambda: self._player_controls.cycle_speed(1)
-        )
-        QShortcut(
-            QKeySequence(Qt.Modifier.SHIFT | Qt.Key.Key_Down), self
-        ).activated.connect(
-            lambda: self._player_controls.cycle_speed(-1)
-        )
+        # -- Speed (Shift+Up/Down) -- unguarded: modifier combos can't
+        # collide with text entry.
+        u(Qt.Modifier.SHIFT | Qt.Key.Key_Up,
+          lambda: self._player_controls.cycle_speed(1))
+        u(Qt.Modifier.SHIFT | Qt.Key.Key_Down,
+          lambda: self._player_controls.cycle_speed(-1))
 
         # -- Loop --
-        QShortcut(QKeySequence(Qt.Key.Key_A), self).activated.connect(
-            self._player_controls.set_loop_a
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_B), self).activated.connect(
-            self._player_controls.set_loop_b
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_L), self).activated.connect(
-            self._player_controls.toggle_looping
-        )
+        g(Qt.Key.Key_A, self._player_controls.set_loop_a)
+        g(Qt.Key.Key_B, self._player_controls.set_loop_b)
+        g(Qt.Key.Key_L, self._player_controls.toggle_looping)
 
         # -- Metronome / Count-in / Recording --
-        QShortcut(QKeySequence(Qt.Key.Key_M), self).activated.connect(
-            self._player_controls.toggle_metronome
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_C), self).activated.connect(
-            self._player_controls.toggle_count_in
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_R), self).activated.connect(
-            self._player_controls.toggle_record
-        )
+        g(Qt.Key.Key_M, self._player_controls.toggle_metronome)
+        g(Qt.Key.Key_C, self._player_controls.toggle_count_in)
+        g(Qt.Key.Key_R, self._player_controls.toggle_record)
 
-        # -- Stems (Ctrl+1-6) --
+        # -- Stems (Ctrl+1-6) -- unguarded: Ctrl+digit isn't normal typing.
         stem_order = list(ALL_STEM_NAMES)
         for i, key in enumerate([
             Qt.Key.Key_1, Qt.Key.Key_2, Qt.Key.Key_3,
             Qt.Key.Key_4, Qt.Key.Key_5, Qt.Key.Key_6,
         ]):
             stem_name = stem_order[i]
-            QShortcut(
-                QKeySequence(Qt.Modifier.CTRL | key), self
-            ).activated.connect(
-                self._make_mute_toggler(stem_name)
-            )
+            u(Qt.Modifier.CTRL | key, self._make_mute_toggler(stem_name))
 
         # -- Library navigation --
-        QShortcut(QKeySequence(Qt.Key.Key_N), self).activated.connect(
-            lambda: self._advance_song(1)
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_P), self).activated.connect(
-            lambda: self._advance_song(-1)
-        )
+        g(Qt.Key.Key_N, lambda: self._advance_song(1))
+        g(Qt.Key.Key_P, lambda: self._advance_song(-1))
 
-        # -- Help --
-        QShortcut(QKeySequence(Qt.Key.Key_F1), self).activated.connect(
-            self._on_keyboard_shortcuts
+        # -- Help -- unguarded: F-keys don't collide with text entry.
+        u(Qt.Key.Key_F1, self._on_keyboard_shortcuts)
+
+    def _guarded_shortcut(self, key, handler) -> None:
+        """Register *handler* for *key*, skipped when a text input is focused.
+
+        Prevents single-letter/digit shortcuts from stealing keystrokes
+        meant for the library search box, spinboxes, or editable combos.
+        """
+        def wrapped():
+            if self._text_input_has_focus():
+                return
+            handler()
+        QShortcut(QKeySequence(key), self).activated.connect(wrapped)
+
+    def _unguarded_shortcut(self, key, handler) -> None:
+        """Register *handler* for *key*. Fires regardless of focus."""
+        QShortcut(QKeySequence(key), self).activated.connect(handler)
+
+    def _text_input_has_focus(self) -> bool:
+        """True when focus is on a widget that should absorb key input."""
+        w = QApplication.focusWidget()
+        if w is None:
+            return False
+        return isinstance(w, (QLineEdit, QAbstractSpinBox)) or (
+            isinstance(w, QComboBox) and w.isEditable()
         )
 
     def _make_mute_toggler(self, stem_name: str):
@@ -364,6 +358,44 @@ class MainWindow(QMainWindow):
         """Adjust master volume by *delta* (clamped 0.0–2.0)."""
         new_vol = max(0.0, min(2.0, self._player.master_volume + delta))
         self._player.set_master_volume(new_vol)
+        self._show_volume_toast(new_vol)
+
+    def _show_volume_toast(self, volume: float) -> None:
+        """Show a transient overlay with the current master volume."""
+        if self._volume_toast is None:
+            toast = QLabel(self)
+            toast.setObjectName("volume-toast")
+            toast.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            toast.setAttribute(
+                Qt.WidgetAttribute.WA_TransparentForMouseEvents, True
+            )
+            # Catppuccin mocha crust with bright text — readable on both
+            # themes without extra theme plumbing.
+            toast.setStyleSheet(
+                "background-color: rgba(17, 17, 27, 220);"
+                "color: #cdd6f4;"
+                "padding: 6px 14px;"
+                "border-radius: 6px;"
+                "font-size: 11pt;"
+            )
+            self._volume_toast = toast
+
+            timer = QTimer(self)
+            timer.setSingleShot(True)
+            timer.setInterval(1500)
+            timer.timeout.connect(self._volume_toast.hide)
+            self._volume_toast_timer = timer
+
+        pct = int(round(volume * 100))
+        self._volume_toast.setText(f"Volume: {pct}%")
+        self._volume_toast.adjustSize()
+        # Top-center of the main window.
+        x = (self.width() - self._volume_toast.width()) // 2
+        y = 24
+        self._volume_toast.move(x, y)
+        self._volume_toast.show()
+        self._volume_toast.raise_()
+        self._volume_toast_timer.start()
 
     def _on_shortcut_play_pause(self) -> None:
         """Toggle play/pause via keyboard shortcut."""
@@ -530,6 +562,9 @@ class MainWindow(QMainWindow):
             "session/volumes", json.dumps(self._player.volumes)
         )
         self._settings.setValue(
+            "session/master_volume", self._player.master_volume
+        )
+        self._settings.setValue(
             "session/nudge_offsets",
             json.dumps(self._player.nudge_offsets),
         )
@@ -646,6 +681,15 @@ class MainWindow(QMainWindow):
             nudge_offsets = {}
 
         self._player_controls.restore_stem_state(muted, soloed, volumes)
+
+        # Master volume
+        try:
+            master_vol = float(
+                self._settings.value("session/master_volume", 1.0)
+            )
+        except (TypeError, ValueError):
+            master_vol = 1.0
+        self._player.set_master_volume(master_vol)
 
         # Loop points
         try:
@@ -1015,24 +1059,30 @@ class MainWindow(QMainWindow):
         if mode == REPEAT_OFF:
             return  # Stop — current behaviour.
         # REPEAT_ALL → advance to the next song.
-        self._advance_song(1, auto=True)
+        self._advance_song(1)
 
-    def _advance_song(self, direction: int = 1, auto: bool = False) -> None:
-        """Move to the next or previous song in the library.
+    def _advance_song(self, direction: int = 1) -> None:
+        """Move to the next or previous song in the library and play it.
 
         *direction*: +1 for next, -1 for previous.
-        *auto*: True when triggered by autoplay (obeys repeat boundary rules).
+
+        Stem loading (via `_on_song_selected`) is synchronous, so by the
+        time `select_song` returns the player is ready to start.
         """
         next_id = self._get_next_song_id(direction)
         if next_id is None:
             return
         self._library_panel.select_song(next_id)
-        # select_song triggers _on_song_selected → loads stems.
-        # Delay play() slightly so stems finish loading.
-        QTimer.singleShot(100, self._player.play)
+        self._player.play()
 
     def _get_next_song_id(self, direction: int = 1) -> str | None:
-        """Resolve the next song ID respecting shuffle and repeat."""
+        """Resolve the next song ID respecting shuffle and repeat.
+
+        Shuffle only affects *forward* navigation (direction == 1).
+        Pressing Previous during shuffle falls through to sequential
+        behaviour — matching YouTube / Spotify semantics where "back"
+        means "the song I was just on", not "back in shuffle order".
+        """
         songs = self._library_panel.song_ids_in_order()
         if not songs:
             return None

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -8,6 +8,7 @@ Menu bar: File / Edit / Help; theme toggle in the menu bar corner.
 import glob
 import json
 import os
+import random
 
 import soundfile as sf
 from PySide6.QtCore import QPointF, QSettings, QSize, Qt, QTimer
@@ -49,7 +50,7 @@ from src.library import SongLibrary
 from src.model_manager import ModelManager
 from src.player import MultiTrackPlayer
 from src.ui.animated_logo import AnimatedLogoWidget
-from src.ui.library_panel import LibraryPanel
+from src.ui.library_panel import REPEAT_ALL, REPEAT_OFF, REPEAT_ONE, LibraryPanel
 from src.ui.player_controls import PlayerControls, _format_time
 from src.ui.styles import get_colors, get_stylesheet
 from src.version import __version__
@@ -111,6 +112,7 @@ class MainWindow(QMainWindow):
         self._model_manager = model_manager
         self._current_song_id: str | None = None
         self._export_worker: ExportWorker | None = None
+        self._shuffle_queue: list[str] = []
 
         self._settings = QSettings("stemma", "stemma")
         self._theme = self._settings.value("theme", "dark")
@@ -238,13 +240,20 @@ class MainWindow(QMainWindow):
         about_action.triggered.connect(self._on_about)
 
     def _setup_shortcuts(self) -> None:
-        """Register global keyboard shortcuts."""
+        """Register global keyboard shortcuts (layout-independent).
+
+        All shortcuts use letters, numbers, arrows, modifiers, or F-keys
+        only — no symbol keys that vary across keyboard layouts.
+        """
+        # -- Playback --
         QShortcut(QKeySequence(Qt.Key.Key_Space), self).activated.connect(
             self._on_shortcut_play_pause
         )
         QShortcut(QKeySequence(Qt.Key.Key_S), self).activated.connect(
             self._player.stop
         )
+
+        # -- Navigation --
         QShortcut(QKeySequence(Qt.Key.Key_Left), self).activated.connect(
             lambda: self._player.seek(
                 max(0.0, self._player.current_seconds - 5.0)
@@ -253,7 +262,45 @@ class MainWindow(QMainWindow):
         QShortcut(QKeySequence(Qt.Key.Key_Right), self).activated.connect(
             lambda: self._player.seek(self._player.current_seconds + 5.0)
         )
+        QShortcut(QKeySequence(Qt.Key.Key_Home), self).activated.connect(
+            lambda: self._player.seek(0.0)
+        )
+        QShortcut(QKeySequence(Qt.Key.Key_End), self).activated.connect(
+            lambda: self._player.seek(self._player.total_seconds)
+        )
 
+        # 0-9: Jump to percentage position (YouTube-style).
+        for digit, key in enumerate([
+            Qt.Key.Key_0, Qt.Key.Key_1, Qt.Key.Key_2, Qt.Key.Key_3,
+            Qt.Key.Key_4, Qt.Key.Key_5, Qt.Key.Key_6, Qt.Key.Key_7,
+            Qt.Key.Key_8, Qt.Key.Key_9,
+        ]):
+            frac = digit / 10.0
+            QShortcut(QKeySequence(key), self).activated.connect(
+                self._make_position_jumper(frac)
+            )
+
+        # -- Volume --
+        QShortcut(QKeySequence(Qt.Key.Key_Up), self).activated.connect(
+            lambda: self._adjust_master_volume(0.05)
+        )
+        QShortcut(QKeySequence(Qt.Key.Key_Down), self).activated.connect(
+            lambda: self._adjust_master_volume(-0.05)
+        )
+
+        # -- Speed (Shift+Up/Down) --
+        QShortcut(
+            QKeySequence(Qt.Modifier.SHIFT | Qt.Key.Key_Up), self
+        ).activated.connect(
+            lambda: self._player_controls.cycle_speed(1)
+        )
+        QShortcut(
+            QKeySequence(Qt.Modifier.SHIFT | Qt.Key.Key_Down), self
+        ).activated.connect(
+            lambda: self._player_controls.cycle_speed(-1)
+        )
+
+        # -- Loop --
         QShortcut(QKeySequence(Qt.Key.Key_A), self).activated.connect(
             self._player_controls.set_loop_a
         )
@@ -264,13 +311,7 @@ class MainWindow(QMainWindow):
             self._player_controls.toggle_looping
         )
 
-        QShortcut(QKeySequence(Qt.Key.Key_BracketRight), self).activated.connect(
-            lambda: self._player_controls.cycle_speed(1)
-        )
-        QShortcut(QKeySequence(Qt.Key.Key_BracketLeft), self).activated.connect(
-            lambda: self._player_controls.cycle_speed(-1)
-        )
-
+        # -- Metronome / Count-in / Recording --
         QShortcut(QKeySequence(Qt.Key.Key_M), self).activated.connect(
             self._player_controls.toggle_metronome
         )
@@ -281,21 +322,48 @@ class MainWindow(QMainWindow):
             self._player_controls.toggle_record
         )
 
+        # -- Stems (Ctrl+1-6) --
         stem_order = list(ALL_STEM_NAMES)
         for i, key in enumerate([
             Qt.Key.Key_1, Qt.Key.Key_2, Qt.Key.Key_3,
             Qt.Key.Key_4, Qt.Key.Key_5, Qt.Key.Key_6,
         ]):
             stem_name = stem_order[i]
-            QShortcut(QKeySequence(key), self).activated.connect(
+            QShortcut(
+                QKeySequence(Qt.Modifier.CTRL | key), self
+            ).activated.connect(
                 self._make_mute_toggler(stem_name)
             )
+
+        # -- Library navigation --
+        QShortcut(QKeySequence(Qt.Key.Key_N), self).activated.connect(
+            lambda: self._advance_song(1)
+        )
+        QShortcut(QKeySequence(Qt.Key.Key_P), self).activated.connect(
+            lambda: self._advance_song(-1)
+        )
+
+        # -- Help --
+        QShortcut(QKeySequence(Qt.Key.Key_F1), self).activated.connect(
+            self._on_keyboard_shortcuts
+        )
 
     def _make_mute_toggler(self, stem_name: str):
         """Return a callable that toggles mute for a stem and updates the UI."""
         def toggle():
             self._player_controls.toggle_stem_mute(stem_name)
         return toggle
+
+    def _make_position_jumper(self, fraction: float):
+        """Return a callable that seeks to *fraction* (0.0–0.9) of the song."""
+        def jump():
+            self._player.seek(self._player.total_seconds * fraction)
+        return jump
+
+    def _adjust_master_volume(self, delta: float) -> None:
+        """Adjust master volume by *delta* (clamped 0.0–2.0)."""
+        new_vol = max(0.0, min(2.0, self._player.master_volume + delta))
+        self._player.set_master_volume(new_vol)
 
     def _on_shortcut_play_pause(self) -> None:
         """Toggle play/pause via keyboard shortcut."""
@@ -354,24 +422,38 @@ class MainWindow(QMainWindow):
         """Show a dialog listing all keyboard shortcuts."""
         dlg = QDialog(self)
         dlg.setWindowTitle("Keyboard Shortcuts")
-        dlg.setMinimumWidth(340)
+        dlg.setMinimumWidth(400)
 
         layout = QVBoxLayout(dlg)
         layout.setContentsMargins(20, 20, 20, 20)
 
         shortcuts_text = (
             "<table cellspacing='6'>"
+            "<tr><td colspan='2'><b>Playback</b></td></tr>"
             "<tr><td><b>Space</b></td><td>Play / Pause</td></tr>"
             "<tr><td><b>S</b></td><td>Stop</td></tr>"
+            "<tr><td colspan='2'><b>Navigation</b></td></tr>"
+            "<tr><td><b>0-9</b></td><td>Jump to 0%-90% position</td></tr>"
             "<tr><td><b>Left / Right</b></td><td>Seek -5s / +5s</td></tr>"
+            "<tr><td><b>Home / End</b></td><td>Jump to start / end</td></tr>"
+            "<tr><td colspan='2'><b>Volume &amp; Speed</b></td></tr>"
+            "<tr><td><b>Up / Down</b></td><td>Master volume</td></tr>"
+            "<tr><td><b>Shift+Up / Down</b></td><td>Speed up / down</td></tr>"
+            "<tr><td colspan='2'><b>Stems</b></td></tr>"
+            "<tr><td><b>Ctrl+1-6</b></td><td>Mute/unmute stem</td></tr>"
+            "<tr><td colspan='2'><b>Loop</b></td></tr>"
             "<tr><td><b>A</b></td><td>Set loop point A</td></tr>"
             "<tr><td><b>B</b></td><td>Set loop point B</td></tr>"
             "<tr><td><b>L</b></td><td>Toggle A-B loop</td></tr>"
-            "<tr><td><b>] / [</b></td><td>Speed up / down</td></tr>"
+            "<tr><td colspan='2'><b>Metronome &amp; Recording</b></td></tr>"
             "<tr><td><b>M</b></td><td>Toggle metronome</td></tr>"
             "<tr><td><b>C</b></td><td>Toggle count-in</td></tr>"
             "<tr><td><b>R</b></td><td>Arm/disarm recording</td></tr>"
-            "<tr><td><b>1-6</b></td><td>Mute/unmute stem</td></tr>"
+            "<tr><td colspan='2'><b>Library</b></td></tr>"
+            "<tr><td><b>N</b></td><td>Next song</td></tr>"
+            "<tr><td><b>P</b></td><td>Previous song</td></tr>"
+            "<tr><td colspan='2'><b>Help</b></td></tr>"
+            "<tr><td><b>F1</b></td><td>This dialog</td></tr>"
             "</table>"
         )
         label = QLabel(shortcuts_text)
@@ -514,9 +596,24 @@ class MainWindow(QMainWindow):
                 json.dumps(self._player.chord_sequence),
             )
             self._settings.setValue(f"{prefix}/det_ver", 4)
+        # Library playback mode.
+        self._settings.setValue(
+            "session/repeat_mode", self._library_panel.repeat_mode
+        )
+        self._settings.setValue(
+            "session/shuffle_enabled", self._library_panel.shuffle_enabled
+        )
 
     def _restore_session(self) -> None:
         """Reload the last song and player state from QSettings."""
+        # Library playback mode.
+        repeat = str(self._settings.value("session/repeat_mode", REPEAT_OFF) or REPEAT_OFF)
+        self._library_panel.set_repeat_mode(repeat)
+        shuffle = self._settings.value("session/shuffle_enabled", False)
+        if isinstance(shuffle, str):
+            shuffle = shuffle.lower() == "true"
+        self._library_panel.set_shuffle_enabled(bool(shuffle))
+
         song_id = self._settings.value("session/song_id", "")
         if not song_id:
             return
@@ -710,6 +807,14 @@ class MainWindow(QMainWindow):
     def _connect_signals(self) -> None:
         """Wire up signals between panels."""
         self._library_panel.song_selected.connect(self._on_song_selected)
+        self._library_panel.previous_requested.connect(
+            lambda: self._advance_song(-1)
+        )
+        self._library_panel.next_requested.connect(
+            lambda: self._advance_song(1)
+        )
+        self._library_panel.shuffle_toggled.connect(self._on_shuffle_toggled)
+        self._player.play_finished.connect(self._on_play_finished)
         self._player.playback_failed.connect(self._on_playback_failed)
         self._player.recording_saved.connect(self._on_recording_saved)
 
@@ -787,6 +892,7 @@ class MainWindow(QMainWindow):
             self._player.stop()
             self._player.load_stems(stem_paths)
             self._current_song_id = song_id
+            self._library_panel.set_playing_song(song_id)
 
             # Restore previously detected values for this song (if any).
             prefix = f"detection/{song_id}"
@@ -894,6 +1000,78 @@ class MainWindow(QMainWindow):
                 row.set_volume_slider(int(volumes[name] * 100))
             if name in nudges:
                 row._nudge_spin.setValue(int(nudges[name]))
+
+    # ------------------------------------------------------------------
+    # Autoplay / Next / Previous
+    # ------------------------------------------------------------------
+
+    def _on_play_finished(self) -> None:
+        """Handle end-of-song: advance based on repeat mode."""
+        mode = self._library_panel.repeat_mode
+        if mode == REPEAT_ONE:
+            self._player.seek(0)
+            self._player.play()
+            return
+        if mode == REPEAT_OFF:
+            return  # Stop — current behaviour.
+        # REPEAT_ALL → advance to the next song.
+        self._advance_song(1, auto=True)
+
+    def _advance_song(self, direction: int = 1, auto: bool = False) -> None:
+        """Move to the next or previous song in the library.
+
+        *direction*: +1 for next, -1 for previous.
+        *auto*: True when triggered by autoplay (obeys repeat boundary rules).
+        """
+        next_id = self._get_next_song_id(direction)
+        if next_id is None:
+            return
+        self._library_panel.select_song(next_id)
+        # select_song triggers _on_song_selected → loads stems.
+        # Delay play() slightly so stems finish loading.
+        QTimer.singleShot(100, self._player.play)
+
+    def _get_next_song_id(self, direction: int = 1) -> str | None:
+        """Resolve the next song ID respecting shuffle and repeat."""
+        songs = self._library_panel.song_ids_in_order()
+        if not songs:
+            return None
+
+        # Shuffle: return from the shuffled queue (forward only).
+        if self._library_panel.shuffle_enabled and direction == 1:
+            return self._pop_shuffle_queue(songs)
+
+        # Sequential: find current index and step.
+        if self._current_song_id not in songs:
+            return songs[0] if songs else None
+        idx = songs.index(self._current_song_id)
+        next_idx = idx + direction
+        if self._library_panel.repeat_mode == REPEAT_ALL:
+            next_idx = next_idx % len(songs)
+        if 0 <= next_idx < len(songs):
+            return songs[next_idx]
+        return None
+
+    def _pop_shuffle_queue(self, songs: list[str]) -> str | None:
+        """Pop the next song from the shuffle queue, regenerating if needed."""
+        # Filter out stale IDs and the current song.
+        song_set = set(songs)
+        self._shuffle_queue = [
+            sid for sid in self._shuffle_queue
+            if sid in song_set and sid != self._current_song_id
+        ]
+        if not self._shuffle_queue:
+            candidates = [sid for sid in songs if sid != self._current_song_id]
+            if not candidates:
+                return None
+            random.shuffle(candidates)
+            self._shuffle_queue = candidates
+        return self._shuffle_queue.pop(0)
+
+    def _on_shuffle_toggled(self, enabled: bool) -> None:
+        """Reset the shuffle queue when shuffle is toggled."""
+        if not enabled:
+            self._shuffle_queue.clear()
 
     def _on_recording_saved(self, path: str) -> None:
         """Handle a newly saved recording: load it and add a UI row."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -459,37 +459,61 @@ class MainWindow(QMainWindow):
         layout = QVBoxLayout(dlg)
         layout.setContentsMargins(20, 20, 20, 20)
 
+        colors = get_colors(self._theme)
+        accent = colors["accent"]
+        surface1 = colors["surface1"]
+
+        def section(title: str, first: bool = False) -> str:
+            spacer = "" if first else (
+                f"<tr><td colspan='2' style='padding-top:10px;"
+                f"border-top:1px solid {surface1};'></td></tr>"
+            )
+            return (
+                spacer
+                + f"<tr><td colspan='2' style='padding-top:4px;padding-bottom:2px;'>"
+                f"<span style='color:{accent};font-weight:600;'>{title}</span>"
+                f"</td></tr>"
+            )
+
+        def row(key: str, desc: str) -> str:
+            return (
+                f"<tr>"
+                f"<td style='padding:2px 16px 2px 8px;white-space:nowrap;'><b>{key}</b></td>"
+                f"<td style='padding:2px 8px 2px 0;'>{desc}</td>"
+                f"</tr>"
+            )
+
         shortcuts_text = (
-            "<table cellspacing='6'>"
-            "<tr><td colspan='2'><b>Playback</b></td></tr>"
-            "<tr><td><b>Space</b></td><td>Play / Pause</td></tr>"
-            "<tr><td><b>S</b></td><td>Stop</td></tr>"
-            "<tr><td colspan='2'><b>Navigation</b></td></tr>"
-            "<tr><td><b>0-9</b></td><td>Jump to 0%-90% position</td></tr>"
-            "<tr><td><b>Left / Right</b></td><td>Seek -5s / +5s</td></tr>"
-            "<tr><td><b>Home / End</b></td><td>Jump to start / end</td></tr>"
-            "<tr><td colspan='2'><b>Volume &amp; Speed</b></td></tr>"
-            "<tr><td><b>Up / Down</b></td><td>Master volume</td></tr>"
-            "<tr><td><b>Shift+Up / Down</b></td><td>Speed up / down</td></tr>"
-            "<tr><td colspan='2'><b>Stems</b></td></tr>"
-            "<tr><td><b>Ctrl+1-6</b></td><td>Mute/unmute stem</td></tr>"
-            "<tr><td colspan='2'><b>Loop</b></td></tr>"
-            "<tr><td><b>A</b></td><td>Set loop point A</td></tr>"
-            "<tr><td><b>B</b></td><td>Set loop point B</td></tr>"
-            "<tr><td><b>L</b></td><td>Toggle A-B loop</td></tr>"
-            "<tr><td colspan='2'><b>Metronome &amp; Recording</b></td></tr>"
-            "<tr><td><b>M</b></td><td>Toggle metronome</td></tr>"
-            "<tr><td><b>C</b></td><td>Toggle count-in</td></tr>"
-            "<tr><td><b>R</b></td><td>Arm/disarm recording</td></tr>"
-            "<tr><td colspan='2'><b>Library</b></td></tr>"
-            "<tr><td><b>N</b></td><td>Next song</td></tr>"
-            "<tr><td><b>P</b></td><td>Previous song</td></tr>"
-            "<tr><td colspan='2'><b>Help</b></td></tr>"
-            "<tr><td><b>F1</b></td><td>This dialog</td></tr>"
-            "</table>"
+            "<table cellspacing='0' cellpadding='0'>"
+            + section("Playback", first=True)
+            + row("Space", "Play / Pause")
+            + row("S", "Stop")
+            + section("Navigation")
+            + row("0-9", "Jump to 0%–90% position")
+            + row("Left / Right", "Seek −5s / +5s")
+            + row("Home / End", "Jump to start / end")
+            + section("Volume &amp; Speed")
+            + row("Up / Down", "Master volume")
+            + row("Shift+Up / Down", "Speed up / down")
+            + section("Stems")
+            + row("Ctrl+1-6", "Mute/unmute stem")
+            + section("Loop")
+            + row("A", "Set loop point A")
+            + row("B", "Set loop point B")
+            + row("L", "Toggle A-B loop")
+            + section("Metronome &amp; Recording")
+            + row("M", "Toggle metronome")
+            + row("C", "Toggle count-in")
+            + row("R", "Arm/disarm recording")
+            + section("Library")
+            + row("N", "Next song")
+            + row("P", "Previous song")
+            + section("Help")
+            + row("F1", "This dialog")
+            + "</table>"
         )
         label = QLabel(shortcuts_text)
-        label.setWordWrap(True)
+        label.setWordWrap(False)
         layout.addWidget(label)
 
         buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -35,6 +35,7 @@ from src.ui.styles import (
     CONFIDENCE_COLORS,
     DARK_COLORS,
     LIGHT_COLORS,
+    ON_ACCENT,
     RECORDING_COLOR,
     STEM_COLORS_DARK,
     STEM_COLORS_LIGHT,
@@ -242,12 +243,16 @@ def _draw_repeat(p: QPainter, s: int) -> None:
 
 _STEM_ICON_SIZE = 18
 
-_CHECKED_ICON_COLOR = QColor("#ffffff")
+_CHECKED_ICON_COLOR = QColor(ON_ACCENT)
 
 
 def _make_toggle_icon(draw_fn, normal_color: QColor,
                       size: int = _ICON_SIZE) -> QIcon:
-    """Create an icon with distinct normal (theme text) and checked (white) pixmaps."""
+    """Create an icon with distinct normal (theme text) and checked (on-accent) pixmaps.
+
+    The checked pixmap uses a fixed near-black (styles.ON_ACCENT) so the icon
+    stays readable against the teal accent fill in both dark and light themes.
+    """
     icon = QIcon()
     for color, state in [
         (normal_color, QIcon.State.Off),

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -32,6 +32,7 @@ from src.player import SPEED_PRESETS, MultiTrackPlayer
 from src.ui.animated_arpeggio import AnimatedArpeggioWidget
 from src.ui.animated_logo import AnimatedLogoWidget
 from src.ui.styles import (
+    CONFIDENCE_COLORS,
     DARK_COLORS,
     LIGHT_COLORS,
     RECORDING_COLOR,
@@ -535,10 +536,8 @@ class PlayerControls(QWidget):
         empty_layout.addWidget(self._empty_logo, alignment=Qt.AlignmentFlag.AlignHCenter)
 
         self._hint_label = QLabel("Drop an audio file or use File > Import")
+        self._hint_label.setObjectName("subtle-label")
         self._hint_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self._hint_label.setStyleSheet(
-            f"color: {colors['surface2']}; margin-top: 0px;"
-        )
         empty_layout.addWidget(self._hint_label, alignment=Qt.AlignmentFlag.AlignHCenter)
 
         empty_layout.addStretch(1)
@@ -559,6 +558,7 @@ class PlayerControls(QWidget):
         self._stop_icon = _make_icon(_draw_stop, icon_color)
 
         self._play_btn = QPushButton()
+        self._play_btn.setObjectName("icon-btn")
         self._play_btn.setIcon(self._play_icon)
         self._play_btn.setIconSize(QSize(_ICON_SIZE, _ICON_SIZE))
         self._play_btn.setFixedSize(36, 36)
@@ -568,6 +568,7 @@ class PlayerControls(QWidget):
         transport.addWidget(self._play_btn)
 
         self._stop_btn = QPushButton()
+        self._stop_btn.setObjectName("icon-btn")
         self._stop_btn.setIcon(self._stop_icon)
         self._stop_btn.setIconSize(QSize(_ICON_SIZE, _ICON_SIZE))
         self._stop_btn.setFixedSize(36, 36)
@@ -580,6 +581,7 @@ class PlayerControls(QWidget):
             _draw_record, QColor(RECORDING_COLOR)
         )
         self._record_btn = QPushButton()
+        self._record_btn.setObjectName("icon-btn")
         self._record_btn.setIcon(self._record_icon)
         self._record_btn.setIconSize(QSize(_ICON_SIZE, _ICON_SIZE))
         self._record_btn.setFixedSize(36, 36)
@@ -651,12 +653,8 @@ class PlayerControls(QWidget):
 
         # -- Waveform display --
         self._waveform_frame = QFrame()
+        self._waveform_frame.setObjectName("card-frame")
         self._waveform_frame.setFrameShape(QFrame.Shape.StyledPanel)
-        self._waveform_frame.setStyleSheet(
-            f"QFrame {{ background-color: {colors['mantle']}; "
-            f"border: 1px solid {colors['surface0']}; "
-            f"border-radius: 6px; }}"
-        )
         wf_layout = QVBoxLayout(self._waveform_frame)
         wf_layout.setContentsMargins(4, 4, 4, 4)
 
@@ -699,13 +697,14 @@ class PlayerControls(QWidget):
         loop_speed_bar.addWidget(self._loop_clear_btn)
 
         self._loop_label = QLabel("")
-        self._loop_label.setStyleSheet(f"color: {colors['surface2']};")
+        self._loop_label.setObjectName("subtle-label")
         loop_speed_bar.addWidget(self._loop_label)
 
         self._key_label = QLabel("")
         self._key_label.setTextFormat(Qt.TextFormat.RichText)
         self._key_label.setToolTip("Detected musical key (double-click to re-detect)")
         self._key_label.setAccessibleName("Detected key")
+        self._key_label.setObjectName("subtle-label")
         self._key_label.setCursor(Qt.CursorShape.PointingHandCursor)
         self._key_label.installEventFilter(self)
         loop_speed_bar.addWidget(self._key_label)
@@ -717,7 +716,7 @@ class PlayerControls(QWidget):
         loop_speed_bar.addWidget(self._chord_label)
 
         self._speed_status = QLabel("")
-        self._speed_status.setStyleSheet(f"color: {colors['surface2']};")
+        self._speed_status.setObjectName("subtle-label")
         loop_speed_bar.addWidget(self._speed_status)
 
         loop_speed_bar.addStretch()
@@ -830,6 +829,7 @@ class PlayerControls(QWidget):
             "Detected tempo — suggestion only (double-click to re-detect)"
         )
         self._detected_bpm_label.setAccessibleName("Detected BPM")
+        self._detected_bpm_label.setObjectName("subtle-label")
         self._detected_bpm_label.setCursor(Qt.CursorShape.PointingHandCursor)
         self._detected_bpm_label.installEventFilter(self)
         metro_ci_bar.addWidget(self._detected_bpm_label)
@@ -843,12 +843,8 @@ class PlayerControls(QWidget):
         controls_layout.addWidget(self._mixer_label)
 
         self._stems_frame = QFrame()
+        self._stems_frame.setObjectName("card-frame")
         self._stems_frame.setFrameShape(QFrame.Shape.StyledPanel)
-        self._stems_frame.setStyleSheet(
-            f"QFrame {{ background-color: {colors['mantle']}; "
-            f"border: 1px solid {colors['surface0']}; "
-            f"border-radius: 6px; }}"
-        )
         self._stem_container = QVBoxLayout(self._stems_frame)
         self._stem_container.setContentsMargins(6, 4, 6, 4)
         self._stem_container.setSpacing(2)
@@ -860,12 +856,8 @@ class PlayerControls(QWidget):
         controls_layout.addWidget(self._recordings_label)
 
         self._recordings_frame = QFrame()
+        self._recordings_frame.setObjectName("card-frame")
         self._recordings_frame.setFrameShape(QFrame.Shape.StyledPanel)
-        self._recordings_frame.setStyleSheet(
-            f"QFrame {{ background-color: {colors['mantle']}; "
-            f"border: 1px solid {colors['surface0']}; "
-            f"border-radius: 6px; }}"
-        )
         self._recordings_frame.setVisible(False)
         self._recordings_container = QVBoxLayout(self._recordings_frame)
         self._recordings_container.setContentsMargins(6, 4, 6, 4)
@@ -879,19 +871,15 @@ class PlayerControls(QWidget):
 
         # -- Footer bar --
         self._footer_widget = QWidget()
+        self._footer_widget.setObjectName("footer")
         self._footer_widget.setFixedHeight(44)
-        self._footer_widget.setStyleSheet(
-            f"border-top: 1px solid {colors['surface0']};"
-        )
         footer_layout = QHBoxLayout(self._footer_widget)
         footer_layout.setContentsMargins(0, 5, 0, 2)
 
         self._copyright_label = QLabel("\u00A9 2026 stemma")
+        self._copyright_label.setObjectName("copyright")
         self._copyright_label.setFixedHeight(36)
         self._copyright_label.setAlignment(Qt.AlignmentFlag.AlignVCenter)
-        self._copyright_label.setStyleSheet(
-            f"color: {colors['surface1']}; font-size: 9pt; border: none;"
-        )
         footer_layout.addWidget(self._copyright_label)
 
         footer_layout.addStretch()
@@ -925,12 +913,6 @@ class PlayerControls(QWidget):
         self._count_in_repeats_cb.setIcon(
             _make_toggle_icon(_draw_repeat, icon_color))
 
-        # Inline-styled labels
-        self._hint_label.setStyleSheet(
-            f"color: {colors['surface2']}; margin-top: 0px;"
-        )
-        self._loop_label.setStyleSheet(f"color: {colors['surface2']};")
-        self._speed_status.setStyleSheet(f"color: {colors['surface2']};")
         # Re-apply badge style and regenerate inline HTML colours for
         # detection labels — the old Rich Text contains hardcoded colour
         # spans from the previous theme.
@@ -957,26 +939,12 @@ class PlayerControls(QWidget):
             self._chord_label.setText(
                 self._badge_html("Chord:", chord if chord else "--")
             )
-        self._footer_widget.setStyleSheet(
-            f"border-top: 1px solid {colors['surface0']};"
-        )
-        self._copyright_label.setStyleSheet(
-            f"color: {colors['surface1']}; font-size: 9pt; border: none;"
-        )
 
         # Animated logos
         self._empty_logo.set_theme(theme)
         self._arpeggio_label.set_theme(theme)
 
-        # Waveform frame and colors
-        frame_style = (
-            f"QFrame {{ background-color: {colors['mantle']}; "
-            f"border: 1px solid {colors['surface0']}; "
-            f"border-radius: 6px; }}"
-        )
-        self._waveform_frame.setStyleSheet(frame_style)
-        self._stems_frame.setStyleSheet(frame_style)
-        self._recordings_frame.setStyleSheet(frame_style)
+        # Waveform colors
         self._waveform.set_theme_colors(colors)
 
         for row in self._stem_rows.values():
@@ -1501,19 +1469,9 @@ class PlayerControls(QWidget):
         self._detection_worker = worker
         worker.start()
 
-    # Confidence label colours — Catppuccin Mocha semantic palette.
-    _CONF_COLORS_DARK = {
-        "high": "#a6e3a1", "medium": "#f9e2af", "low": "#f38ba8",
-    }
-    _CONF_COLORS_LIGHT = {
-        "high": "#40a02b", "medium": "#df8e1d", "low": "#d20f39",
-    }
-
     def _conf_color(self, level: str) -> str:
         """Return the themed colour string for a confidence level."""
-        if self._theme == "light":
-            return self._CONF_COLORS_LIGHT.get(level, "")
-        return self._CONF_COLORS_DARK.get(level, "")
+        return CONFIDENCE_COLORS[self._theme].get(level, "")
 
     def _badge_style(self) -> str:
         """Return the CSS stylesheet for a detection badge label."""

--- a/src/ui/styles.py
+++ b/src/ui/styles.py
@@ -27,6 +27,12 @@ STEM_COLORS = STEM_COLORS_DARK
 
 RECORDING_COLOR = "#d4849a"  # Brand rose -- used for recording stem rows
 
+# Foreground color to use on top of the teal accent fill. Fixed near-black
+# (Catppuccin Mocha "crust") — readable on #4fb8b8 in both dark and light
+# themes. Do NOT bind this to theme.base: in light mode base is near-white
+# and becomes invisible on teal.
+ON_ACCENT = "#11111b"
+
 CONFIDENCE_COLORS = {
     "dark": {"high": "#a6e3a1", "medium": "#f9e2af", "low": "#f38ba8"},
     "light": {"high": "#40a02b", "medium": "#df8e1d", "low": "#d20f39"},
@@ -40,6 +46,7 @@ DARK_COLORS = {
     "surface2": "#585b70",
     "text": "#cdd6f4",
     "accent": "#4fb8b8",
+    "on_accent": ON_ACCENT,
     "red": "#f38ba8",
     "item_hover": "#252536",
 }
@@ -52,6 +59,7 @@ LIGHT_COLORS = {
     "surface2": "#9ca0b0",
     "text": "#4c4f69",
     "accent": "#4fb8b8",
+    "on_accent": ON_ACCENT,
     "red": "#d20f39",
     "item_hover": "#dce0e8",
 }
@@ -149,14 +157,14 @@ QPushButton:pressed {{
 
 QPushButton:checked {{
     background-color: {c["accent"]};
-    color: {c["base"]};
+    color: {c["on_accent"]};
     border: 1px solid {c["accent"]};
 }}
 
 QPushButton:checked:hover {{
     background-color: {c["accent"]};
-    color: {c["base"]};
-    border: 1px solid {c["text"]};
+    color: {c["on_accent"]};
+    border: 1px solid {c["on_accent"]};
 }}
 
 QPushButton:disabled {{
@@ -174,11 +182,12 @@ QPushButton#icon-btn {{
 
 QPushButton#icon-btn:checked {{
     background-color: {c["accent"]};
+    color: {c["on_accent"]};
     border: 1px solid {c["accent"]};
 }}
 
 QPushButton#icon-btn:checked:hover {{
-    border: 1px solid {c["text"]};
+    border: 1px solid {c["on_accent"]};
 }}
 
 QSlider::groove:horizontal {{

--- a/src/ui/styles.py
+++ b/src/ui/styles.py
@@ -27,6 +27,11 @@ STEM_COLORS = STEM_COLORS_DARK
 
 RECORDING_COLOR = "#d4849a"  # Brand rose -- used for recording stem rows
 
+CONFIDENCE_COLORS = {
+    "dark": {"high": "#a6e3a1", "medium": "#f9e2af", "low": "#f38ba8"},
+    "light": {"high": "#40a02b", "medium": "#df8e1d", "low": "#d20f39"},
+}
+
 DARK_COLORS = {
     "base": "#1e1e2e",
     "mantle": "#181825",
@@ -364,6 +369,40 @@ QToolTip {{
     border-radius: 4px;
     padding: 4px 8px;
     font-size: 9pt;
+}}
+
+QFrame#card-frame {{
+    background-color: {c["mantle"]};
+    border: 1px solid {c["surface0"]};
+    border-radius: 6px;
+}}
+
+QSpinBox {{
+    background-color: {c["surface0"]};
+    color: {c["text"]};
+    border: 1px solid {c["surface1"]};
+    border-radius: 4px;
+    padding: 2px 4px;
+    min-height: 24px;
+}}
+
+QSpinBox:focus {{
+    border: 1px solid {c["accent"]};
+}}
+
+QSpinBox::up-button, QSpinBox::down-button {{
+    border: none;
+    width: 16px;
+}}
+
+QWidget#footer {{
+    border-top: 1px solid {c["surface0"]};
+}}
+
+QLabel#copyright {{
+    color: {c["surface1"]};
+    font-size: 9pt;
+    border: none;
 }}
 """
 

--- a/tests/test_library_playback.py
+++ b/tests/test_library_playback.py
@@ -1,0 +1,278 @@
+"""Tests for library playback controls: repeat, shuffle, next/prev, now-playing."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication
+
+from src.library import Song
+from src.ui.library_panel import (
+    REPEAT_ALL,
+    REPEAT_OFF,
+    REPEAT_ONE,
+    LibraryPanel,
+)
+
+
+@pytest.fixture(scope="module")
+def app():
+    """Ensure a QApplication exists for widget tests."""
+    instance = QApplication.instance()
+    if instance is None:
+        instance = QApplication([])
+    return instance
+
+
+def _make_library(songs: list[Song]) -> MagicMock:
+    library = MagicMock()
+    library.songs = songs
+    library.get_song.side_effect = lambda sid: next(
+        (s for s in songs if s.id == sid), None
+    )
+    return library
+
+
+def _make_songs(n: int = 5) -> list[Song]:
+    """Return *n* test songs."""
+    return [
+        Song(
+            id=str(i),
+            title=f"Song {i}",
+            artist=f"Artist {i}",
+            original_path="",
+            stems_path="",
+            model_used="",
+            date_added="",
+        )
+        for i in range(1, n + 1)
+    ]
+
+
+# ------------------------------------------------------------------
+# Repeat button
+# ------------------------------------------------------------------
+
+
+class TestRepeatMode:
+    def test_initial_mode_is_off(self, app):
+        panel = LibraryPanel(_make_library([]))
+        assert panel.repeat_mode == REPEAT_OFF
+
+    def test_cycle_off_to_all(self, app):
+        panel = LibraryPanel(_make_library([]))
+        panel._on_repeat_clicked()
+        assert panel.repeat_mode == REPEAT_ALL
+
+    def test_cycle_all_to_one(self, app):
+        panel = LibraryPanel(_make_library([]))
+        panel._on_repeat_clicked()  # off → all
+        panel._on_repeat_clicked()  # all → one
+        assert panel.repeat_mode == REPEAT_ONE
+
+    def test_cycle_one_back_to_off(self, app):
+        panel = LibraryPanel(_make_library([]))
+        for _ in range(3):
+            panel._on_repeat_clicked()
+        assert panel.repeat_mode == REPEAT_OFF
+
+    def test_set_repeat_mode_programmatic(self, app):
+        panel = LibraryPanel(_make_library([]))
+        panel.set_repeat_mode(REPEAT_ALL)
+        assert panel.repeat_mode == REPEAT_ALL
+
+    def test_set_repeat_mode_invalid_falls_back(self, app):
+        panel = LibraryPanel(_make_library([]))
+        panel.set_repeat_mode("invalid")
+        assert panel.repeat_mode == REPEAT_OFF
+
+    def test_repeat_signal_emitted(self, app):
+        panel = LibraryPanel(_make_library([]))
+        received = []
+        panel.repeat_mode_changed.connect(received.append)
+        panel._on_repeat_clicked()
+        assert received == [REPEAT_ALL]
+
+
+# ------------------------------------------------------------------
+# Shuffle button
+# ------------------------------------------------------------------
+
+
+class TestShuffle:
+    def test_initial_shuffle_off(self, app):
+        panel = LibraryPanel(_make_library([]))
+        assert not panel.shuffle_enabled
+
+    def test_toggle_shuffle_on(self, app):
+        panel = LibraryPanel(_make_library([]))
+        panel._shuffle_btn.setChecked(True)
+        assert panel.shuffle_enabled
+
+    def test_set_shuffle_programmatic(self, app):
+        panel = LibraryPanel(_make_library([]))
+        panel.set_shuffle_enabled(True)
+        assert panel.shuffle_enabled
+        assert panel._shuffle_btn.isChecked()
+
+    def test_shuffle_signal_emitted(self, app):
+        panel = LibraryPanel(_make_library([]))
+        received = []
+        panel.shuffle_toggled.connect(received.append)
+        panel._shuffle_btn.setChecked(True)
+        assert received == [True]
+
+
+# ------------------------------------------------------------------
+# Now-playing indicator
+# ------------------------------------------------------------------
+
+
+class TestNowPlaying:
+    def test_set_playing_song(self, app):
+        panel = LibraryPanel(_make_library(_make_songs()))
+        panel.set_playing_song("2")
+        assert panel._song_delegate._playing_song_id == "2"
+
+    def test_clear_playing_song(self, app):
+        panel = LibraryPanel(_make_library(_make_songs()))
+        panel.set_playing_song("2")
+        panel.set_playing_song(None)
+        assert panel._song_delegate._playing_song_id is None
+
+
+# ------------------------------------------------------------------
+# Next / Previous signals
+# ------------------------------------------------------------------
+
+
+class TestNavSignals:
+    def test_next_signal_emitted(self, app):
+        panel = LibraryPanel(_make_library(_make_songs()))
+        received = []
+        panel.next_requested.connect(lambda: received.append("next"))
+        panel._next_btn.click()
+        assert received == ["next"]
+
+    def test_previous_signal_emitted(self, app):
+        panel = LibraryPanel(_make_library(_make_songs()))
+        received = []
+        panel.previous_requested.connect(lambda: received.append("prev"))
+        panel._prev_btn.click()
+        assert received == ["prev"]
+
+
+# ------------------------------------------------------------------
+# Song ordering helpers
+# ------------------------------------------------------------------
+
+
+class TestSongOrder:
+    def test_song_ids_in_order(self, app):
+        songs = _make_songs(3)
+        panel = LibraryPanel(_make_library(songs))
+        assert panel.song_ids_in_order() == ["1", "2", "3"]
+
+    def test_song_count(self, app):
+        songs = _make_songs(4)
+        panel = LibraryPanel(_make_library(songs))
+        assert panel.song_count() == 4
+
+    def test_song_count_empty(self, app):
+        panel = LibraryPanel(_make_library([]))
+        assert panel.song_count() == 0
+
+
+# ------------------------------------------------------------------
+# MainWindow autoplay logic (unit-tested via extracted methods)
+# ------------------------------------------------------------------
+
+
+class TestNextSongResolution:
+    """Test _get_next_song_id logic by calling it on a mock MainWindow."""
+
+    def _make_main_window_stub(self, songs, current_id, repeat, shuffle):
+        """Create a minimal stub with the methods we need to test."""
+        panel = LibraryPanel(_make_library(songs))
+        panel.set_repeat_mode(repeat)
+        panel.set_shuffle_enabled(shuffle)
+
+        stub = MagicMock()
+        stub._library_panel = panel
+        stub._current_song_id = current_id
+        stub._shuffle_queue = []
+        return stub
+
+    def test_next_sequential(self, app):
+        from src.ui.main_window import MainWindow
+
+        songs = _make_songs(3)
+        stub = self._make_main_window_stub(songs, "1", REPEAT_ALL, False)
+        result = MainWindow._get_next_song_id(stub, direction=1)
+        assert result == "2"
+
+    def test_prev_sequential(self, app):
+        from src.ui.main_window import MainWindow
+
+        songs = _make_songs(3)
+        stub = self._make_main_window_stub(songs, "2", REPEAT_ALL, False)
+        result = MainWindow._get_next_song_id(stub, direction=-1)
+        assert result == "1"
+
+    def test_wrap_around_forward(self, app):
+        from src.ui.main_window import MainWindow
+
+        songs = _make_songs(3)
+        stub = self._make_main_window_stub(songs, "3", REPEAT_ALL, False)
+        result = MainWindow._get_next_song_id(stub, direction=1)
+        assert result == "1"
+
+    def test_wrap_around_backward(self, app):
+        from src.ui.main_window import MainWindow
+
+        songs = _make_songs(3)
+        stub = self._make_main_window_stub(songs, "1", REPEAT_ALL, False)
+        result = MainWindow._get_next_song_id(stub, direction=-1)
+        assert result == "3"
+
+    def test_no_wrap_when_repeat_off(self, app):
+        from src.ui.main_window import MainWindow
+
+        songs = _make_songs(3)
+        stub = self._make_main_window_stub(songs, "3", REPEAT_OFF, False)
+        result = MainWindow._get_next_song_id(stub, direction=1)
+        assert result is None
+
+    def test_empty_library(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = self._make_main_window_stub([], None, REPEAT_ALL, False)
+        result = MainWindow._get_next_song_id(stub, direction=1)
+        assert result is None
+
+    def test_shuffle_returns_different_order(self, app):
+        """Shuffle should return all songs before repeating any."""
+        from src.ui.main_window import MainWindow
+
+        songs = _make_songs(5)
+        stub = self._make_main_window_stub(songs, "1", REPEAT_ALL, True)
+
+        seen = set()
+        for _ in range(4):  # 5 songs - 1 current = 4 others
+            result = MainWindow._pop_shuffle_queue(stub, [s.id for s in songs])
+            assert result is not None
+            assert result != "1"  # Never returns current
+            seen.add(result)
+
+        assert seen == {"2", "3", "4", "5"}
+
+    def test_shuffle_excludes_current(self, app):
+        """Shuffle queue should never contain the current song."""
+        from src.ui.main_window import MainWindow
+
+        songs = _make_songs(3)
+        stub = self._make_main_window_stub(songs, "2", REPEAT_ALL, True)
+
+        for _ in range(10):
+            result = MainWindow._pop_shuffle_queue(stub, [s.id for s in songs])
+            assert result != "2"

--- a/tests/test_library_playback.py
+++ b/tests/test_library_playback.py
@@ -276,3 +276,180 @@ class TestNextSongResolution:
         for _ in range(10):
             result = MainWindow._pop_shuffle_queue(stub, [s.id for s in songs])
             assert result != "2"
+
+    def test_previous_falls_through_to_sequential_during_shuffle(self, app):
+        """Pressing Previous during shuffle uses sequential order (YouTube-style)."""
+        from src.ui.main_window import MainWindow
+
+        songs = _make_songs(3)
+        stub = self._make_main_window_stub(songs, "2", REPEAT_ALL, True)
+        # direction=-1 should NOT hit the shuffle queue.
+        result = MainWindow._get_next_song_id(stub, direction=-1)
+        assert result == "1"
+
+    def test_shuffle_toggle_off_clears_queue(self, app):
+        """Disabling shuffle on MainWindow clears the pending queue."""
+        from src.ui.main_window import MainWindow
+
+        songs = _make_songs(3)
+        stub = self._make_main_window_stub(songs, "1", REPEAT_ALL, True)
+        # Prime the queue.
+        MainWindow._pop_shuffle_queue(stub, [s.id for s in songs])
+        assert stub._shuffle_queue  # non-empty after first pop
+        # Toggle off — should clear.
+        MainWindow._on_shuffle_toggled(stub, False)
+        assert stub._shuffle_queue == []
+
+
+# ------------------------------------------------------------------
+# Master volume via shortcut
+# ------------------------------------------------------------------
+
+
+class TestMasterVolumeAdjust:
+    """_adjust_master_volume delegates to the player and clamps correctly."""
+
+    def test_adjust_adds_delta(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        stub._player.master_volume = 1.0
+        MainWindow._adjust_master_volume(stub, 0.1)
+        stub._player.set_master_volume.assert_called_once_with(
+            pytest.approx(1.1)
+        )
+
+    def test_adjust_clamps_upper(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        stub._player.master_volume = 1.95
+        MainWindow._adjust_master_volume(stub, 0.1)
+        # Caller clamps to 2.0 before calling set_master_volume.
+        stub._player.set_master_volume.assert_called_once_with(2.0)
+
+    def test_adjust_clamps_lower(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        stub._player.master_volume = 0.02
+        MainWindow._adjust_master_volume(stub, -0.1)
+        stub._player.set_master_volume.assert_called_once_with(0.0)
+
+    def test_adjust_shows_toast(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        stub._player.master_volume = 0.5
+        MainWindow._adjust_master_volume(stub, 0.1)
+        stub._show_volume_toast.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Autoplay on play_finished
+# ------------------------------------------------------------------
+
+
+class TestOnPlayFinished:
+    """Autoplay behaviour depends on the current repeat mode."""
+
+    def _make_stub(self, mode):
+        panel = LibraryPanel(_make_library(_make_songs(3)))
+        panel.set_repeat_mode(mode)
+        stub = MagicMock()
+        stub._library_panel = panel
+        stub._player = MagicMock()
+        return stub
+
+    def test_repeat_one_seeks_and_plays(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = self._make_stub(REPEAT_ONE)
+        MainWindow._on_play_finished(stub)
+        stub._player.seek.assert_called_once_with(0)
+        stub._player.play.assert_called_once()
+        stub._advance_song.assert_not_called()
+
+    def test_repeat_off_is_noop(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = self._make_stub(REPEAT_OFF)
+        MainWindow._on_play_finished(stub)
+        stub._player.seek.assert_not_called()
+        stub._player.play.assert_not_called()
+        stub._advance_song.assert_not_called()
+
+    def test_repeat_all_advances_forward(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = self._make_stub(REPEAT_ALL)
+        MainWindow._on_play_finished(stub)
+        stub._advance_song.assert_called_once_with(1)
+
+
+# ------------------------------------------------------------------
+# Shortcut focus guard
+# ------------------------------------------------------------------
+
+
+class TestShortcutFocusGuard:
+    """_text_input_has_focus returns True only for text-entry widgets."""
+
+    def test_no_focus_returns_false(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        with patch(
+            "src.ui.main_window.QApplication.focusWidget", return_value=None
+        ):
+            assert MainWindow._text_input_has_focus(stub) is False
+
+    def test_line_edit_focus_returns_true(self, app):
+        from PySide6.QtWidgets import QLineEdit
+
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        w = QLineEdit()
+        with patch(
+            "src.ui.main_window.QApplication.focusWidget", return_value=w
+        ):
+            assert MainWindow._text_input_has_focus(stub) is True
+
+    def test_spinbox_focus_returns_true(self, app):
+        from PySide6.QtWidgets import QSpinBox
+
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        w = QSpinBox()
+        with patch(
+            "src.ui.main_window.QApplication.focusWidget", return_value=w
+        ):
+            assert MainWindow._text_input_has_focus(stub) is True
+
+    def test_non_editable_combo_returns_false(self, app):
+        from PySide6.QtWidgets import QComboBox
+
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        w = QComboBox()
+        w.setEditable(False)
+        with patch(
+            "src.ui.main_window.QApplication.focusWidget", return_value=w
+        ):
+            assert MainWindow._text_input_has_focus(stub) is False
+
+    def test_editable_combo_returns_true(self, app):
+        from PySide6.QtWidgets import QComboBox
+
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        w = QComboBox()
+        w.setEditable(True)
+        with patch(
+            "src.ui.main_window.QApplication.focusWidget", return_value=w
+        ):
+            assert MainWindow._text_input_has_focus(stub) is True

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1068,3 +1068,33 @@ class TestChordSequence:
         assert len(player.chord_sequence) == 1
         player.load_stems(mock_stems)
         assert player.chord_sequence == []
+
+
+class TestMasterVolume:
+    """Master volume multiplier for all stems."""
+
+    def test_default_master_volume_is_unity(self):
+        player = MultiTrackPlayer()
+        assert player.master_volume == 1.0
+
+    def test_set_master_volume(self):
+        player = MultiTrackPlayer()
+        player.set_master_volume(0.5)
+        assert player.master_volume == 0.5
+
+    def test_master_volume_clamps_below_zero(self):
+        player = MultiTrackPlayer()
+        player.set_master_volume(-0.5)
+        assert player.master_volume == 0.0
+
+    def test_master_volume_clamps_above_two(self):
+        player = MultiTrackPlayer()
+        player.set_master_volume(5.0)
+        assert player.master_volume == 2.0
+
+    def test_master_volume_accepts_boundary_values(self):
+        player = MultiTrackPlayer()
+        player.set_master_volume(0.0)
+        assert player.master_volume == 0.0
+        player.set_master_volume(2.0)
+        assert player.master_volume == 2.0


### PR DESCRIPTION
## Summary

Three-phase update for v2.3.0 while v2.2.0 awaits MS Store approval.

### Phase 1 — UI Polish
- Centralize scattered styling via QSS objectName selectors (`card-frame`, `icon-btn`, `subtle-label`, `footer`, `copyright`, `QSpinBox` rules) in `styles.py`
- Remove ~20 hardcoded `setStyleSheet` calls from `player_controls.py`
- Move confidence colors and list delegate defaults into `styles.py`
- Transport buttons (play/stop/record) now share `icon-btn` styling with stem buttons

### Phase 2 — Library Features
- **Repeat** (off / all / one) with cycling icon button
- **Shuffle** toggle with randomized queue (all songs before repeat, excludes current)
- **Prev / Next** navigation buttons + signals
- **Now-playing indicator** — accent bar on current song in library list
- **Autoplay** on `play_finished`, respecting repeat mode
- Session persistence for `repeat_mode` and `shuffle_enabled`

### Phase 3 — Keyboard Shortcuts Overhaul (#119)
YouTube-style controls, **zero symbol keys** (works on Nordic/Finnish + all layouts):

| Key | Action |
|-----|--------|
| `Space` / `S` | Play-pause / Stop |
| `0-9` | Jump to 0%-90% position |
| `Left/Right` | Seek ±5s |
| `Home/End` | Start / End |
| `Up/Down` | Master volume ±5% |
| `Shift+Up/Down` | Speed cycle (replaces `[` / `]`) |
| `Ctrl+1-6` | Stem mute toggle (replaces bare `1-6`) |
| `A` / `B` / `L` | Loop points and toggle |
| `M` / `C` / `R` | Metronome / count-in / record |
| `N` / `P` | Next / previous song |
| `F1` | Keyboard shortcuts dialog |

Master volume added to `MultiTrackPlayer` as a gain multiplier in the audio callback.

## Test plan
- [x] 26 new tests in `test_library_playback.py` (repeat modes, shuffle queue, nav signals, now-playing, next-song resolution)
- [x] Full test suite: **621 passed, 5 skipped**
- [x] Manual: verify dark/light themes look consistent
- [x] Manual: play through 3+ songs with each repeat mode
- [x] Manual: test all shortcuts on Nordic keyboard
- [x] Manual: session save/restore of repeat + shuffle state

Closes #119