### PR TITLE
feat: v2.4.0 -- pitch shift / transposition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -25,4 +25,10 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run fast tests
+        # The offscreen QPA platform keeps Qt away from the runner's
+        # display driver entirely: real window show() on the hosted
+        # Windows image intermittently access-violates or hangs inside
+        # WM_PAINT once enough widget tests have run before it.
+        env:
+          QT_QPA_PLATFORM: offscreen
         run: pytest -m "not slow and not hardware" -v --tb=short --timeout=120

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -31,6 +31,10 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run fast tests
+        # Same offscreen rationale as ci.yml: keep Qt off the hosted
+        # runner's display driver.
+        env:
+          QT_QPA_PLATFORM: offscreen
         run: pytest -m "not slow and not hardware" -v --tb=short --timeout=120
 
       - name: Build executable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-04-18 -- v2.4.0 Pitch Shift / Transposition
+
+### Done
+- **Pitch transposition:** New Pitch spinbox in the transport bar (±7 semitones). Uses `librosa.effects.pitch_shift` for pitch-preserving transposition. `Shift+Left`/`Shift+Right` shortcuts nudge by one semitone. Layout-safe (no symbol keys).
+- **Unified stretch worker:** `SpeedWorker` replaced by `StretchWorker`, which applies pitch shift and time stretch in a single pass per channel, from the original buffers — avoids artefact compounding across chained renders. Peak amplitude preserved after phase-vocoder processing. Identity state (speed=1.0 ∧ pitch=0) is a fast-path no-op that reuses the original buffers.
+- **Effective key display:** When pitch ≠ 0, the Key badge shows `<detected> → <transposed>` (e.g. `A minor → B minor`). Tooltip includes the shift amount. `transpose_key()` helper in `beat_detector.py` handles sharp/flat alias parsing and wrap-around.
+- **Recording guard:** Recording cannot be armed while pitch ≠ 0. Recording takes are not pitch-shifted by default so playback matches what was actually performed.
+- **Sync-recording-pitch preference:** New "Pitch-shift recording takes with the stems" checkbox in the Playback group of Preferences. Toggling with an active pitch re-renders stems in place.
+- **Per-song session persistence:** Pitch value saves/restores alongside speed. Single combined stretch pass at restore when both speed and pitch are non-identity.
+- **Auto-reset on song switch:** Loading a new song resets pitch to 0 (before the saved pitch for that song restores, if any).
+
+### Metrics
+- 708 tests pass, 1 skipped. +34 new tests covering pitch clamping/signals/fast-path, combined render ordering, recording-take handling, and the `transpose_key` helper.
+
+---
+
 ## 2026-04-17 -- v2.3.0 Library, Polish & Shortcuts
 
 ### Done

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import QApplication, QMessageBox
 
 from src.paths import app_root
 from src.ui.splash_screen import SplashScreen
-from src.ui.styles import get_stylesheet
+from src.ui.styles import apply_tooltip_palette, get_stylesheet
 from src.version import __version__
 
 _ROOT_DIR = app_root()
@@ -63,6 +63,7 @@ def main() -> int:
     if theme not in ("dark", "light"):
         theme = "dark"
     qapp.setStyleSheet(get_stylesheet(theme))
+    apply_tooltip_palette(theme)
 
     if os.path.exists(_ICON_PATH):
         qapp.setWindowIcon(QIcon(_ICON_PATH))

--- a/src/app_settings.py
+++ b/src/app_settings.py
@@ -151,3 +151,14 @@ def read_latency_offset_ms(settings: QSettings) -> float:
 def read_startup_play_sound(settings: QSettings) -> bool:
     """Return True if the startup arpeggio sound should play (default True)."""
     return bool(settings.value("startup/play_sound", True, type=bool))
+
+
+def read_sync_recording_pitch(settings: QSettings) -> bool:
+    """Return True if recording takes should follow the stems' pitch shift.
+
+    Default is False — recording stems are left un-pitched so practice
+    playback matches what was actually sung/played.
+    """
+    return bool(
+        settings.value("playback/sync_recording_pitch", False, type=bool)
+    )

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -253,6 +253,35 @@ _MINOR_PROFILE = np.array([
 _KEY_NAMES = ["C", "C#", "D", "Eb", "E", "F",
               "F#", "G", "Ab", "A", "Bb", "B"]
 
+# Alias table for parsing: accept both sharp and flat spellings back to index.
+_TONIC_TO_INDEX: dict[str, int] = {name: i for i, name in enumerate(_KEY_NAMES)}
+_TONIC_TO_INDEX.update({
+    "Db": 1, "D#": 3, "Gb": 6, "G#": 8, "A#": 10,
+    "Cb": 11, "E#": 5, "Fb": 4, "B#": 0,
+})
+
+
+def transpose_key(key_str: str, n_steps: int) -> str:
+    """Transpose a key label (e.g. ``"A minor"``) by ``n_steps`` semitones.
+
+    Returns the input unchanged when it cannot be parsed. Uses the canonical
+    sharp/flat spelling defined by ``_KEY_NAMES`` (matches the detector's
+    output).
+    """
+    if not key_str or n_steps == 0:
+        return key_str
+    parts = key_str.strip().split()
+    if len(parts) != 2:
+        return key_str
+    tonic, mode = parts[0], parts[1].lower()
+    if mode not in ("major", "minor"):
+        return key_str
+    idx = _TONIC_TO_INDEX.get(tonic)
+    if idx is None:
+        return key_str
+    new_idx = (idx + int(n_steps)) % 12
+    return f"{_KEY_NAMES[new_idx]} {mode}"
+
 
 def _detect_key(
     audio_mono: np.ndarray, sr: int,

--- a/src/player.py
+++ b/src/player.py
@@ -1272,6 +1272,10 @@ class MultiTrackPlayer(QObject):
         self._playback_speed = 1.0
         self._pitch_semitones = 0
         self._apply_stretched_stems(dict(self._original_stems))
+        # Beat frames must be recomputed after the stem swap: if speed was
+        # non-identity before the error, _beat_frames still held stretched
+        # indices that no longer match the restored (original-length) stems.
+        self._recompute_beat_frames()
         # Emit both signals so any UI bound to either knob resets.
         self.speed_changed.emit(1.0)
         self.pitch_changed.emit(0)

--- a/src/player.py
+++ b/src/player.py
@@ -27,33 +27,67 @@ from src.qt_signal_utils import safe_disconnect as _safe_disconnect
 
 SPEED_PRESETS = (0.5, 0.75, 0.85, 1.0, 1.25, 1.5, 2.0)
 
+# Bounds for pitch transposition, in semitones. librosa's pitch_shift
+# quality degrades noticeably beyond ±7 (it chains resample+time_stretch
+# internally); this range covers the practical use cases (vocal range
+# adjustment, capo equivalents) without exposing the quality cliff.
+PITCH_MIN_SEMITONES = -7
+PITCH_MAX_SEMITONES = 7
+
+# Prefix used for recording-take stem names (e.g. "recording_take1").
+# Used to distinguish user recordings from source stems when deciding
+# whether to apply pitch transposition.
+RECORDING_STEM_PREFIX = "recording_take"
+
 
 def next_take_number(song_dir: str) -> int:
     """Return the next recording take number for *song_dir*."""
-    existing = glob.glob(os.path.join(song_dir, "recording_take*.wav"))
+    existing = glob.glob(os.path.join(song_dir, f"{RECORDING_STEM_PREFIX}*.wav"))
     nums: list[int] = []
     for p in existing:
         base = os.path.basename(p)
         try:
-            n = int(base.replace("recording_take", "").replace(".wav", ""))
+            n = int(base.replace(RECORDING_STEM_PREFIX, "").replace(".wav", ""))
             nums.append(n)
         except ValueError:
             continue
     return max(nums, default=0) + 1
 
 
-class SpeedWorker(QThread):
-    """Background thread for pitch-preserving time-stretch of all stems."""
+class StretchWorker(QThread):
+    """Background thread for pitch-preserving time-stretch and/or pitch
+    shift of all stems.
+
+    Both transforms are applied in a single pass per stem so artifacts do
+    not compound. Pitch shift runs first (it internally resamples then
+    time-stretches back to the original length), then the requested
+    playback-speed stretch is applied.
+
+    Recording-take stems are only pitch-shifted when
+    ``sync_recording_pitch`` is True. Speed is always applied to every
+    stem (speed changes affect all audible audio; recordings must stay in
+    sync with the backing track).
+    """
 
     completed = Signal(dict)  # {name: stretched_ndarray}
     progress = Signal(int, int)  # (current_stem, total_stems)
     error = Signal(str)
 
-    def __init__(self, stems: dict[str, np.ndarray], speed: float,
-                 parent=None) -> None:
+    def __init__(
+        self,
+        stems: dict[str, np.ndarray],
+        sample_rate: int,
+        speed: float,
+        pitch_semitones: int,
+        sync_recording_pitch: bool = False,
+        parent=None,
+    ) -> None:
         super().__init__(parent)
         self._stems = stems
-        self._speed = speed
+        self._sample_rate = int(sample_rate)
+        self._speed = float(speed)
+        self._pitch_semitones = int(pitch_semitones)
+        self._sync_recording_pitch = bool(sync_recording_pitch)
 
     def run(self) -> None:
         try:
@@ -63,19 +97,38 @@ class SpeedWorker(QThread):
 
     def _stretch(self) -> None:
         total = len(self._stems)
-        stretched = {}
+        out: dict[str, np.ndarray] = {}
+        apply_speed = self._speed != 1.0
+        apply_pitch = self._pitch_semitones != 0
         for i, (name, data) in enumerate(self._stems.items()):
-            # Preserve the peak amplitude after phase-vocoder stretch.
+            is_recording = name.startswith(RECORDING_STEM_PREFIX)
+            stem_apply_pitch = apply_pitch and (
+                not is_recording or self._sync_recording_pitch
+            )
+            if not apply_speed and not stem_apply_pitch:
+                # Nothing to do for this stem -- reuse the original buffer.
+                out[name] = data
+                self.progress.emit(i + 1, total)
+                continue
+
+            # Preserve the peak amplitude after phase-vocoder processing.
             original_peak = np.max(np.abs(data))
 
-            # librosa.effects.time_stretch works on mono; process each channel.
+            # librosa effects work on mono; process each channel.
             channels = []
             for ch_idx in range(data.shape[1]):
                 mono = data[:, ch_idx].astype(np.float32)
-                stretched_ch = librosa.effects.time_stretch(
-                    mono, rate=self._speed
-                )
-                channels.append(stretched_ch)
+                if stem_apply_pitch:
+                    mono = librosa.effects.pitch_shift(
+                        mono,
+                        sr=self._sample_rate,
+                        n_steps=self._pitch_semitones,
+                    )
+                if apply_speed:
+                    mono = librosa.effects.time_stretch(
+                        mono, rate=self._speed
+                    )
+                channels.append(mono)
             # Recombine to stereo, matching shortest channel.
             min_len = min(c.shape[0] for c in channels)
             stereo = np.column_stack([c[:min_len] for c in channels])
@@ -87,9 +140,9 @@ class SpeedWorker(QThread):
             if stretched_peak > 0 and original_peak > 0:
                 stereo *= original_peak / stretched_peak
 
-            stretched[name] = stereo
+            out[name] = stereo
             self.progress.emit(i + 1, total)
-        self.completed.emit(stretched)
+        self.completed.emit(out)
 
 
 class MultiTrackPlayer(QObject):
@@ -107,6 +160,7 @@ class MultiTrackPlayer(QObject):
     state_changed = Signal(bool)
     play_finished = Signal()
     speed_changed = Signal(float)
+    pitch_changed = Signal(int)  # emitted with semitones (-N..+N)
     playback_failed = Signal(str)
     recording_saved = Signal(str)  # emitted with the saved WAV path
 
@@ -133,10 +187,12 @@ class MultiTrackPlayer(QObject):
         self._loop_b_frame: int | None = None
         self._looping: bool = False
 
-        # Speed / time-stretch state.
+        # Speed / time-stretch / pitch state.
         self._playback_speed: float = 1.0
+        self._pitch_semitones: int = 0
+        self._sync_recording_pitch: bool = False
         self._original_stems: dict[str, np.ndarray] = {}
-        self._speed_worker: SpeedWorker | None = None
+        self._stretch_worker: StretchWorker | None = None
 
         # Metronome state.
         self._metronome_enabled: bool = False
@@ -435,11 +491,16 @@ class MultiTrackPlayer(QObject):
     def arm_recording(self, armed: bool) -> None:
         """Arm or disarm recording.
 
-        Recording cannot be armed when playback speed is not 1.0x or when
-        no stems are loaded.  Arming while already recording is a no-op.
+        Recording requires the backing track at its original tempo and
+        pitch (speed=1.0, pitch=0). Recording against time-stretched or
+        transposed audio would capture performance that can't be cleanly
+        mixed with the source stems later. Also requires stems to be
+        loaded. Arming while already recording is a no-op.
         """
         if armed:
             if self._playback_speed != 1.0:
+                return
+            if self._pitch_semitones != 0:
                 return
             if not self._stems:
                 return
@@ -573,7 +634,7 @@ class MultiTrackPlayer(QObject):
             stem_paths: Dictionary mapping stem names to file paths.
         """
         self.stop()
-        self._detach_speed_worker()
+        self._detach_stretch_worker()
         self._stems.clear()
         self._original_stems.clear()
         self._muted_stems.clear()
@@ -592,6 +653,7 @@ class MultiTrackPlayer(QObject):
         self._loop_b_frame = None
         self._looping = False
         self._playback_speed = 1.0
+        self._pitch_semitones = 0
         self._recording_armed = False
         self._recording = False
         self._recording_buffer = None
@@ -914,13 +976,28 @@ class MultiTrackPlayer(QObject):
         self._looping = False
 
     # ------------------------------------------------------------------
-    # Speed / Time-Stretch
+    # Speed / Pitch / Time-Stretch
     # ------------------------------------------------------------------
+    #
+    # Speed (time-stretch) and pitch (transposition) are both pre-rendered
+    # from ``_original_stems`` in a single ``StretchWorker`` pass so their
+    # artifacts do not compound. The fast path (speed=1.0 AND pitch=0)
+    # skips the worker entirely and swaps originals in directly.
 
     @property
     def speed(self) -> float:
         """Return the current playback speed multiplier."""
         return self._playback_speed
+
+    @property
+    def pitch_semitones(self) -> int:
+        """Return the current pitch transposition in semitones."""
+        return self._pitch_semitones
+
+    @property
+    def sync_recording_pitch(self) -> bool:
+        """Return True if recording stems are pitch-shifted with the backing track."""
+        return self._sync_recording_pitch
 
     def set_speed(self, speed: float) -> None:
         """Set the playback speed with pitch-preserving time-stretch.
@@ -930,57 +1007,127 @@ class MultiTrackPlayer(QObject):
         audio is ready.
         """
         speed = max(0.5, min(speed, 2.0))
-
         if speed == self._playback_speed:
             return
-
         self._playback_speed = speed
+        self._render_stretch(emit=("speed",))
+
+    def set_pitch(self, semitones: int) -> None:
+        """Set pitch transposition in semitones.
+
+        Clamps to [PITCH_MIN_SEMITONES, PITCH_MAX_SEMITONES]. Rendering
+        runs in a background thread; ``pitch_changed`` fires when the
+        transposed audio is ready (or immediately, on the fast path).
+        """
+        try:
+            semitones = int(semitones)
+        except (TypeError, ValueError):
+            return
+        semitones = max(PITCH_MIN_SEMITONES,
+                        min(PITCH_MAX_SEMITONES, semitones))
+        if semitones == self._pitch_semitones:
+            return
+        self._pitch_semitones = semitones
+        self._render_stretch(emit=("pitch",))
+
+    def set_sync_recording_pitch(self, sync: bool) -> None:
+        """Enable or disable pitch-shifting of recording-take stems.
+
+        When False (default), recordings keep their source pitch even when
+        the backing track is transposed. When True, recordings are shifted
+        alongside the source stems. Takes effect on the next render.
+        """
+        sync = bool(sync)
+        if sync == self._sync_recording_pitch:
+            return
+        self._sync_recording_pitch = sync
+        # Only re-render if a pitch shift is actually active -- otherwise
+        # the setting has no audible effect and we can skip the work.
+        if self._pitch_semitones != 0 and self._original_stems:
+            self._render_stretch(emit=("pitch",))
+
+    def _render_stretch(self, emit: tuple[str, ...] = ()) -> None:
+        """Render stems for the current speed + pitch state.
+
+        Detaches any in-flight worker first. Uses the fast path when both
+        transforms are identity. Otherwise spawns a new ``StretchWorker``.
+
+        *emit* is a tuple of signal names ("speed", "pitch") to fire after
+        the render completes; the caller uses this to indicate which knob
+        the user just turned so the UI can react appropriately.
+        """
+        self._detach_stretch_worker()
 
         if not self._original_stems:
+            self._emit_stretch_signals(emit)
             return
 
-        # Detach any in-flight worker so its signals don't fire stale data.
-        self._detach_speed_worker()
+        speed = self._playback_speed
+        pitch = self._pitch_semitones
 
-        if speed == 1.0:
+        if speed == 1.0 and pitch == 0:
+            # Fast path: no transform at all, swap originals in directly.
             self._apply_stretched_stems(dict(self._original_stems))
             self._recompute_beat_frames()
-            self.speed_changed.emit(speed)
+            self._emit_stretch_signals(emit)
             return
 
-        self._speed_worker = SpeedWorker(
-            self._original_stems, speed, parent=self
+        self._stretch_worker = StretchWorker(
+            self._original_stems,
+            self._sample_rate,
+            speed,
+            pitch,
+            sync_recording_pitch=self._sync_recording_pitch,
+            parent=self,
         )
-        self._speed_worker.completed.connect(self._on_speed_ready)
-        self._speed_worker.error.connect(self._on_speed_error)
-        self._speed_worker.start()
+        self._stretch_worker.completed.connect(
+            lambda stems: self._on_stretch_ready(stems, emit)
+        )
+        self._stretch_worker.error.connect(
+            lambda msg: self._on_stretch_error(msg, emit)
+        )
+        self._stretch_worker.start()
 
-    def _detach_speed_worker(self) -> None:
-        """Disconnect and release the current speed worker, if any."""
-        if self._speed_worker is not None:
-            _safe_disconnect(self._speed_worker.completed)
-            _safe_disconnect(self._speed_worker.error)
-            _safe_disconnect(self._speed_worker.progress)
+    def _detach_stretch_worker(self) -> None:
+        """Disconnect and release the current stretch worker, if any."""
+        if self._stretch_worker is not None:
+            _safe_disconnect(self._stretch_worker.completed)
+            _safe_disconnect(self._stretch_worker.error)
+            _safe_disconnect(self._stretch_worker.progress)
             # Let it finish in the background; don't block the UI.
-            worker = self._speed_worker
-            self._speed_worker = None
+            worker = self._stretch_worker
+            self._stretch_worker = None
             worker.setParent(None)
             if worker.isRunning():
                 worker.finished.connect(worker.deleteLater)
             else:
                 worker.deleteLater()
 
-    def _on_speed_ready(self, stretched: dict) -> None:
-        """Swap in stretched stems and adjust frame indices."""
-        self._apply_stretched_stems(stretched)
+    def _on_stretch_ready(
+        self, stems: dict, emit: tuple[str, ...],
+    ) -> None:
+        """Swap in rendered stems and adjust frame indices."""
+        self._apply_stretched_stems(stems)
         self._recompute_beat_frames()
-        self.speed_changed.emit(self._playback_speed)
+        self._emit_stretch_signals(emit)
 
-    def _on_speed_error(self, message: str) -> None:
-        """Handle stretch failure by restoring original speed."""
+    def _on_stretch_error(
+        self, message: str, emit: tuple[str, ...],
+    ) -> None:
+        """Handle stretch failure by restoring originals at identity state."""
         self._playback_speed = 1.0
+        self._pitch_semitones = 0
         self._apply_stretched_stems(dict(self._original_stems))
+        # Emit both signals so any UI bound to either knob resets.
         self.speed_changed.emit(1.0)
+        self.pitch_changed.emit(0)
+
+    def _emit_stretch_signals(self, emit: tuple[str, ...]) -> None:
+        """Fire speed_changed / pitch_changed signals per *emit* contents."""
+        if "speed" in emit:
+            self.speed_changed.emit(self._playback_speed)
+        if "pitch" in emit:
+            self.pitch_changed.emit(self._pitch_semitones)
 
     def _apply_stretched_stems(self, stems: dict) -> None:
         """Replace current stems with *stems* and adjust frame indices."""

--- a/src/player.py
+++ b/src/player.py
@@ -64,10 +64,12 @@ class StretchWorker(QThread):
     time-stretches back to the original length), then the requested
     playback-speed stretch is applied.
 
-    Stems are processed in parallel via a ThreadPoolExecutor.  The heavy
-    librosa / numpy / resampy code runs in C and releases the GIL, so
-    real multi-core speed-up is achievable here -- typically 2-3x on a
-    4-stem mix.
+    Stems are dispatched to a ThreadPoolExecutor for overlap between the
+    Python bookkeeping and the C-level FFT / resampling kernels.  In
+    practice the GIL and librosa's own internal Python loops limit
+    wall-clock speedup to roughly 1.0-1.3x; the main perf lever is
+    ``_HOP_LENGTH`` (STFT hop size), which trades STFT frame count
+    linearly against render time with minimal quality impact.
 
     Recording-take stems are only pitch-shifted when
     ``sync_recording_pitch`` is True. Speed is always applied to every
@@ -92,10 +94,20 @@ class StretchWorker(QThread):
     # interactive scrubbing we want responsiveness.
     _RESAMPLE_TYPE = "soxr_mq"
 
-    # Cap parallelism: 4 threads saturates 8-core CPUs once the C-level
-    # FFT/resample kernels each spawn their own OpenMP work.  Going wider
-    # increases memory (each thread buffers a mono copy per stem) without
-    # faster wall time.
+    # STFT hop size for pitch_shift / time_stretch.  Default librosa value
+    # is 512 (75 % overlap at n_fft=2048).  Doubling to 1024 (50 % overlap)
+    # reduces the number of STFT frames by 2x → roughly 2-3x faster
+    # end-to-end, with no perceptible quality difference for ±1–7 semitone
+    # shifts on typical music material.  Benchmarked values for a 5-min
+    # 4-stem song at 44.1 kHz:
+    #   hop=512  → ~44 s  (default)
+    #   hop=1024 → ~19 s  (current — ~2.3x faster)
+    #   hop=2048 → ~10 s  (further speedup but audible smearing on drums)
+    _HOP_LENGTH = 1024
+
+    # Cap parallelism to avoid excess RAM usage.  Each thread buffers a
+    # mono copy of one stem; 4 threads × ~28 MB/stem = ~112 MB overhead
+    # for a typical 5-min project.
     _MAX_PARALLEL_STEMS = 4
 
     def __init__(
@@ -144,6 +156,12 @@ class StretchWorker(QThread):
 
         apply_speed = self._speed != 1.0
         apply_pitch = self._pitch_semitones != 0
+
+        # Show "(0/N)" in the spinbox suffix immediately so the user sees
+        # the expected count from the first frame rather than "..." for the
+        # full render duration.
+        if not self._cancelled:
+            self.progress.emit(0, total)
 
         out: dict[str, np.ndarray] = {}
 
@@ -214,10 +232,12 @@ class StretchWorker(QThread):
                     sr=self._sample_rate,
                     n_steps=self._pitch_semitones,
                     res_type=self._RESAMPLE_TYPE,
+                    hop_length=self._HOP_LENGTH,
                 )
             if apply_speed:
                 mono = librosa.effects.time_stretch(
-                    mono, rate=self._speed
+                    mono, rate=self._speed,
+                    hop_length=self._HOP_LENGTH,
                 )
             channels.append(mono)
 

--- a/src/player.py
+++ b/src/player.py
@@ -89,21 +89,14 @@ class StretchWorker(QThread):
     progress = Signal(int, int)  # (current_stem, total_stems)
     error = Signal(str)
 
-    # soxr_mq is ~3-4x faster than the default soxr_hq with no audible
-    # difference at musical material. soxr_hq is mastering-grade; for
-    # interactive scrubbing we want responsiveness.
-    _RESAMPLE_TYPE = "soxr_mq"
-
-    # STFT hop size for pitch_shift / time_stretch.  Default librosa value
-    # is 512 (75 % overlap at n_fft=2048).  Doubling to 1024 (50 % overlap)
-    # reduces the number of STFT frames by 2x → roughly 2-3x faster
-    # end-to-end, with no perceptible quality difference for ±1–7 semitone
-    # shifts on typical music material.  Benchmarked values for a 5-min
-    # 4-stem song at 44.1 kHz:
-    #   hop=512  → ~44 s  (default)
-    #   hop=1024 → ~19 s  (current — ~2.3x faster)
-    #   hop=2048 → ~10 s  (further speedup but audible smearing on drums)
-    _HOP_LENGTH = 1024
+    # Resampler quality.  librosa's default is "soxr_hq" (high-quality
+    # SOX resampler).  We keep it -- dropping to "soxr_mq" is ~3x faster
+    # but introduces an audible metallic timbre on transient-heavy
+    # material (drums, plucked strings), which is unacceptable for a
+    # tool whose whole purpose is faithful playback of the source.
+    # Speed wins come from parallel stem rendering, not from cutting
+    # resampler quality.
+    _RESAMPLE_TYPE = "soxr_hq"
 
     # Cap parallelism to avoid excess RAM usage.  Each thread buffers a
     # mono copy of one stem; 4 threads × ~28 MB/stem = ~112 MB overhead
@@ -232,12 +225,10 @@ class StretchWorker(QThread):
                     sr=self._sample_rate,
                     n_steps=self._pitch_semitones,
                     res_type=self._RESAMPLE_TYPE,
-                    hop_length=self._HOP_LENGTH,
                 )
             if apply_speed:
                 mono = librosa.effects.time_stretch(
                     mono, rate=self._speed,
-                    hop_length=self._HOP_LENGTH,
                 )
             channels.append(mono)
 

--- a/src/player.py
+++ b/src/player.py
@@ -13,6 +13,7 @@ frame synchronisation with the stems being mixed to output.
 import glob
 import math
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 import numpy as np
@@ -63,15 +64,39 @@ class StretchWorker(QThread):
     time-stretches back to the original length), then the requested
     playback-speed stretch is applied.
 
+    Stems are processed in parallel via a ThreadPoolExecutor.  The heavy
+    librosa / numpy / resampy code runs in C and releases the GIL, so
+    real multi-core speed-up is achievable here -- typically 2-3x on a
+    4-stem mix.
+
     Recording-take stems are only pitch-shifted when
     ``sync_recording_pitch`` is True. Speed is always applied to every
     stem (speed changes affect all audible audio; recordings must stay in
     sync with the backing track).
+
+    Cancellation:
+        ``cancel()`` sets a flag checked between each stem and each
+        channel. In-flight librosa calls cannot be interrupted -- cancel
+        responsiveness is bounded by the length of a single channel's
+        pitch-shift / time-stretch pass (~0.5-2s on typical songs).
+        A cancelled worker emits no further ``progress`` / ``completed``
+        / ``error`` signals.
     """
 
     completed = Signal(dict)  # {name: stretched_ndarray}
     progress = Signal(int, int)  # (current_stem, total_stems)
     error = Signal(str)
+
+    # soxr_mq is ~3-4x faster than the default soxr_hq with no audible
+    # difference at musical material. soxr_hq is mastering-grade; for
+    # interactive scrubbing we want responsiveness.
+    _RESAMPLE_TYPE = "soxr_mq"
+
+    # Cap parallelism: 4 threads saturates 8-core CPUs once the C-level
+    # FFT/resample kernels each spawn their own OpenMP work.  Going wider
+    # increases memory (each thread buffers a mono copy per stem) without
+    # faster wall time.
+    _MAX_PARALLEL_STEMS = 4
 
     def __init__(
         self,
@@ -88,61 +113,129 @@ class StretchWorker(QThread):
         self._speed = float(speed)
         self._pitch_semitones = int(pitch_semitones)
         self._sync_recording_pitch = bool(sync_recording_pitch)
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        """Request early termination at the next stem/channel boundary.
+
+        Once set, the worker emits no further ``progress``, ``completed``,
+        or ``error`` signals; its ``run()`` returns cleanly so the QThread
+        ``finished`` signal still fires and the player can reap it.
+        """
+        self._cancelled = True
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled
 
     def run(self) -> None:
         try:
             self._stretch()
-        except Exception as exc:
-            self.error.emit(str(exc))
+        except Exception as exc:  # noqa: BLE001
+            if not self._cancelled:
+                self.error.emit(str(exc))
 
     def _stretch(self) -> None:
         total = len(self._stems)
-        out: dict[str, np.ndarray] = {}
+        if total == 0:
+            if not self._cancelled:
+                self.completed.emit({})
+            return
+
         apply_speed = self._speed != 1.0
         apply_pitch = self._pitch_semitones != 0
-        for i, (name, data) in enumerate(self._stems.items()):
-            is_recording = name.startswith(RECORDING_STEM_PREFIX)
-            stem_apply_pitch = apply_pitch and (
-                not is_recording or self._sync_recording_pitch
+
+        out: dict[str, np.ndarray] = {}
+
+        def process(item):
+            name, data = item
+            if self._cancelled:
+                return name, None
+            result = self._process_stem(
+                name, data, apply_speed, apply_pitch,
             )
-            if not apply_speed and not stem_apply_pitch:
-                # Nothing to do for this stem -- reuse the original buffer.
-                out[name] = data
-                self.progress.emit(i + 1, total)
-                continue
+            return name, result
 
-            # Preserve the peak amplitude after phase-vocoder processing.
-            original_peak = np.max(np.abs(data))
+        # Progress is emitted from this (the run) thread rather than from
+        # pool workers so the signal behaves consistently whether the
+        # worker is started via QThread.start() or called synchronously
+        # via run().  Qt cross-thread emits need an event loop to be
+        # delivered; same-thread emits do not.
+        max_workers = min(total, self._MAX_PARALLEL_STEMS)
+        completed_count = 0
+        with ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="stretch",
+        ) as pool:
+            futures = [
+                pool.submit(process, item)
+                for item in self._stems.items()
+            ]
+            for fut in as_completed(futures):
+                name, result = fut.result()
+                completed_count += 1
+                if result is not None:
+                    out[name] = result
+                    if not self._cancelled:
+                        self.progress.emit(completed_count, total)
 
-            # librosa effects work on mono; process each channel.
-            channels = []
-            for ch_idx in range(data.shape[1]):
-                mono = data[:, ch_idx].astype(np.float32)
-                if stem_apply_pitch:
-                    mono = librosa.effects.pitch_shift(
-                        mono,
-                        sr=self._sample_rate,
-                        n_steps=self._pitch_semitones,
-                    )
-                if apply_speed:
-                    mono = librosa.effects.time_stretch(
-                        mono, rate=self._speed
-                    )
-                channels.append(mono)
-            # Recombine to stereo, matching shortest channel.
-            min_len = min(c.shape[0] for c in channels)
-            stereo = np.column_stack([c[:min_len] for c in channels])
-            stereo = stereo.astype(np.float32)
-
-            # Normalize to match original peak level (phase vocoder can
-            # reduce amplitude).
-            stretched_peak = np.max(np.abs(stereo))
-            if stretched_peak > 0 and original_peak > 0:
-                stereo *= original_peak / stretched_peak
-
-            out[name] = stereo
-            self.progress.emit(i + 1, total)
+        if self._cancelled:
+            return
         self.completed.emit(out)
+
+    def _process_stem(
+        self,
+        name: str,
+        data: np.ndarray,
+        apply_speed: bool,
+        apply_pitch: bool,
+    ) -> np.ndarray | None:
+        """Render one stem; return ``None`` if cancelled mid-flight."""
+        is_recording = name.startswith(RECORDING_STEM_PREFIX)
+        stem_apply_pitch = apply_pitch and (
+            not is_recording or self._sync_recording_pitch
+        )
+        if not apply_speed and not stem_apply_pitch:
+            # Nothing to do for this stem -- reuse the original buffer.
+            return data
+
+        # Preserve the peak amplitude after phase-vocoder processing.
+        original_peak = np.max(np.abs(data))
+
+        # librosa effects work on mono; process each channel.
+        channels = []
+        for ch_idx in range(data.shape[1]):
+            if self._cancelled:
+                return None
+            mono = data[:, ch_idx].astype(np.float32)
+            if stem_apply_pitch:
+                mono = librosa.effects.pitch_shift(
+                    mono,
+                    sr=self._sample_rate,
+                    n_steps=self._pitch_semitones,
+                    res_type=self._RESAMPLE_TYPE,
+                )
+            if apply_speed:
+                mono = librosa.effects.time_stretch(
+                    mono, rate=self._speed
+                )
+            channels.append(mono)
+
+        if self._cancelled:
+            return None
+
+        # Recombine to stereo, matching shortest channel.
+        min_len = min(c.shape[0] for c in channels)
+        stereo = np.column_stack([c[:min_len] for c in channels])
+        stereo = stereo.astype(np.float32)
+
+        # Normalize to match original peak level (phase vocoder can
+        # reduce amplitude).
+        stretched_peak = np.max(np.abs(stereo))
+        if stretched_peak > 0 and original_peak > 0:
+            stereo *= original_peak / stretched_peak
+
+        return stereo
 
 
 class MultiTrackPlayer(QObject):
@@ -161,6 +254,9 @@ class MultiTrackPlayer(QObject):
     play_finished = Signal()
     speed_changed = Signal(float)
     pitch_changed = Signal(int)  # emitted with semitones (-N..+N)
+    stretch_started = Signal()   # render began (worker spawned)
+    stretch_progress = Signal(int, int)  # (current_stem, total_stems)
+    stretch_finished = Signal()  # render completed (success or error)
     playback_failed = Signal(str)
     recording_saved = Signal(str)  # emitted with the saved WAV path
 
@@ -193,6 +289,12 @@ class MultiTrackPlayer(QObject):
         self._sync_recording_pitch: bool = False
         self._original_stems: dict[str, np.ndarray] = {}
         self._stretch_worker: StretchWorker | None = None
+        # Keepalive refs for detached-but-still-running workers. Without
+        # this, a rapid succession of set_pitch/set_speed calls drops the
+        # previous Python wrapper to refcount zero; the GC then deletes
+        # the QThread while its run loop is still active, producing
+        # "QThread: Destroyed while thread is still running" crashes.
+        self._detached_workers: list[StretchWorker] = []
 
         # Metronome state.
         self._metronome_enabled: bool = False
@@ -1056,10 +1158,12 @@ class MultiTrackPlayer(QObject):
         the render completes; the caller uses this to indicate which knob
         the user just turned so the UI can react appropriately.
         """
-        self._detach_stretch_worker()
+        was_rendering = self._detach_stretch_worker()
 
         if not self._original_stems:
             self._emit_stretch_signals(emit)
+            if was_rendering:
+                self.stretch_finished.emit()
             return
 
         speed = self._playback_speed
@@ -1070,6 +1174,10 @@ class MultiTrackPlayer(QObject):
             self._apply_stretched_stems(dict(self._original_stems))
             self._recompute_beat_frames()
             self._emit_stretch_signals(emit)
+            if was_rendering:
+                # Close the render lifecycle the UI was waiting on so it
+                # can restore its indicator.
+                self.stretch_finished.emit()
             return
 
         self._stretch_worker = StretchWorker(
@@ -1086,22 +1194,67 @@ class MultiTrackPlayer(QObject):
         self._stretch_worker.error.connect(
             lambda msg: self._on_stretch_error(msg, emit)
         )
+        # Re-emit per-stem progress so the UI can show a meaningful
+        # "rendering N/M stems" indicator instead of an indefinite spinner.
+        self._stretch_worker.progress.connect(self.stretch_progress)
+        # Only emit stretch_started if this is a fresh render.  When we
+        # chain worker-to-worker (user scrubbed the spinbox), the UI is
+        # already in "rendering" mode; starting again would reset the
+        # progress counter visibly but not restart the lifecycle.
+        if not was_rendering:
+            self.stretch_started.emit()
         self._stretch_worker.start()
 
-    def _detach_stretch_worker(self) -> None:
-        """Disconnect and release the current stretch worker, if any."""
-        if self._stretch_worker is not None:
-            _safe_disconnect(self._stretch_worker.completed)
-            _safe_disconnect(self._stretch_worker.error)
-            _safe_disconnect(self._stretch_worker.progress)
-            # Let it finish in the background; don't block the UI.
-            worker = self._stretch_worker
-            self._stretch_worker = None
+    def _detach_stretch_worker(self) -> bool:
+        """Disconnect, cancel, and release the current stretch worker.
+
+        Returns True if a running worker was detached (UI can use this
+        to emit a matching ``stretch_finished`` when no new render is
+        about to start).  Running workers are asked to ``cancel()`` so
+        they stop at the next stem/channel boundary instead of finishing
+        their full (now-stale) render; we retain a Python reference on
+        ``_detached_workers`` until the thread's ``finished`` signal
+        fires, preventing QThread GC-during-run crashes.
+        """
+        if self._stretch_worker is None:
+            return False
+        _safe_disconnect(self._stretch_worker.completed)
+        _safe_disconnect(self._stretch_worker.error)
+        _safe_disconnect(self._stretch_worker.progress)
+        worker = self._stretch_worker
+        self._stretch_worker = None
+        was_running = worker.isRunning()
+        if was_running:
+            worker.cancel()
+            # Keep alive until the thread actually stops. ``setParent(None)``
+            # is intentionally deferred to _reap_detached_worker so the Qt
+            # parent remains valid while the run loop is active.
+            self._detached_workers.append(worker)
+            worker.finished.connect(
+                lambda w=worker: self._reap_detached_worker(w)
+            )
+        else:
             worker.setParent(None)
-            if worker.isRunning():
-                worker.finished.connect(worker.deleteLater)
-            else:
-                worker.deleteLater()
+            worker.deleteLater()
+        return was_running
+
+    def cancel_stretch(self) -> None:
+        """Cancel any in-flight stretch render without starting a new one.
+
+        Emits ``stretch_finished`` so the UI can clear its render
+        indicator.  Safe to call when no render is active (no-op).
+        """
+        if self._detach_stretch_worker():
+            self.stretch_finished.emit()
+
+    def _reap_detached_worker(self, worker: "StretchWorker") -> None:
+        """Release a detached worker after its thread has stopped."""
+        try:
+            self._detached_workers.remove(worker)
+        except ValueError:
+            pass
+        worker.setParent(None)
+        worker.deleteLater()
 
     def _on_stretch_ready(
         self, stems: dict, emit: tuple[str, ...],
@@ -1110,6 +1263,7 @@ class MultiTrackPlayer(QObject):
         self._apply_stretched_stems(stems)
         self._recompute_beat_frames()
         self._emit_stretch_signals(emit)
+        self.stretch_finished.emit()
 
     def _on_stretch_error(
         self, message: str, emit: tuple[str, ...],
@@ -1121,6 +1275,7 @@ class MultiTrackPlayer(QObject):
         # Emit both signals so any UI bound to either knob resets.
         self.speed_changed.emit(1.0)
         self.pitch_changed.emit(0)
+        self.stretch_finished.emit()
 
     def _emit_stretch_signals(self, emit: tuple[str, ...]) -> None:
         """Fire speed_changed / pitch_changed signals per *emit* contents."""

--- a/src/player.py
+++ b/src/player.py
@@ -13,7 +13,8 @@ frame synchronisation with the stems being mixed to output.
 import glob
 import math
 import os
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import queue
+import threading
 from typing import Any
 
 import numpy as np
@@ -64,12 +65,27 @@ class StretchWorker(QThread):
     time-stretches back to the original length), then the requested
     playback-speed stretch is applied.
 
-    Stems are dispatched to a ThreadPoolExecutor for overlap between the
+    Stems are dispatched to a small pool of **daemon threads** (not
+    ``concurrent.futures.ThreadPoolExecutor``) for overlap between the
     Python bookkeeping and the C-level FFT / resampling kernels.  In
     practice the GIL and librosa's own internal Python loops limit
     wall-clock speedup to roughly 1.0-1.3x; the main perf lever is
     ``_HOP_LENGTH`` (STFT hop size), which trades STFT frame count
     linearly against render time with minimal quality impact.
+
+    Why daemon threads instead of ``ThreadPoolExecutor``:
+        ``ThreadPoolExecutor`` registers its workers with
+        ``concurrent.futures.thread._threads_queues``, which its atexit
+        handler ``_python_exit`` drains by calling ``t.join()`` on each
+        thread.  In-flight librosa calls are uninterruptible (pure C
+        kernels) -- if the user closes the app mid-render the pool
+        threads are stuck inside librosa and ``_python_exit`` hangs
+        indefinitely, forcing a Ctrl+C kill.  Daemon threads are *not*
+        registered in ``_threads_queues``; Python exits cleanly and
+        reaps them as part of process teardown.  This is safe here
+        because we only touch in-memory numpy buffers -- no file I/O
+        or external resources whose state would be corrupted by
+        abrupt termination.
 
     Recording-take stems are only pitch-shifted when
     ``sync_recording_pitch`` is True. Speed is always applied to every
@@ -82,7 +98,10 @@ class StretchWorker(QThread):
         responsiveness is bounded by the length of a single channel's
         pitch-shift / time-stretch pass (~0.5-2s on typical songs).
         A cancelled worker emits no further ``progress`` / ``completed``
-        / ``error`` signals.
+        / ``error`` signals.  The dispatcher loop polls the cancel flag
+        every 100 ms and returns from ``run()`` as soon as it sees one
+        (orphaning any still-running daemon worker) so the QThread
+        ``finished`` signal fires promptly.
     """
 
     completed = Signal(dict)  # {name: stretched_ndarray}
@@ -156,42 +175,97 @@ class StretchWorker(QThread):
         if not self._cancelled:
             self.progress.emit(0, total)
 
-        out: dict[str, np.ndarray] = {}
+        # Per-stem work queue consumed by daemon workers.  A queue is
+        # used (rather than pre-partitioned slices) so faster stems
+        # don't leave slow ones dangling on a single worker.
+        work_q: queue.Queue[tuple[str, np.ndarray]] = queue.Queue()
+        for item in self._stems.items():
+            work_q.put(item)
 
-        def process(item):
-            name, data = item
-            if self._cancelled:
-                return name, None
-            result = self._process_stem(
-                name, data, apply_speed, apply_pitch,
-            )
-            return name, result
+        # Results funnel: workers push (name, array, exc); the dispatcher
+        # thread drains it so ``progress.emit`` is called from the same
+        # thread that runs ``_stretch``.  Emitting from the daemon workers
+        # themselves breaks callers that invoke ``run()`` synchronously
+        # without an event loop: cross-thread signal deliveries are
+        # queued by Qt and never dispatched, so the progress updates
+        # would be lost until the test's event loop tick happens to run.
+        result_q: queue.Queue[
+            tuple[str, "np.ndarray | None", "BaseException | None"]
+        ] = queue.Queue()
 
-        # Progress is emitted from this (the run) thread rather than from
-        # pool workers so the signal behaves consistently whether the
-        # worker is started via QThread.start() or called synchronously
-        # via run().  Qt cross-thread emits need an event loop to be
-        # delivered; same-thread emits do not.
+        def worker() -> None:
+            while not self._cancelled:
+                try:
+                    name, data = work_q.get_nowait()
+                except queue.Empty:
+                    return
+                try:
+                    result = self._process_stem(
+                        name, data, apply_speed, apply_pitch,
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    # Surface the first error to the dispatcher and bail.
+                    result_q.put((name, None, exc))
+                    return
+                if result is None:
+                    # _process_stem returns None when it observed the
+                    # cancel flag mid-channel.  Put a tombstone so the
+                    # dispatcher can count it as "done-but-empty" and
+                    # doesn't block waiting for a result that will
+                    # never arrive.
+                    result_q.put((name, None, None))
+                    return
+                result_q.put((name, result, None))
+
         max_workers = min(total, self._MAX_PARALLEL_STEMS)
+        threads: list[threading.Thread] = []
+        for i in range(max_workers):
+            t = threading.Thread(
+                target=worker,
+                name=f"stretch-{i}",
+                daemon=True,  # see class docstring for rationale
+            )
+            t.start()
+            threads.append(t)
+
+        # Drain the results queue on the dispatcher thread.  Poll with a
+        # short timeout so we notice cancellation quickly (every 100 ms)
+        # instead of waiting up to several seconds for the currently-
+        # running librosa call to complete.  Orphaning still-running
+        # daemons on cancel is intentional: they finish their current
+        # librosa call and exit; the next render spawns fresh ones after
+        # the previous worker's QThread.finished fires.
+        out: dict[str, np.ndarray] = {}
+        worker_error: BaseException | None = None
         completed_count = 0
-        with ThreadPoolExecutor(
-            max_workers=max_workers,
-            thread_name_prefix="stretch",
-        ) as pool:
-            futures = [
-                pool.submit(process, item)
-                for item in self._stems.items()
-            ]
-            for fut in as_completed(futures):
-                name, result = fut.result()
-                completed_count += 1
-                if result is not None:
-                    out[name] = result
-                    if not self._cancelled:
-                        self.progress.emit(completed_count, total)
+        while completed_count < total and not self._cancelled:
+            try:
+                name, result, exc = result_q.get(timeout=0.1)
+            except queue.Empty:
+                # All workers dead without filling the queue?  Unusual
+                # but possible if they all saw the cancel flag between
+                # pulling work and processing.  Exit to avoid hanging.
+                if all(not t.is_alive() for t in threads):
+                    break
+                continue
+            if exc is not None:
+                worker_error = exc
+                break
+            completed_count += 1
+            if result is None:
+                # Cancelled mid-stem tombstone -- don't accumulate, but
+                # it still counts toward completion so the loop exits.
+                continue
+            out[name] = result
+            if not self._cancelled:
+                self.progress.emit(completed_count, total)
 
         if self._cancelled:
             return
+        if worker_error is not None:
+            # Re-raise inside run() so StretchWorker.run's outer
+            # try/except converts it into an ``error`` signal.
+            raise worker_error
         self.completed.emit(out)
 
     def _process_stem(
@@ -306,6 +380,15 @@ class MultiTrackPlayer(QObject):
         # the QThread while its run loop is still active, producing
         # "QThread: Destroyed while thread is still running" crashes.
         self._detached_workers: list[StretchWorker] = []
+        # Serialisation: at most one StretchWorker may be actively
+        # processing at a time.  When a render is requested while a
+        # previous worker is still draining its cancellation, the request
+        # is coalesced into this field and dispatched from
+        # ``_reap_detached_worker`` once the drain finishes.  Without
+        # this, rapid pitch/speed scrubbing spawns overlapping workers
+        # -- each allocating hundreds of MB of librosa intermediates --
+        # and the OS swaps them to the pagefile, filling the disk.
+        self._pending_render_emit: tuple[str, ...] | None = None
 
         # Metronome state.
         self._metronome_enabled: bool = False
@@ -354,6 +437,38 @@ class MultiTrackPlayer(QObject):
         self._timer = QTimer(self)
         self._timer.setInterval(50)  # ~20fps
         self._timer.timeout.connect(self._emit_position)
+
+    def shutdown(self, wait_ms: int = 3000) -> None:
+        """Cancel in-flight work and wait (briefly) for QThreads to exit.
+
+        Called from the main window's ``closeEvent``.  StretchWorker
+        uses daemon threads for parallel stem processing so Python's
+        atexit handlers don't block on them, but the QThread itself
+        (which dispatches to those daemons) is non-daemon and we wait
+        for it cleanly so Qt's teardown doesn't print
+        ``"QThread: Destroyed while thread is still running"``.
+
+        *wait_ms* is the per-worker upper bound; cancellation is only
+        checked at stem/channel boundaries inside librosa, which can
+        take a second or two to reach on large stems.  On timeout we
+        proceed anyway -- the QThread's dispatcher loop polls the
+        cancel flag every 100 ms and will return from run() soon
+        after, at which point Qt can safely reap it.
+        """
+        self._pending_render_emit = None
+        if self._timer.isActive():
+            self._timer.stop()
+        workers: list[StretchWorker] = list(self._detached_workers)
+        if self._stretch_worker is not None:
+            workers.append(self._stretch_worker)
+        for w in workers:
+            w.cancel()
+        for w in workers:
+            if w.isRunning():
+                # QThread.wait returns False on timeout; we accept that
+                # silently -- the OS will clean the thread up, and at
+                # worst atexit blocks for wait_ms instead of forever.
+                w.wait(wait_ms)
 
     @property
     def has_stems(self) -> bool:
@@ -747,6 +862,7 @@ class MultiTrackPlayer(QObject):
             stem_paths: Dictionary mapping stem names to file paths.
         """
         self.stop()
+        self._pending_render_emit = None
         self._detach_stretch_worker()
         self._stems.clear()
         self._original_stems.clear()
@@ -1163,17 +1279,25 @@ class MultiTrackPlayer(QObject):
         """Render stems for the current speed + pitch state.
 
         Detaches any in-flight worker first. Uses the fast path when both
-        transforms are identity. Otherwise spawns a new ``StretchWorker``.
+        transforms are identity.  Otherwise spawns a new ``StretchWorker``
+        -- unless a previously cancelled worker is still draining, in
+        which case the render is queued and dispatched from
+        ``_reap_detached_worker`` once the drain completes.  This
+        serialisation bounds memory use to one worker's intermediates.
 
         *emit* is a tuple of signal names ("speed", "pitch") to fire after
         the render completes; the caller uses this to indicate which knob
         the user just turned so the UI can react appropriately.
         """
         was_rendering = self._detach_stretch_worker()
+        # A pending queued render is superseded by this one; keep the
+        # new emit tuple (so we still emit the correct signal at the end).
+        had_pending = self._pending_render_emit is not None
+        self._pending_render_emit = None
 
         if not self._original_stems:
             self._emit_stretch_signals(emit)
-            if was_rendering:
+            if was_rendering or had_pending:
                 self.stretch_finished.emit()
             return
 
@@ -1182,20 +1306,47 @@ class MultiTrackPlayer(QObject):
 
         if speed == 1.0 and pitch == 0:
             # Fast path: no transform at all, swap originals in directly.
+            # The draining worker (if any) is now irrelevant; its result
+            # would be discarded even if it completed.
             self._apply_stretched_stems(dict(self._original_stems))
             self._recompute_beat_frames()
             self._emit_stretch_signals(emit)
-            if was_rendering:
+            if was_rendering or had_pending:
                 # Close the render lifecycle the UI was waiting on so it
                 # can restore its indicator.
                 self.stretch_finished.emit()
             return
 
+        # A prior worker is still draining its cancellation.  Coalesce
+        # this render into the pending slot and let _reap_detached_worker
+        # dispatch it when the drain finishes.  Starting a second worker
+        # now would double the peak memory footprint (two pools, up to
+        # 8 parallel librosa calls) and reliably trips the OS into
+        # swapping to pagefile on modest machines.
+        if self._detached_workers:
+            self._pending_render_emit = emit
+            return
+
+        self._spawn_stretch_worker(emit)
+
+    def _spawn_stretch_worker(self, emit: tuple[str, ...]) -> None:
+        """Start a ``StretchWorker`` for the player's current speed/pitch.
+
+        Always fires ``stretch_started`` so the UI can re-light its
+        render indicator.  Earlier revisions suppressed this emission
+        on queued dispatches (assuming the indicator was still on from
+        the previous worker), but that missed the common case where
+        the UI had already cleared the indicator via an intervening
+        ``cancel_stretch`` call -- the queued render would then run
+        invisibly.  Re-emitting on every spawn is idempotent: the UI's
+        handler resets the progress counter to (0/total) which is
+        indistinguishable from the initial state.
+        """
         self._stretch_worker = StretchWorker(
             self._original_stems,
             self._sample_rate,
-            speed,
-            pitch,
+            self._playback_speed,
+            self._pitch_semitones,
             sync_recording_pitch=self._sync_recording_pitch,
             parent=self,
         )
@@ -1208,12 +1359,7 @@ class MultiTrackPlayer(QObject):
         # Re-emit per-stem progress so the UI can show a meaningful
         # "rendering N/M stems" indicator instead of an indefinite spinner.
         self._stretch_worker.progress.connect(self.stretch_progress)
-        # Only emit stretch_started if this is a fresh render.  When we
-        # chain worker-to-worker (user scrubbed the spinbox), the UI is
-        # already in "rendering" mode; starting again would reset the
-        # progress counter visibly but not restart the lifecycle.
-        if not was_rendering:
-            self.stretch_started.emit()
+        self.stretch_started.emit()
         self._stretch_worker.start()
 
     def _detach_stretch_worker(self) -> bool:
@@ -1252,20 +1398,60 @@ class MultiTrackPlayer(QObject):
     def cancel_stretch(self) -> None:
         """Cancel any in-flight stretch render without starting a new one.
 
-        Emits ``stretch_finished`` so the UI can clear its render
-        indicator.  Safe to call when no render is active (no-op).
+        Clears any queued render as well -- an explicit cancel should
+        supersede a pending request.  Emits ``stretch_finished`` so the
+        UI can clear its render indicator.  Safe to call when no render
+        is active (no-op).
         """
-        if self._detach_stretch_worker():
+        had_pending = self._pending_render_emit is not None
+        self._pending_render_emit = None
+        detached = self._detach_stretch_worker()
+        if detached or had_pending:
             self.stretch_finished.emit()
 
     def _reap_detached_worker(self, worker: "StretchWorker") -> None:
-        """Release a detached worker after its thread has stopped."""
+        """Release a detached worker after its thread has stopped.
+
+        When the last detached worker drains, any render coalesced into
+        ``_pending_render_emit`` is dispatched here.  Fast-path swaps are
+        handled inline so the UI's ``stretch_finished`` fires promptly.
+        """
         try:
             self._detached_workers.remove(worker)
         except ValueError:
             pass
         worker.setParent(None)
         worker.deleteLater()
+
+        # Still more workers draining?  Wait for the last one.
+        if self._detached_workers:
+            return
+
+        emit = self._pending_render_emit
+        if emit is None:
+            return
+        self._pending_render_emit = None
+
+        if not self._original_stems:
+            self._emit_stretch_signals(emit)
+            self.stretch_finished.emit()
+            return
+
+        speed = self._playback_speed
+        pitch = self._pitch_semitones
+        if speed == 1.0 and pitch == 0:
+            self._apply_stretched_stems(dict(self._original_stems))
+            self._recompute_beat_frames()
+            self._emit_stretch_signals(emit)
+            self.stretch_finished.emit()
+            return
+
+        # Always re-emit stretch_started here.  The UI may have
+        # cleared its indicator if cancel_stretch was the reason we
+        # reached the queued-render path; we must re-light it.  When
+        # the indicator is already on, re-emitting just resets the
+        # counter to (0/total) -- harmless.
+        self._spawn_stretch_worker(emit)
 
     def _on_stretch_ready(
         self, stems: dict, emit: tuple[str, ...],

--- a/src/player.py
+++ b/src/player.py
@@ -389,6 +389,13 @@ class MultiTrackPlayer(QObject):
         # -- each allocating hundreds of MB of librosa intermediates --
         # and the OS swaps them to the pagefile, filling the disk.
         self._pending_render_emit: tuple[str, ...] | None = None
+        # What self._stems actually contain, as (speed, pitch, sync).
+        # The knobs (_playback_speed / _pitch_semitones) are set
+        # optimistically before a render lands, and cancel_stretch()
+        # can discard the render that would have realised them -- so
+        # "requested value unchanged" is not the same as "nothing to
+        # do".  set_speed/set_pitch compare against this instead.
+        self._applied_render_state: tuple[float, int, bool] = (1.0, 0, False)
 
         # Metronome state.
         self._metronome_enabled: bool = False
@@ -883,6 +890,7 @@ class MultiTrackPlayer(QObject):
         self._looping = False
         self._playback_speed = 1.0
         self._pitch_semitones = 0
+        self._applied_render_state = (1.0, 0, False)
         self._recording_armed = False
         self._recording = False
         self._recording_buffer = None
@@ -1236,7 +1244,7 @@ class MultiTrackPlayer(QObject):
         audio is ready.
         """
         speed = max(0.5, min(speed, 2.0))
-        if speed == self._playback_speed:
+        if speed == self._playback_speed and self._stems_render_current():
             return
         self._playback_speed = speed
         self._render_stretch(emit=("speed",))
@@ -1254,10 +1262,31 @@ class MultiTrackPlayer(QObject):
             return
         semitones = max(PITCH_MIN_SEMITONES,
                         min(PITCH_MAX_SEMITONES, semitones))
-        if semitones == self._pitch_semitones:
+        if semitones == self._pitch_semitones and self._stems_render_current():
             return
         self._pitch_semitones = semitones
         self._render_stretch(emit=("pitch",))
+
+    def _target_render_state(self) -> tuple[float, int, bool]:
+        """The render state the knobs currently ask for.
+
+        The sync-recording-pitch flag only changes audible output while
+        a pitch shift is active, so it is normalised to False at pitch 0
+        -- toggling the preference at pitch 0 must not mark the stems
+        stale.
+        """
+        pitch = self._pitch_semitones
+        sync = self._sync_recording_pitch if pitch != 0 else False
+        return (self._playback_speed, pitch, sync)
+
+    def _stems_render_current(self) -> bool:
+        """True when self._stems already reflect the knob values.
+
+        False means a render is owed -- either one is in flight, or a
+        previous one was discarded by ``cancel_stretch()`` before it
+        could land.
+        """
+        return self._applied_render_state == self._target_render_state()
 
     def set_sync_recording_pitch(self, sync: bool) -> None:
         """Enable or disable pitch-shifting of recording-take stems.
@@ -1296,6 +1325,15 @@ class MultiTrackPlayer(QObject):
         self._pending_render_emit = None
 
         if not self._original_stems:
+            self._emit_stretch_signals(emit)
+            if was_rendering or had_pending:
+                self.stretch_finished.emit()
+            return
+
+        if self._stems_render_current():
+            # Stems already reflect the target -- e.g. a cancelled scrub
+            # came back to the applied value, or a completed render landed
+            # just before this request. Nothing to render.
             self._emit_stretch_signals(emit)
             if was_rendering or had_pending:
                 self.stretch_finished.emit()
@@ -1390,6 +1428,14 @@ class MultiTrackPlayer(QObject):
             worker.finished.connect(
                 lambda w=worker: self._reap_detached_worker(w)
             )
+            if not worker.isRunning():
+                # The thread can finish between the isRunning() check
+                # above and the connect() -- the finished signal then
+                # fired with nobody listening, and the worker would sit
+                # in _detached_workers forever, blocking every queued
+                # render. Reap it now; the reaper tolerates a double
+                # call if the signal did land after all.
+                self._reap_detached_worker(worker)
         else:
             worker.setParent(None)
             worker.deleteLater()
@@ -1419,7 +1465,10 @@ class MultiTrackPlayer(QObject):
         try:
             self._detached_workers.remove(worker)
         except ValueError:
-            pass
+            # Already reaped (double delivery: manual reap in
+            # _detach_stretch_worker plus the queued finished signal).
+            # The wrapper may already be deleteLater'd -- don't touch it.
+            return
         worker.setParent(None)
         worker.deleteLater()
 
@@ -1433,6 +1482,13 @@ class MultiTrackPlayer(QObject):
         self._pending_render_emit = None
 
         if not self._original_stems:
+            self._emit_stretch_signals(emit)
+            self.stretch_finished.emit()
+            return
+
+        if self._stems_render_current():
+            # A completed render landed before the queued request was
+            # dispatched and already matches the target.
             self._emit_stretch_signals(emit)
             self.stretch_finished.emit()
             return
@@ -1487,6 +1543,11 @@ class MultiTrackPlayer(QObject):
 
     def _apply_stretched_stems(self, stems: dict) -> None:
         """Replace current stems with *stems* and adjust frame indices."""
+        # Every call site applies stems that realise the knob values as
+        # they stand right now (any knob change detaches the worker whose
+        # completion would land here), so the applied state is simply the
+        # current target.
+        self._applied_render_state = self._target_render_state()
         old_total = self._total_frames if self._total_frames > 0 else 1
 
         self._stems = stems

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -824,7 +824,8 @@ class MainWindow(QMainWindow):
                 if idx >= 0:
                     self._player_controls._speed_combo.setCurrentIndex(idx)
                 self._player_controls._speed_combo.blockSignals(False)
-                self._player_controls._speed_status.setText("Stretching...")
+                # Status text driven by the player's stretch_started/progress
+                # signals -- no need to set it manually here.
                 self._player.set_speed(speed)
 
         # Metronome state

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -46,12 +46,17 @@ from src.app_settings import (
     read_default_export_format,
     read_default_mp3_bitrate,
     read_latency_offset_ms,
+    read_sync_recording_pitch,
 )
 from src.data_paths import consume_data_dir_reset_notice
 from src.exporter import ExportWorker, StemExporter
 from src.library import SongLibrary
 from src.model_manager import ModelManager
-from src.player import MultiTrackPlayer
+from src.player import (
+    PITCH_MAX_SEMITONES,
+    PITCH_MIN_SEMITONES,
+    MultiTrackPlayer,
+)
 from src.ui.animated_logo import AnimatedLogoWidget
 from src.ui.library_panel import REPEAT_ALL, REPEAT_OFF, REPEAT_ONE, LibraryPanel
 from src.ui.player_controls import PlayerControls, _format_time
@@ -136,6 +141,9 @@ class MainWindow(QMainWindow):
         )
         self._player.set_latency_offset_ms(
             read_latency_offset_ms(self._settings)
+        )
+        self._player.set_sync_recording_pitch(
+            read_sync_recording_pitch(self._settings)
         )
         self._intro_pending = True
         QTimer.singleShot(0, self._maybe_show_data_dir_reset_notice)
@@ -291,6 +299,12 @@ class MainWindow(QMainWindow):
         u(Qt.Modifier.SHIFT | Qt.Key.Key_Down,
           lambda: self._player_controls.cycle_speed(-1))
 
+        # -- Pitch (Shift+Left/Right) -- unguarded; one semitone per press.
+        u(Qt.Modifier.SHIFT | Qt.Key.Key_Right,
+          lambda: self._player_controls.bump_pitch(1))
+        u(Qt.Modifier.SHIFT | Qt.Key.Key_Left,
+          lambda: self._player_controls.bump_pitch(-1))
+
         # -- Loop --
         g(Qt.Key.Key_A, self._player_controls.set_loop_a)
         g(Qt.Key.Key_B, self._player_controls.set_loop_b)
@@ -419,6 +433,9 @@ class MainWindow(QMainWindow):
             self._player.set_latency_offset_ms(
                 read_latency_offset_ms(self._settings)
             )
+            self._player.set_sync_recording_pitch(
+                read_sync_recording_pitch(self._settings)
+            )
 
     def apply_theme(self, theme: str, colors: dict[str, str]) -> None:
         """Apply a theme to all child widgets that need explicit updates."""
@@ -492,9 +509,10 @@ class MainWindow(QMainWindow):
             + row("0-9", "Jump to 0%–90% position")
             + row("Left / Right", "Seek −5s / +5s")
             + row("Home / End", "Jump to start / end")
-            + section("Volume &amp; Speed")
+            + section("Volume, Speed &amp; Pitch")
             + row("Up / Down", "Master volume")
             + row("Shift+Up / Down", "Speed up / down")
+            + row("Shift+Left / Right", "Transpose \u2212 / + 1 semitone")
             + section("Stems")
             + row("Ctrl+1-6", "Mute/unmute stem")
             + section("Loop")
@@ -598,6 +616,9 @@ class MainWindow(QMainWindow):
         self._settings.setValue("session/loop_b", loop_b if loop_b is not None else -1)
         self._settings.setValue("session/looping", self._player.looping)
         self._settings.setValue("session/speed", self._player.speed)
+        self._settings.setValue(
+            "session/pitch_semitones", self._player.pitch_semitones
+        )
         self._settings.setValue(
             "session/metronome_bpm", self._player.metronome_bpm
         )
@@ -734,33 +755,77 @@ class MainWindow(QMainWindow):
             bool(looping),
         )
 
-        # Speed (async — seek after stretch completes)
+        # Speed + pitch (async — seek after stretch completes). When both
+        # are non-identity, the pitch worker is superseded by the speed
+        # worker, which renders both in a single pass.
         try:
             speed = float(self._settings.value("session/speed", 1.0))
         except (TypeError, ValueError):
             speed = 1.0
 
         try:
+            pitch_semi = int(self._settings.value(
+                "session/pitch_semitones", 0,
+            ))
+        except (TypeError, ValueError):
+            pitch_semi = 0
+        pitch_semi = max(
+            PITCH_MIN_SEMITONES, min(PITCH_MAX_SEMITONES, pitch_semi),
+        )
+
+        try:
             position = float(self._settings.value("session/position", 0.0))
         except (TypeError, ValueError):
             position = 0.0
 
-        if speed != 1.0:
-            def _after_speed_applied(_s: float, pos=position) -> None:
-                self._player.speed_changed.disconnect(_after_speed_applied)
-                self._player.seek(pos)
+        # Sync the spinbox display now so the UI matches the restored
+        # state even if the render is superseded (pitch_changed wouldn't
+        # fire in that case).
+        self._player_controls._pitch_spin.blockSignals(True)
+        self._player_controls._pitch_spin.setValue(pitch_semi)
+        self._player_controls._pitch_spin.blockSignals(False)
 
-            self._player.speed_changed.connect(_after_speed_applied)
-            self._player_controls._speed_combo.blockSignals(True)
-            label = f"{speed}x"
-            idx = self._player_controls._speed_combo.findText(label)
-            if idx >= 0:
-                self._player_controls._speed_combo.setCurrentIndex(idx)
-            self._player_controls._speed_combo.blockSignals(False)
-            self._player_controls._speed_status.setText("Stretching...")
-            self._player.set_speed(speed)
-        else:
+        speed_non_identity = speed != 1.0
+        pitch_non_identity = pitch_semi != 0
+
+        def _seek_after_render(_v: object = None, pos=position) -> None:
+            self._player.seek(pos)
+            # Ensure key label reflects pitch even if only speed_changed fired.
+            self._player_controls._refresh_key_label()
+
+        if not speed_non_identity and not pitch_non_identity:
             self._player.seek(position)
+        else:
+            # The last signal to fire is the one from the final render;
+            # speed supersedes pitch when both are active.
+            if speed_non_identity:
+                def _after_speed(_s: float) -> None:
+                    try:
+                        self._player.speed_changed.disconnect(_after_speed)
+                    except (TypeError, RuntimeError):
+                        pass
+                    _seek_after_render()
+                self._player.speed_changed.connect(_after_speed)
+            else:
+                def _after_pitch(_p: int) -> None:
+                    try:
+                        self._player.pitch_changed.disconnect(_after_pitch)
+                    except (TypeError, RuntimeError):
+                        pass
+                    _seek_after_render()
+                self._player.pitch_changed.connect(_after_pitch)
+
+            if pitch_non_identity:
+                self._player.set_pitch(pitch_semi)
+            if speed_non_identity:
+                self._player_controls._speed_combo.blockSignals(True)
+                label = f"{speed}x"
+                idx = self._player_controls._speed_combo.findText(label)
+                if idx >= 0:
+                    self._player_controls._speed_combo.setCurrentIndex(idx)
+                self._player_controls._speed_combo.blockSignals(False)
+                self._player_controls._speed_status.setText("Stretching...")
+                self._player.set_speed(speed)
 
         # Metronome state
         try:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -59,8 +59,12 @@ from src.player import (
 )
 from src.ui.animated_logo import AnimatedLogoWidget
 from src.ui.library_panel import REPEAT_ALL, REPEAT_OFF, REPEAT_ONE, LibraryPanel
-from src.ui.player_controls import PlayerControls, _format_time
-from src.ui.styles import get_colors, get_stylesheet
+from src.ui.player_controls import (
+    PlayerControls,
+    _format_time,
+    shutdown_peak_pool,
+)
+from src.ui.styles import apply_tooltip_palette, get_colors, get_stylesheet
 from src.version import __version__
 
 ALL_STEM_NAMES = ("vocals", "drums", "bass", "other", "guitar", "piano")
@@ -371,7 +375,9 @@ class MainWindow(QMainWindow):
     def _adjust_master_volume(self, delta: float) -> None:
         """Adjust master volume by *delta* (clamped 0.0–2.0)."""
         new_vol = max(0.0, min(2.0, self._player.master_volume + delta))
-        self._player.set_master_volume(new_vol)
+        # Route through PlayerControls so the slider + percent label in
+        # the transport row stay in sync with the player.
+        self._player_controls.set_master_volume(new_vol)
         self._show_volume_toast(new_vol)
 
     def _show_volume_toast(self, volume: float) -> None:
@@ -462,6 +468,9 @@ class MainWindow(QMainWindow):
         app = QApplication.instance()
         if app is not None:
             app.setStyleSheet(get_stylesheet(self._theme))
+        # Palette-based tooltip colors survive child widget stylesheet
+        # scopes; the QSS rule alone isn't reliable on toggle.
+        apply_tooltip_palette(self._theme)
 
         colors = get_colors(self._theme)
         self.apply_theme(self._theme, colors)
@@ -734,7 +743,7 @@ class MainWindow(QMainWindow):
             )
         except (TypeError, ValueError):
             master_vol = 1.0
-        self._player.set_master_volume(master_vol)
+        self._player_controls.set_master_volume(master_vol)
 
         # Loop points
         try:
@@ -935,6 +944,12 @@ class MainWindow(QMainWindow):
             self._export_worker.wait(5000)
 
         self._player.stop()
+        # Cancel and drain stretch/peak workers *before* Qt tears down,
+        # otherwise Python's atexit blocks in ThreadPoolExecutor.join()
+        # (librosa pitch/time-stretch is uninterruptible mid-call, so
+        # the pool threads can't exit until the current stem finishes).
+        self._player.shutdown()
+        shutdown_peak_pool()
 
         super().closeEvent(event)
 

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -1027,6 +1027,11 @@ class PlayerControls(QWidget):
         self._speed_combo.blockSignals(False)
         self._speed_status.setText("")
 
+        # Kill any in-flight debounce from the previous song so a pending
+        # scroll doesn't fire set_pitch against the freshly loaded stems.
+        self._pitch_debounce.stop()
+        self._pending_pitch = None
+
         self._pitch_spin.blockSignals(True)
         self._pitch_spin.setValue(0)
         self._pitch_spin.blockSignals(False)
@@ -2132,12 +2137,20 @@ class PlayerControls(QWidget):
         return len(self._recording_rows) >= _MAX_RECORDING_TAKES
 
     def update_record_button_state(self) -> None:
-        """Sync Record button enabled state with current speed."""
-        at_1x = self._player.speed == 1.0
-        self._record_btn.setEnabled(at_1x and self._player.has_stems)
-        if not at_1x:
+        """Sync Record button enabled state with current speed and pitch."""
+        at_identity = (
+            self._player.speed == 1.0
+            and self._player.pitch_semitones == 0
+        )
+        self._record_btn.setEnabled(at_identity and self._player.has_stems)
+        if not at_identity:
+            reasons = []
+            if self._player.speed != 1.0:
+                reasons.append("1.0x speed")
+            if self._player.pitch_semitones != 0:
+                reasons.append("0 st pitch")
             self._record_btn.setToolTip(
-                "Recording requires 1.0x speed"
+                "Recording requires " + " and ".join(reasons)
             )
             if self._record_btn.isChecked():
                 self._record_btn.blockSignals(True)

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -751,13 +751,26 @@ class PlayerControls(QWidget):
         self._pitch_spin.setRange(PITCH_MIN_SEMITONES, PITCH_MAX_SEMITONES)
         self._pitch_spin.setValue(0)
         self._pitch_spin.setSuffix(" st")
-        self._pitch_spin.setFixedWidth(70)
+        # Room for the "… 1/6" progress suffix that appears during a render.
+        self._pitch_spin.setFixedWidth(130)
         self._pitch_spin.setToolTip(
             "Transpose in semitones (Shift+Left / Shift+Right)"
         )
         self._pitch_spin.setAccessibleName("Pitch semitones")
         self._pitch_spin.valueChanged.connect(self._on_pitch_changed)
         loop_speed_bar.addWidget(self._pitch_spin)
+
+        # Debounce rapid spinbox scrolling so we don't spawn a librosa
+        # render for every intermediate semitone when the user scrubs
+        # through 1..7st. Each pitch render takes ~1-2s per stem; without
+        # debounce, holding the up arrow or scrolling the wheel pile up
+        # parallel workers, saturating the CPU and (historically) crashing
+        # the QThread layer.
+        self._pitch_debounce = QTimer(self)
+        self._pitch_debounce.setSingleShot(True)
+        self._pitch_debounce.setInterval(200)
+        self._pitch_debounce.timeout.connect(self._flush_pending_pitch)
+        self._pending_pitch: int | None = None
 
         controls_layout.addLayout(loop_speed_bar)
 
@@ -983,6 +996,9 @@ class PlayerControls(QWidget):
         self._player.play_finished.connect(self._on_play_finished)
         self._player.speed_changed.connect(self._on_speed_applied)
         self._player.pitch_changed.connect(self._on_pitch_applied)
+        self._player.stretch_started.connect(self._on_stretch_started)
+        self._player.stretch_progress.connect(self._on_stretch_progress)
+        self._player.stretch_finished.connect(self._on_stretch_finished)
 
     def set_stem_names(self, stem_names: list[str]) -> None:
         """Populate the stem mixer with rows for each stem."""
@@ -1318,12 +1334,12 @@ class PlayerControls(QWidget):
         speed = self._speed_combo.currentData()
         if speed is None:
             return
-        self._speed_status.setText("Stretching..." if speed != 1.0 else "")
+        # Status text is now driven by stretch_started/progress/finished
+        # signals from the player, not set here. Spawn the render.
         self._player.set_speed(speed)
 
     def _on_speed_applied(self, speed: float) -> None:
         """Player finished stretching; update UI."""
-        self._speed_status.setText("")
         self._speed_combo.blockSignals(True)
         label = f"{speed}x"
         idx = self._speed_combo.findText(label)
@@ -1346,13 +1362,33 @@ class PlayerControls(QWidget):
     # -- Pitch control slots --
 
     def _on_pitch_changed(self, semitones: int) -> None:
-        """User adjusted the pitch spinbox."""
-        self._speed_status.setText("Stretching..." if semitones != 0 else "")
-        self._player.set_pitch(int(semitones))
+        """User adjusted the pitch spinbox.
+
+        We don't call ``player.set_pitch`` immediately; a 200ms debounce
+        timer coalesces rapid scroll/arrow input into a single render.
+        The descriptive status text is set by ``_on_stretch_started``
+        once the worker actually spawns, not while the user is still
+        adjusting the value.
+
+        Any already-running render is cancelled right away so we stop
+        wasting CPU on a stale target -- the new render will spawn when
+        the debounce timer fires.
+        """
+        self._pending_pitch = int(semitones)
+        self._pitch_debounce.start()
+        # Kill the stale render immediately; the next one is queued.
+        self._player.cancel_stretch()
+
+    def _flush_pending_pitch(self) -> None:
+        """Apply the latest pitch value after the debounce window expires."""
+        if self._pending_pitch is None:
+            return
+        pitch = self._pending_pitch
+        self._pending_pitch = None
+        self._player.set_pitch(pitch)
 
     def _on_pitch_applied(self, semitones: int) -> None:
         """Player finished pitch-shifting; update UI."""
-        self._speed_status.setText("")
         self._pitch_spin.blockSignals(True)
         self._pitch_spin.setValue(int(semitones))
         self._pitch_spin.blockSignals(False)
@@ -1369,6 +1405,87 @@ class PlayerControls(QWidget):
             direction: +1 for up, -1 for down. Clamped by the spinbox range.
         """
         self._pitch_spin.setValue(self._pitch_spin.value() + direction)
+
+    # -- Stretch worker progress indicator --
+    #
+    # Progress is shown *inside* the control the user is manipulating:
+    # the pitch spinbox suffix becomes " st (2/4)" during a pitch render,
+    # and a short "Time-stretching stems…" label sits next to the speed
+    # combo (combos can't carry inline progress text).  The spinbox stays
+    # enabled throughout -- scrolling it cancels the in-flight render
+    # and queues a fresh one via the debounce timer.
+
+    def _on_stretch_started(self) -> None:
+        """Begin showing render progress on the active control.
+
+        The spinbox stays enabled so the user can keep scrubbing -- the
+        player cancels the in-flight worker as soon as a new target is
+        committed (see ``_flush_pending_pitch``).
+        """
+        self._update_stretch_indicator(0, 0)
+
+    def _on_stretch_progress(self, current: int, total: int) -> None:
+        """Update the live render indicator with per-stem progress."""
+        self._update_stretch_indicator(current, total)
+
+    def _on_stretch_finished(self) -> None:
+        """Clear the render indicator and restore the idle suffix."""
+        self._pitch_spin.setSuffix(" st")
+        self._speed_status.setText("")
+
+    def _update_stretch_indicator(self, current: int, total: int) -> None:
+        """Paint render progress onto the pitch spinbox / speed label.
+
+        Pitch progress goes on the spinbox as a suffix
+        (e.g. ``" st (2/4)"``) so the indicator is unmistakably tied
+        to the control that spawned the render.  Speed progress stays
+        as a small label next to the speed combo, since combos can't
+        carry inline suffix text.
+        """
+        pitch_on = self._player.pitch_semitones != 0
+        speed_on = self._player.speed != 1.0
+
+        if pitch_on:
+            if total > 0:
+                self._pitch_spin.setSuffix(f" st ({current}/{total})")
+            else:
+                self._pitch_spin.setSuffix(" st\u2026")
+        else:
+            self._pitch_spin.setSuffix(" st")
+
+        if speed_on and not pitch_on:
+            verb = "Time-stretching"
+            if total > 0:
+                self._speed_status.setText(
+                    f"{verb} stems ({current}/{total})\u2026"
+                )
+            else:
+                self._speed_status.setText(f"{verb} stems\u2026")
+        else:
+            # When pitch is active, the spinbox suffix already carries
+            # the indicator; don't duplicate it in a floating label.
+            self._speed_status.setText("")
+
+    def _render_status_label(self, current: int, total: int) -> str:
+        """Compose the floating-label status text (speed-only renders).
+
+        Retained for tests and for callers that want a single-string
+        status. For the pitch case the spinbox suffix is authoritative.
+        """
+        pitch_on = self._player.pitch_semitones != 0
+        speed_on = self._player.speed != 1.0
+        if pitch_on and speed_on:
+            verb = "Transposing and time-stretching"
+        elif pitch_on:
+            verb = "Transposing"
+        elif speed_on:
+            verb = "Time-stretching"
+        else:
+            # Transition back to identity (fast path emits no progress).
+            verb = "Rendering"
+        if total > 0:
+            return f"{verb} stems ({current}/{total})\u2026"
+        return f"{verb} stems\u2026"
 
     # -- Metronome handlers --
 

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -26,9 +26,14 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from src.beat_detector import DetectionResult, DetectionWorker
+from src.beat_detector import DetectionResult, DetectionWorker, transpose_key
 from src.metronome import tap_tempo
-from src.player import SPEED_PRESETS, MultiTrackPlayer
+from src.player import (
+    PITCH_MAX_SEMITONES,
+    PITCH_MIN_SEMITONES,
+    SPEED_PRESETS,
+    MultiTrackPlayer,
+)
 from src.ui.animated_arpeggio import AnimatedArpeggioWidget
 from src.ui.animated_logo import AnimatedLogoWidget
 from src.ui.styles import (
@@ -739,6 +744,21 @@ class PlayerControls(QWidget):
         self._speed_combo.currentIndexChanged.connect(self._on_speed_changed)
         loop_speed_bar.addWidget(self._speed_combo)
 
+        self._pitch_label = QLabel("Pitch:")
+        loop_speed_bar.addWidget(self._pitch_label)
+
+        self._pitch_spin = QSpinBox()
+        self._pitch_spin.setRange(PITCH_MIN_SEMITONES, PITCH_MAX_SEMITONES)
+        self._pitch_spin.setValue(0)
+        self._pitch_spin.setSuffix(" st")
+        self._pitch_spin.setFixedWidth(70)
+        self._pitch_spin.setToolTip(
+            "Transpose in semitones (Shift+Left / Shift+Right)"
+        )
+        self._pitch_spin.setAccessibleName("Pitch semitones")
+        self._pitch_spin.valueChanged.connect(self._on_pitch_changed)
+        loop_speed_bar.addWidget(self._pitch_spin)
+
         controls_layout.addLayout(loop_speed_bar)
 
         # -- Metronome bar --
@@ -923,11 +943,7 @@ class PlayerControls(QWidget):
         # spans from the previous theme.
         badge = self._badge_style()
         if self._detected_key_raw:
-            key_c = self._conf_color(self._key_conf) if self._key_conf else ""
-            self._key_label.setStyleSheet(badge)
-            self._key_label.setText(
-                self._badge_html("Key:", self._detected_key_raw, key_c)
-            )
+            self._refresh_key_label()
         if self._detected_bpm_raw:
             bpm_c = self._conf_color(self._bpm_conf) if self._bpm_conf else ""
             self._detected_bpm_label.setStyleSheet(badge)
@@ -966,6 +982,7 @@ class PlayerControls(QWidget):
         self._player.state_changed.connect(self._on_state_changed)
         self._player.play_finished.connect(self._on_play_finished)
         self._player.speed_changed.connect(self._on_speed_applied)
+        self._player.pitch_changed.connect(self._on_pitch_applied)
 
     def set_stem_names(self, stem_names: list[str]) -> None:
         """Populate the stem mixer with rows for each stem."""
@@ -993,6 +1010,10 @@ class PlayerControls(QWidget):
         self._speed_combo.setCurrentText("1.0x")
         self._speed_combo.blockSignals(False)
         self._speed_status.setText("")
+
+        self._pitch_spin.blockSignals(True)
+        self._pitch_spin.setValue(0)
+        self._pitch_spin.blockSignals(False)
 
         self._record_btn.blockSignals(True)
         self._record_btn.setChecked(False)
@@ -1322,6 +1343,33 @@ class PlayerControls(QWidget):
         idx = max(0, min(idx, self._speed_combo.count() - 1))
         self._speed_combo.setCurrentIndex(idx)
 
+    # -- Pitch control slots --
+
+    def _on_pitch_changed(self, semitones: int) -> None:
+        """User adjusted the pitch spinbox."""
+        self._speed_status.setText("Stretching..." if semitones != 0 else "")
+        self._player.set_pitch(int(semitones))
+
+    def _on_pitch_applied(self, semitones: int) -> None:
+        """Player finished pitch-shifting; update UI."""
+        self._speed_status.setText("")
+        self._pitch_spin.blockSignals(True)
+        self._pitch_spin.setValue(int(semitones))
+        self._pitch_spin.blockSignals(False)
+        # Refresh peaks (buffers may have new lengths after a combined render)
+        self._do_recompute_peaks()
+        # Refresh the detected-key label to show the transposed key.
+        self._refresh_key_label()
+        self.update_record_button_state()
+
+    def bump_pitch(self, direction: int) -> None:
+        """Nudge the pitch spinbox by one semitone.
+
+        Args:
+            direction: +1 for up, -1 for down. Clamped by the spinbox range.
+        """
+        self._pitch_spin.setValue(self._pitch_spin.value() + direction)
+
     # -- Metronome handlers --
 
     def _on_bpm_changed(self, value: int) -> None:
@@ -1502,6 +1550,33 @@ class PlayerControls(QWidget):
             )
         return f'<span style="color:{val_c};">{value}</span>'
 
+    def _refresh_key_label(self) -> None:
+        """Re-render the key badge, showing ``detected → effective`` when pitch != 0."""
+        if not self._detected_key_raw:
+            return
+        pitch = self._player.pitch_semitones
+        key_c = self._conf_color(self._key_conf) if self._key_conf else ""
+        self._key_label.setStyleSheet(self._badge_style())
+        if pitch == 0:
+            self._key_label.setText(
+                self._badge_html("Key:", self._detected_key_raw, key_c)
+            )
+            self._key_label.setToolTip(
+                f"Detected key: {self._detected_key_raw}\n"
+                f"Confidence: {self._key_conf}\n"
+                f"Double-click to re-detect"
+            )
+            return
+        effective = transpose_key(self._detected_key_raw, pitch)
+        shown = f"{self._detected_key_raw} \u2192 {effective}"
+        self._key_label.setText(self._badge_html("Key:", shown, key_c))
+        self._key_label.setToolTip(
+            f"Detected key: {self._detected_key_raw}\n"
+            f"Transposed by {pitch:+d} st: {effective}\n"
+            f"Confidence: {self._key_conf}\n"
+            f"Double-click to re-detect"
+        )
+
     def _update_sync_btn_state(self, has_beats: bool) -> None:
         """Update beat-sync button enabled state."""
         self._beat_sync_btn.setEnabled(has_beats)
@@ -1548,16 +1623,7 @@ class PlayerControls(QWidget):
         if result.key:
             self._key_conf = result.key_confidence
             self._detected_key_raw = result.key
-            key_c = self._conf_color(result.key_confidence)
-            self._key_label.setStyleSheet(badge)
-            self._key_label.setText(
-                self._badge_html("Key:", result.key, key_c)
-            )
-            self._key_label.setToolTip(
-                f"Detected key: {result.key}\n"
-                f"Confidence: {result.key_confidence}\n"
-                f"Double-click to re-detect"
-            )
+            self._refresh_key_label()
         else:
             self._key_label.setText("")
             self._key_label.setStyleSheet("")
@@ -1620,14 +1686,7 @@ class PlayerControls(QWidget):
         if result.key:
             self._key_conf = result.key_confidence
             self._detected_key_raw = result.key
-            key_c = self._conf_color(result.key_confidence)
-            self._key_label.setStyleSheet(self._badge_style())
-            self._key_label.setText(self._badge_html("Key:", result.key, key_c))
-            self._key_label.setToolTip(
-                f"Detected key: {result.key}\n"
-                f"Confidence: {result.key_confidence}\n"
-                f"Double-click to re-detect"
-            )
+            self._refresh_key_label()
         else:
             self._key_label.setText("")
             self._key_label.setStyleSheet("")
@@ -1719,14 +1778,7 @@ class PlayerControls(QWidget):
         self._detected_key_raw = key
         if key:
             self._key_conf = confidence
-            c = self._conf_color(confidence) if confidence else ""
-            self._key_label.setStyleSheet(self._badge_style())
-            self._key_label.setText(self._badge_html("Key:", key, c))
-            parts = [f"Detected key: {key}"]
-            if confidence:
-                parts.append(f"Confidence: {confidence}")
-            parts.append("Double-click to re-detect")
-            self._key_label.setToolTip("\n".join(parts))
+            self._refresh_key_label()
         else:
             self._key_label.setText("")
             self._key_label.setStyleSheet("")

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -22,6 +22,8 @@ from PySide6.QtWidgets import (
     QPushButton,
     QSlider,
     QSpinBox,
+    QStyle,
+    QStyleOptionSpinBox,
     QVBoxLayout,
     QWidget,
 )
@@ -291,7 +293,43 @@ class PitchSpinBox(QSpinBox):
     QSpinBox always renders ``prefix + textFromValue(value) + suffix``,
     so ``suffix`` is used exclusively for the live render-progress tail
     (e.g. ``" (processing 2/4)"``) and kept empty when idle.
+
+    The default ``QSpinBox.sizeHint`` is based on the widest possible
+    value ("+12 semitones"), which isn't enough during rendering
+    ("+12 semitones (processing 10/10)") and wastes space when idle
+    ("original").  We override ``sizeHint`` and ``minimumSizeHint``
+    to fit the *current* displayed text instead, and call
+    ``updateGeometry`` when the text changes so the parent layout
+    shrink-wraps immediately.
     """
+
+    def setSuffix(self, suffix: str) -> None:  # noqa: D401 (Qt API)
+        super().setSuffix(suffix)
+        self.updateGeometry()
+
+    def _hint_for_text(self, text: str) -> QSize:
+        """Compute the spinbox sizeHint that fits ``text`` exactly.
+
+        Uses QStyle.sizeFromContents so button/frame padding matches
+        whatever the active style (native or stylesheet) would apply.
+        """
+        fm = self.fontMetrics()
+        text_w = fm.horizontalAdvance(text)
+        text_h = fm.height()
+        # A few pixels of slack so the cursor doesn't butt up against
+        # the frame on focus.
+        content = QSize(text_w + 6, text_h)
+        opt = QStyleOptionSpinBox()
+        self.initStyleOption(opt)
+        return self.style().sizeFromContents(
+            QStyle.ContentsType.CT_SpinBox, opt, content, self,
+        )
+
+    def sizeHint(self) -> QSize:  # noqa: D401 (Qt API)
+        return self._hint_for_text(self.text())
+
+    def minimumSizeHint(self) -> QSize:  # noqa: D401 (Qt API)
+        return self._hint_for_text(self.text())
 
     def textFromValue(self, value: int) -> str:  # noqa: D401 (Qt API)
         if value == 0:
@@ -482,7 +520,7 @@ class RecordingStemRow(StemRow):
         self._nudge_spin.setRange(-200, 200)
         self._nudge_spin.setValue(0)
         self._nudge_spin.setSuffix(" ms")
-        self._nudge_spin.setFixedWidth(104)
+        # Default sizeHint fits "-200 ms" -- no fixed width needed.
         self._nudge_spin.setToolTip(
             f"Nudge {display_name} alignment (-200 to +200 ms)"
         )
@@ -668,7 +706,8 @@ class PlayerControls(QWidget):
         self._count_in_beats_spin.setRange(1, 8)
         self._count_in_beats_spin.setValue(4)
         self._count_in_beats_spin.setSuffix(" beats")
-        self._count_in_beats_spin.setFixedWidth(96)
+        # No setFixedWidth -- QSpinBox.sizeHint fits the widest value
+        # ("8 beats") plus frame + buttons, which is what we want.
         self._count_in_beats_spin.setToolTip("Number of count-in beats")
         self._count_in_beats_spin.setAccessibleName("Count-in beats")
         self._count_in_beats_spin.valueChanged.connect(
@@ -713,14 +752,12 @@ class PlayerControls(QWidget):
         loop_speed_bar = QHBoxLayout()
 
         self._loop_a_btn = QPushButton("Set A")
-        self._loop_a_btn.setFixedWidth(50)
         self._loop_a_btn.setToolTip("Set loop start point (A)")
         self._loop_a_btn.setAccessibleName("Set loop A")
         self._loop_a_btn.clicked.connect(self.set_loop_a)
         loop_speed_bar.addWidget(self._loop_a_btn)
 
         self._loop_b_btn = QPushButton("Set B")
-        self._loop_b_btn.setFixedWidth(50)
         self._loop_b_btn.setToolTip("Set loop end point (B)")
         self._loop_b_btn.setAccessibleName("Set loop B")
         self._loop_b_btn.clicked.connect(self.set_loop_b)
@@ -728,14 +765,12 @@ class PlayerControls(QWidget):
 
         self._loop_toggle_btn = QPushButton("Loop")
         self._loop_toggle_btn.setCheckable(True)
-        self._loop_toggle_btn.setFixedWidth(48)
         self._loop_toggle_btn.setToolTip("Toggle A-B loop (L)")
         self._loop_toggle_btn.setAccessibleName("Toggle loop")
         self._loop_toggle_btn.toggled.connect(self._on_loop_toggled)
         loop_speed_bar.addWidget(self._loop_toggle_btn)
 
         self._loop_clear_btn = QPushButton("Clear")
-        self._loop_clear_btn.setFixedWidth(48)
         self._loop_clear_btn.setToolTip("Clear loop points")
         self._loop_clear_btn.setAccessibleName("Clear loop")
         self._loop_clear_btn.clicked.connect(self._on_clear_loop)
@@ -773,7 +808,9 @@ class PlayerControls(QWidget):
         for preset in SPEED_PRESETS:
             self._speed_combo.addItem(f"{preset}x", preset)
         self._speed_combo.setCurrentText("1.0x")
-        self._speed_combo.setFixedWidth(66)
+        self._speed_combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToContents
+        )
         self._speed_combo.setToolTip("Playback speed ([ / ])")
         self._speed_combo.setAccessibleName("Playback speed")
         self._speed_combo.currentIndexChanged.connect(self._on_speed_changed)
@@ -785,10 +822,7 @@ class PlayerControls(QWidget):
         self._pitch_spin = PitchSpinBox()
         self._pitch_spin.setRange(PITCH_MIN_SEMITONES, PITCH_MAX_SEMITONES)
         self._pitch_spin.setValue(0)
-        # The display ("+2 semitones") plus the processing suffix
-        # ("(processing 2/4)") need room without clipping; pick a width
-        # that fits "+12 semitones (processing 10/10)" comfortably.
-        self._pitch_spin.setFixedWidth(230)
+        # PitchSpinBox self-sizes via AdjustToContents; no fixed width.
         self._pitch_spin.setToolTip(
             "Transpose in semitones (Shift+Left / Shift+Right)"
         )
@@ -832,7 +866,7 @@ class PlayerControls(QWidget):
         self._bpm_spin.setRange(20, 300)
         self._bpm_spin.setValue(120)
         self._bpm_spin.setSuffix(" BPM")
-        self._bpm_spin.setFixedWidth(105)
+        # Default sizeHint fits "300 BPM" -- no fixed width needed.
         self._bpm_spin.setToolTip("Metronome tempo")
         self._bpm_spin.setAccessibleName("Metronome BPM")
         self._bpm_spin.valueChanged.connect(self._on_bpm_changed)
@@ -840,7 +874,6 @@ class PlayerControls(QWidget):
 
         self._tap_times: list[float] = []
         self._tap_btn = QPushButton("Tap")
-        self._tap_btn.setFixedWidth(46)
         self._tap_btn.setToolTip("Tap to set tempo")
         self._tap_btn.setAccessibleName("Tap tempo")
         self._tap_btn.clicked.connect(self._on_tap)
@@ -848,7 +881,6 @@ class PlayerControls(QWidget):
 
         self._beat_sync_btn = QPushButton("Sync")
         self._beat_sync_btn.setCheckable(True)
-        self._beat_sync_btn.setFixedWidth(50)
         self._beat_sync_btn.setToolTip(
             "Sync metronome to detected beats (click on actual beat positions)"
         )
@@ -861,7 +893,7 @@ class PlayerControls(QWidget):
         self._beat_nudge_spin.setRange(-500, 500)
         self._beat_nudge_spin.setValue(0)
         self._beat_nudge_spin.setSuffix(" ms")
-        self._beat_nudge_spin.setFixedWidth(104)
+        # Default sizeHint fits "-500 ms" -- no fixed width needed.
         self._beat_nudge_spin.setToolTip("Metronome nudge (shift metronome clicking)")
         self._beat_nudge_spin.setAccessibleName("Sync Nudge")
         self._beat_nudge_spin.valueChanged.connect(self._on_beat_nudge_changed)
@@ -889,7 +921,9 @@ class PlayerControls(QWidget):
         for v in _MET_VOL_PRESETS:
             self._metronome_vol_combo.addItem(f"{v}%", v)
         self._metronome_vol_combo.setCurrentText("100%")
-        self._metronome_vol_combo.setFixedWidth(62)
+        self._metronome_vol_combo.setSizeAdjustPolicy(
+            QComboBox.SizeAdjustPolicy.AdjustToContents
+        )
         self._metronome_vol_combo.setToolTip("Metronome volume")
         self._metronome_vol_combo.setAccessibleName("Metronome volume preset")
         self._metronome_vol_combo.activated.connect(

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -284,6 +284,41 @@ def _format_time(seconds: float) -> str:
     return f"{m}:{s:02d}"
 
 
+class PitchSpinBox(QSpinBox):
+    """Spinbox whose displayed text is human-readable ("original",
+    "+1 semitone", "-2 semitones") rather than a bare number.
+
+    QSpinBox always renders ``prefix + textFromValue(value) + suffix``,
+    so ``suffix`` is used exclusively for the live render-progress tail
+    (e.g. ``" (processing 2/4)"``) and kept empty when idle.
+    """
+
+    def textFromValue(self, value: int) -> str:  # noqa: D401 (Qt API)
+        if value == 0:
+            return "original"
+        sign = "+" if value > 0 else "-"
+        magnitude = abs(value)
+        word = "semitone" if magnitude == 1 else "semitones"
+        return f"{sign}{magnitude} {word}"
+
+    def valueFromText(self, text: str) -> int:  # noqa: D401 (Qt API)
+        # Users edit via the wheel / spin buttons / keyboard arrows
+        # rather than typing, but Qt still calls valueFromText during
+        # focus-out.  Parse the leading signed integer if present;
+        # anything else (including "original") maps to 0.
+        import re
+        stripped = text.strip()
+        if not stripped:
+            return 0
+        match = re.match(r"[+-]?\d+", stripped)
+        if match:
+            try:
+                return int(match.group())
+            except ValueError:
+                return 0
+        return 0
+
+
 class StemRow(QWidget):
     """A single stem row with label, mute, and solo buttons."""
 
@@ -747,12 +782,13 @@ class PlayerControls(QWidget):
         self._pitch_label = QLabel("Pitch:")
         loop_speed_bar.addWidget(self._pitch_label)
 
-        self._pitch_spin = QSpinBox()
+        self._pitch_spin = PitchSpinBox()
         self._pitch_spin.setRange(PITCH_MIN_SEMITONES, PITCH_MAX_SEMITONES)
         self._pitch_spin.setValue(0)
-        self._pitch_spin.setSuffix(" st")
-        # Room for the "… 1/6" progress suffix that appears during a render.
-        self._pitch_spin.setFixedWidth(130)
+        # The display ("+2 semitones") plus the processing suffix
+        # ("(processing 2/4)") need room without clipping; pick a width
+        # that fits "+12 semitones (processing 10/10)" comfortably.
+        self._pitch_spin.setFixedWidth(230)
         self._pitch_spin.setToolTip(
             "Transpose in semitones (Shift+Left / Shift+Right)"
         )
@@ -1434,29 +1470,29 @@ class PlayerControls(QWidget):
         self._update_stretch_indicator(current, total)
 
     def _on_stretch_finished(self) -> None:
-        """Clear the render indicator and restore the idle suffix."""
-        self._pitch_spin.setSuffix(" st")
+        """Clear the render indicator and restore the idle display."""
+        self._pitch_spin.setSuffix("")
         self._speed_status.setText("")
 
     def _update_stretch_indicator(self, current: int, total: int) -> None:
         """Paint render progress onto the pitch spinbox / speed label.
 
-        Pitch progress goes on the spinbox as a suffix
-        (e.g. ``" st (2/4)"``) so the indicator is unmistakably tied
-        to the control that spawned the render.  Speed progress stays
-        as a small label next to the speed combo, since combos can't
-        carry inline suffix text.
+        The pitch spinbox's primary text ("+2 semitones") is produced by
+        :class:`PitchSpinBox.textFromValue`; this method only manages the
+        trailing progress suffix (e.g. ``" (processing 2/4)"``).  Speed
+        progress uses a small floating label next to the speed combo,
+        since QComboBox can't carry inline suffix text.
         """
         pitch_on = self._player.pitch_semitones != 0
         speed_on = self._player.speed != 1.0
 
         if pitch_on:
             if total > 0:
-                self._pitch_spin.setSuffix(f" st ({current}/{total})")
+                self._pitch_spin.setSuffix(f" (processing {current}/{total})")
             else:
-                self._pitch_spin.setSuffix(" st\u2026")
+                self._pitch_spin.setSuffix(" (processing\u2026)")
         else:
-            self._pitch_spin.setSuffix(" st")
+            self._pitch_spin.setSuffix("")
 
         if speed_on and not pitch_on:
             verb = "Time-stretching"

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -95,6 +95,80 @@ def _compute_peaks_bg(stems, muted, soloed, volumes, num_bins=2000,
 _peak_pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="peak")
 
 
+def _get_peak_pool() -> ThreadPoolExecutor:
+    """Return the module's peak-computation pool, recreating it if needed.
+
+    ``closeEvent`` calls ``shutdown_peak_pool`` to let the interpreter
+    exit promptly instead of blocking in atexit on an in-flight peak
+    computation.  In test runs several ``MainWindow`` instances are
+    constructed and closed sequentially; once the shared pool is shut
+    down, later tests still expect it to accept submits.  Rather than
+    plumb a per-window pool through every call site, we detect the
+    shutdown state and lazily spin up a fresh pool.
+    """
+    global _peak_pool
+    if getattr(_peak_pool, "_shutdown", False):
+        _peak_pool = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="peak",
+        )
+    return _peak_pool
+
+
+def _fit_spinbox_width(spin: QSpinBox, sample: str | None = None) -> None:
+    """Shrink a QSpinBox so its frame hugs its widest value.
+
+    Uses Qt's own ``QStyle.sizeFromContents(CT_SpinBox, ...)`` to get
+    the native frame + up/down-button chrome size -- the previous
+    hand-rolled formula underestimated on Windows (the native spinbox
+    arrows are ~20 px wide, not 16) and occasionally clipped the last
+    character of ``"120 BPM"`` and similar right-justified values.
+
+    *sample* may override the measured text for spinboxes whose
+    displayed width isn't captured by ``prefix+max+suffix`` (e.g.
+    negative-signed nudge values, PitchSpinBox).
+    """
+    if sample is None:
+        sample = f"{spin.prefix()}{spin.maximum()}{spin.suffix()}"
+    fm = spin.fontMetrics()
+    text_w = fm.horizontalAdvance(sample)
+    text_h = fm.height()
+    # Stylesheet adds 4px padding on each side -> 8px horizontal.
+    content = QSize(text_w + 8, text_h)
+    opt = QStyleOptionSpinBox()
+    spin.initStyleOption(opt)
+    hint = spin.style().sizeFromContents(
+        QStyle.ContentsType.CT_SpinBox, opt, content, spin,
+    )
+    # Small extra slack so the last character doesn't kiss the
+    # up/down button edge at fractional DPI scales.
+    spin.setFixedWidth(hint.width() + 4)
+
+
+def _fit_combo_width(combo: QComboBox, extra: int = 0) -> None:
+    """Shrink a QComboBox so its frame hugs its widest entry.
+
+    Similar reasoning to ``_fit_spinbox_width`` but for combos: accounts
+    for the padding, drop-down arrow, and border from ``styles.py``.
+    ``extra`` adds additional pixels when the combo is editable (its
+    ``QLineEdit`` child doubles up the left padding).
+    """
+    fm = combo.fontMetrics()
+    widest = 0
+    for i in range(combo.count()):
+        widest = max(widest, fm.horizontalAdvance(combo.itemText(i)))
+    combo.setFixedWidth(widest + 10 + 20 + 2 + 8 + extra)
+
+
+def shutdown_peak_pool() -> None:
+    """Shut down the module-level peak computation pool.
+
+    Called from the main window's ``closeEvent`` so the interpreter
+    doesn't block in ``atexit`` waiting for an in-flight waveform peak
+    computation to finish.
+    """
+    _peak_pool.shutdown(wait=True, cancel_futures=True)
+
+
 def _make_icon(draw_fn, color: QColor, size: int = _ICON_SIZE) -> QIcon:
     """Create a crisp QIcon by painting with *draw_fn(painter, size)*."""
     pixmap = QPixmap(QSize(size, size))
@@ -288,37 +362,43 @@ def _format_time(seconds: float) -> str:
 
 class PitchSpinBox(QSpinBox):
     """Spinbox whose displayed text is human-readable ("original",
-    "+1 semitone", "-2 semitones") rather than a bare number.
+    "+1 semi", "-2 semi") rather than a bare number.
 
     QSpinBox always renders ``prefix + textFromValue(value) + suffix``,
-    so ``suffix`` is used exclusively for the live render-progress tail
-    (e.g. ``" (processing 2/4)"``) and kept empty when idle.
+    so ``suffix`` is used exclusively for the live render-progress
+    tail (e.g. ``" (2/4)"``) and kept empty when idle.
 
-    The default ``QSpinBox.sizeHint`` is based on the widest possible
-    value ("+12 semitones"), which isn't enough during rendering
-    ("+12 semitones (processing 10/10)") and wastes space when idle
-    ("original").  We override ``sizeHint`` and ``minimumSizeHint``
-    to fit the *current* displayed text instead, and call
-    ``updateGeometry`` when the text changes so the parent layout
-    shrink-wraps immediately.
+    Sizing strategy: the width is *fixed at construction* to fit the
+    worst-case text ("+7 semi (10/10)") plus Qt's native frame chrome.
+    An earlier attempt dynamically resized the spinbox whenever the
+    text changed, via a per-text ``sizeHint`` override + a
+    ``updateGeometry`` call in ``setSuffix``.  That approach had two
+    failure modes:
+      - the parent QHBoxLayout sometimes refused to shrink the widget
+        when the text got shorter (layouts cache child hints between
+        full relayouts), so the spinbox stayed stuck at its widest
+        recent size with visible trailing whitespace;
+      - on DPI scales the layout *did* honour the smaller hint and
+        the spinbox would then snap narrower than the text needed,
+        clipping the processing suffix.
+    A single fixed width avoids both: "original" shows with a bit of
+    trailing space (acceptable -- it's the idle state), and
+    "+7 semi (10/10)" always fits.
     """
 
-    def setSuffix(self, suffix: str) -> None:  # noqa: D401 (Qt API)
-        super().setSuffix(suffix)
-        self.updateGeometry()
+    # Widest text we'll ever display: ±7 semitones max, and the
+    # progress counter maxes out at the stem count (≤ ~10 for any
+    # realistic project).  Longer strings would get clipped by Qt's
+    # right-padded up/down button so we only need to fit this case.
+    _WIDEST_TEXT = "+7 semi (10/10)"
 
-    def _hint_for_text(self, text: str) -> QSize:
-        """Compute the spinbox sizeHint that fits ``text`` exactly.
-
-        Uses QStyle.sizeFromContents so button/frame padding matches
-        whatever the active style (native or stylesheet) would apply.
-        """
+    def _compute_fixed_hint(self) -> QSize:
         fm = self.fontMetrics()
-        text_w = fm.horizontalAdvance(text)
+        text_w = fm.horizontalAdvance(self._WIDEST_TEXT)
         text_h = fm.height()
-        # A few pixels of slack so the cursor doesn't butt up against
-        # the frame on focus.
-        content = QSize(text_w + 6, text_h)
+        # Stylesheet's 4 px left+right padding (8 total) + slack for
+        # anti-aliasing and fractional-DPI rounding.
+        content = QSize(text_w + 16, text_h)
         opt = QStyleOptionSpinBox()
         self.initStyleOption(opt)
         return self.style().sizeFromContents(
@@ -326,18 +406,20 @@ class PitchSpinBox(QSpinBox):
         )
 
     def sizeHint(self) -> QSize:  # noqa: D401 (Qt API)
-        return self._hint_for_text(self.text())
+        return self._compute_fixed_hint()
 
     def minimumSizeHint(self) -> QSize:  # noqa: D401 (Qt API)
-        return self._hint_for_text(self.text())
+        return self._compute_fixed_hint()
 
     def textFromValue(self, value: int) -> str:  # noqa: D401 (Qt API)
+        # Compact display -- the accompanying label reads "Pitch:" so
+        # the unit can be abbreviated.  "semi" (short for semitone) is
+        # unambiguous in a music app without bloating the spinbox
+        # width every time the processing suffix is appended.
         if value == 0:
             return "original"
         sign = "+" if value > 0 else "-"
-        magnitude = abs(value)
-        word = "semitone" if magnitude == 1 else "semitones"
-        return f"{sign}{magnitude} {word}"
+        return f"{sign}{abs(value)} semi"
 
     def valueFromText(self, text: str) -> int:  # noqa: D401 (Qt API)
         # Users edit via the wheel / spin buttons / keyboard arrows
@@ -520,7 +602,7 @@ class RecordingStemRow(StemRow):
         self._nudge_spin.setRange(-200, 200)
         self._nudge_spin.setValue(0)
         self._nudge_spin.setSuffix(" ms")
-        # Default sizeHint fits "-200 ms" -- no fixed width needed.
+        _fit_spinbox_width(self._nudge_spin, sample="-200 ms")
         self._nudge_spin.setToolTip(
             f"Nudge {display_name} alignment (-200 to +200 ms)"
         )
@@ -679,6 +761,30 @@ class PlayerControls(QWidget):
         self._time_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         transport.addWidget(self._time_label)
 
+        # Master volume indicator (slider + percent).  Sits in the
+        # transport row so the user has a single glance-target for
+        # "what's my volume at" and a direct manipulator.  The same
+        # keyboard shortcut (Up/Down) drives this slider.
+        self._master_vol_label_prefix = QLabel("Vol:")
+        transport.addWidget(self._master_vol_label_prefix)
+
+        self._master_volume_slider = QSlider(Qt.Orientation.Horizontal)
+        self._master_volume_slider.setRange(0, 200)
+        self._master_volume_slider.setValue(100)
+        self._master_volume_slider.setFixedWidth(90)
+        self._master_volume_slider.setToolTip("Master volume (Up / Down)")
+        self._master_volume_slider.setAccessibleName("Master volume")
+        self._master_volume_slider.valueChanged.connect(
+            self._on_master_volume_slider_changed
+        )
+        transport.addWidget(self._master_volume_slider)
+
+        self._master_volume_label = QLabel("100%")
+        self._master_volume_label.setFixedWidth(42)
+        self._master_volume_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._master_volume_label.setObjectName("subtle-label")
+        transport.addWidget(self._master_volume_label)
+
         transport.addStretch()
 
         # -- Count-in controls (right side of transport bar) --
@@ -706,8 +812,7 @@ class PlayerControls(QWidget):
         self._count_in_beats_spin.setRange(1, 8)
         self._count_in_beats_spin.setValue(4)
         self._count_in_beats_spin.setSuffix(" beats")
-        # No setFixedWidth -- QSpinBox.sizeHint fits the widest value
-        # ("8 beats") plus frame + buttons, which is what we want.
+        _fit_spinbox_width(self._count_in_beats_spin)
         self._count_in_beats_spin.setToolTip("Number of count-in beats")
         self._count_in_beats_spin.setAccessibleName("Count-in beats")
         self._count_in_beats_spin.valueChanged.connect(
@@ -795,10 +900,6 @@ class PlayerControls(QWidget):
         self._chord_label.setAccessibleName("Detected chord")
         loop_speed_bar.addWidget(self._chord_label)
 
-        self._speed_status = QLabel("")
-        self._speed_status.setObjectName("subtle-label")
-        loop_speed_bar.addWidget(self._speed_status)
-
         loop_speed_bar.addStretch()
 
         self._speed_label = QLabel("Speed:")
@@ -808,13 +909,20 @@ class PlayerControls(QWidget):
         for preset in SPEED_PRESETS:
             self._speed_combo.addItem(f"{preset}x", preset)
         self._speed_combo.setCurrentText("1.0x")
-        self._speed_combo.setSizeAdjustPolicy(
-            QComboBox.SizeAdjustPolicy.AdjustToContents
-        )
+        _fit_combo_width(self._speed_combo)
         self._speed_combo.setToolTip("Playback speed ([ / ])")
         self._speed_combo.setAccessibleName("Playback speed")
         self._speed_combo.currentIndexChanged.connect(self._on_speed_changed)
         loop_speed_bar.addWidget(self._speed_combo)
+
+        # Render-progress indicator sits immediately after the speed combo
+        # so it reads as "Speed: [1.5x] (processing 2/4)" -- the user sees
+        # the feedback on the control they just turned, not across the row
+        # by the chord label.  Only visible while a speed-only render is
+        # in flight (pitch renders use the spinbox suffix).
+        self._speed_status = QLabel("")
+        self._speed_status.setObjectName("subtle-label")
+        loop_speed_bar.addWidget(self._speed_status)
 
         self._pitch_label = QLabel("Pitch:")
         loop_speed_bar.addWidget(self._pitch_label)
@@ -842,6 +950,16 @@ class PlayerControls(QWidget):
         self._pitch_debounce.timeout.connect(self._flush_pending_pitch)
         self._pending_pitch: int | None = None
 
+        # Speed debounce mirrors pitch: Shift+Up/Down cycles presets in
+        # quick bursts, and each cycle would otherwise spawn a render
+        # that gets cancelled by the next press.  Shorter window (100ms)
+        # than pitch because speed changes aren't typically scrubbed.
+        self._speed_debounce = QTimer(self)
+        self._speed_debounce.setSingleShot(True)
+        self._speed_debounce.setInterval(100)
+        self._speed_debounce.timeout.connect(self._flush_pending_speed)
+        self._pending_speed: float | None = None
+
         controls_layout.addLayout(loop_speed_bar)
 
         # -- Metronome bar --
@@ -866,7 +984,7 @@ class PlayerControls(QWidget):
         self._bpm_spin.setRange(20, 300)
         self._bpm_spin.setValue(120)
         self._bpm_spin.setSuffix(" BPM")
-        # Default sizeHint fits "300 BPM" -- no fixed width needed.
+        _fit_spinbox_width(self._bpm_spin)
         self._bpm_spin.setToolTip("Metronome tempo")
         self._bpm_spin.setAccessibleName("Metronome BPM")
         self._bpm_spin.valueChanged.connect(self._on_bpm_changed)
@@ -893,7 +1011,7 @@ class PlayerControls(QWidget):
         self._beat_nudge_spin.setRange(-500, 500)
         self._beat_nudge_spin.setValue(0)
         self._beat_nudge_spin.setSuffix(" ms")
-        # Default sizeHint fits "-500 ms" -- no fixed width needed.
+        _fit_spinbox_width(self._beat_nudge_spin, sample="-500 ms")
         self._beat_nudge_spin.setToolTip("Metronome nudge (shift metronome clicking)")
         self._beat_nudge_spin.setAccessibleName("Sync Nudge")
         self._beat_nudge_spin.valueChanged.connect(self._on_beat_nudge_changed)
@@ -921,9 +1039,11 @@ class PlayerControls(QWidget):
         for v in _MET_VOL_PRESETS:
             self._metronome_vol_combo.addItem(f"{v}%", v)
         self._metronome_vol_combo.setCurrentText("100%")
-        self._metronome_vol_combo.setSizeAdjustPolicy(
-            QComboBox.SizeAdjustPolicy.AdjustToContents
-        )
+        # AdjustToContents misbehaves on editable combos (via
+        # _make_display_combo) -- the line-edit padding isn't accounted
+        # for and the first digit of "100%" gets clipped.  Match the
+        # stem-row volume combo's fixed width for consistency.
+        self._metronome_vol_combo.setFixedWidth(62)
         self._metronome_vol_combo.setToolTip("Metronome volume")
         self._metronome_vol_combo.setAccessibleName("Metronome volume preset")
         self._metronome_vol_combo.activated.connect(
@@ -1098,9 +1218,12 @@ class PlayerControls(QWidget):
         self._speed_status.setText("")
 
         # Kill any in-flight debounce from the previous song so a pending
-        # scroll doesn't fire set_pitch against the freshly loaded stems.
+        # scroll doesn't fire set_pitch / set_speed against the freshly
+        # loaded stems.
         self._pitch_debounce.stop()
         self._pending_pitch = None
+        self._speed_debounce.stop()
+        self._pending_speed = None
 
         self._pitch_spin.blockSignals(True)
         self._pitch_spin.setValue(0)
@@ -1213,6 +1336,25 @@ class PlayerControls(QWidget):
     def _on_stop(self) -> None:
         self._player.stop()
 
+    def _on_master_volume_slider_changed(self, value: int) -> None:
+        """Slider moved -- mirror the new value into the player and label."""
+        self._player.set_master_volume(value / 100.0)
+        self._master_volume_label.setText(f"{value}%")
+
+    def set_master_volume(self, volume: float) -> None:
+        """Set master volume from any entry point (shortcut, session load).
+
+        Keeps the slider, percent label, and player in sync so callers
+        don't need to update each surface separately.
+        """
+        value = max(0, min(200, int(round(float(volume) * 100))))
+        if self._master_volume_slider.value() != value:
+            self._master_volume_slider.blockSignals(True)
+            self._master_volume_slider.setValue(value)
+            self._master_volume_slider.blockSignals(False)
+        self._master_volume_label.setText(f"{value}%")
+        self._player.set_master_volume(value / 100.0)
+
     def _on_waveform_seek(self, seconds: float) -> None:
         self._player.seek(seconds)
 
@@ -1296,7 +1438,7 @@ class PlayerControls(QWidget):
             self._peaks_timer.start()
             return
 
-        self._peak_future = _peak_pool.submit(
+        self._peak_future = _get_peak_pool().submit(
             _compute_peaks_bg,
             stems=stems,
             muted=self._player.muted_stems,
@@ -1405,12 +1547,25 @@ class PlayerControls(QWidget):
     # -- Speed control slots --
 
     def _on_speed_changed(self, index: int) -> None:
-        """User selected a speed preset from the combo box."""
+        """User selected a speed preset from the combo box.
+
+        Debounced so burst input (Shift+Up/Down cycling) coalesces into
+        a single render; any in-flight render is cancelled immediately
+        to free CPU while the user is still choosing.
+        """
         speed = self._speed_combo.currentData()
         if speed is None:
             return
-        # Status text is now driven by stretch_started/progress/finished
-        # signals from the player, not set here. Spawn the render.
+        self._pending_speed = float(speed)
+        self._speed_debounce.start()
+        self._player.cancel_stretch()
+
+    def _flush_pending_speed(self) -> None:
+        """Apply the latest speed value after the debounce window expires."""
+        if self._pending_speed is None:
+            return
+        speed = self._pending_speed
+        self._pending_speed = None
         self._player.set_speed(speed)
 
     def _on_speed_applied(self, speed: float) -> None:
@@ -1483,12 +1638,15 @@ class PlayerControls(QWidget):
 
     # -- Stretch worker progress indicator --
     #
-    # Progress is shown *inside* the control the user is manipulating:
-    # the pitch spinbox suffix becomes " st (2/4)" during a pitch render,
-    # and a short "Time-stretching stems…" label sits next to the speed
-    # combo (combos can't carry inline progress text).  The spinbox stays
-    # enabled throughout -- scrolling it cancels the in-flight render
-    # and queues a fresh one via the debounce timer.
+    # Progress is shown *inside* (or immediately beside) the control the
+    # user is manipulating.  The pitch spinbox carries a "(processing
+    # 2/4)" suffix; the speed combo is followed by a small label with
+    # the same suffix text (combos can't carry inline text of their own).
+    # When both knobs are active, only the pitch suffix is shown -- the
+    # single worker renders both transforms in one pass, and duplicating
+    # the indicator confuses the eye.  The control stays enabled
+    # throughout -- any new input cancels the in-flight render and queues
+    # a fresh one via the debounce timer.
 
     def _on_stretch_started(self) -> None:
         """Begin showing render progress on the active control.
@@ -1511,31 +1669,37 @@ class PlayerControls(QWidget):
     def _update_stretch_indicator(self, current: int, total: int) -> None:
         """Paint render progress onto the pitch spinbox / speed label.
 
-        The pitch spinbox's primary text ("+2 semitones") is produced by
-        :class:`PitchSpinBox.textFromValue`; this method only manages the
-        trailing progress suffix (e.g. ``" (processing 2/4)"``).  Speed
+        The pitch spinbox's primary text ("+2 semi") is produced by
+        :class:`PitchSpinBox.textFromValue`; this method only manages
+        the trailing progress suffix (e.g. ``" (2/4)"``).  Speed
         progress uses a small floating label next to the speed combo,
         since QComboBox can't carry inline suffix text.
+
+        The suffix format is deliberately minimal -- the spinbox/label
+        is already tight, and the bare ``(N/M)`` form is still read
+        as progress-out-of-total in context (the control is frozen
+        grey while it's showing).  Earlier versions used
+        ``(processing N/M)`` but that pushed the spinbox ~80 px wider.
         """
         pitch_on = self._player.pitch_semitones != 0
         speed_on = self._player.speed != 1.0
 
         if pitch_on:
             if total > 0:
-                self._pitch_spin.setSuffix(f" (processing {current}/{total})")
+                self._pitch_spin.setSuffix(f" ({current}/{total})")
             else:
-                self._pitch_spin.setSuffix(" (processing\u2026)")
+                self._pitch_spin.setSuffix(" \u2026")
         else:
             self._pitch_spin.setSuffix("")
 
         if speed_on and not pitch_on:
-            verb = "Time-stretching"
+            # Match the pitch spinbox suffix format verbatim so both
+            # renders look visually identical.  Sits right after the
+            # combo so the user sees "Speed: [1.5x] (2/4)".
             if total > 0:
-                self._speed_status.setText(
-                    f"{verb} stems ({current}/{total})\u2026"
-                )
+                self._speed_status.setText(f"({current}/{total})")
             else:
-                self._speed_status.setText(f"{verb} stems\u2026")
+                self._speed_status.setText("\u2026")
         else:
             # When pitch is active, the spinbox suffix already carries
             # the indicator; don't duplicate it in a floating label.

--- a/src/ui/preferences_dialog.py
+++ b/src/ui/preferences_dialog.py
@@ -34,6 +34,7 @@ from src.app_settings import (
     read_default_mp3_bitrate,
     read_latency_offset_ms,
     read_startup_play_sound,
+    read_sync_recording_pitch,
 )
 from src.data_paths import platform_user_data_dir
 from src.version import __version__
@@ -130,6 +131,17 @@ class PreferencesDialog(QDialog):
         sform = QFormLayout(startup_box)
         sform.addRow(self._startup_sound_cb)
 
+        self._sync_rec_pitch_cb = QCheckBox(
+            "Pitch-shift recording takes with the stems"
+        )
+        self._sync_rec_pitch_cb.setToolTip(
+            "When off (default), recordings play back at their original "
+            "pitch even when the stems are transposed."
+        )
+        playback_box = QGroupBox("Playback")
+        pform = QFormLayout(playback_box)
+        pform.addRow(self._sync_rec_pitch_cb)
+
         self._load_from_settings()
 
         buttons = QDialogButtonBox(
@@ -143,6 +155,7 @@ class PreferencesDialog(QDialog):
         layout.addWidget(audio_box)
         layout.addWidget(import_box)
         layout.addWidget(export_box)
+        layout.addWidget(playback_box)
         layout.addWidget(startup_box)
 
         ver = QLabel(f"stemma {__version__}")
@@ -218,6 +231,10 @@ class PreferencesDialog(QDialog):
 
         self._startup_sound_cb.setChecked(
             read_startup_play_sound(self._settings)
+        )
+
+        self._sync_rec_pitch_cb.setChecked(
+            read_sync_recording_pitch(self._settings)
         )
 
         self._model_combo.setCurrentIndex(
@@ -308,5 +325,10 @@ class PreferencesDialog(QDialog):
         self._settings.setValue(
             "startup/play_sound",
             self._startup_sound_cb.isChecked(),
+        )
+
+        self._settings.setValue(
+            "playback/sync_recording_pitch",
+            self._sync_rec_pitch_cb.isChecked(),
         )
         self.accept()

--- a/src/ui/styles.py
+++ b/src/ui/styles.py
@@ -433,3 +433,29 @@ def get_stylesheet(theme: str) -> str:
 def get_colors(theme: str) -> dict[str, str]:
     """Return the color token dict for the given theme name."""
     return THEMES[theme]["colors"]
+
+
+def apply_tooltip_palette(theme: str) -> None:
+    """Force QToolTip colors via QPalette.
+
+    Qt's stylesheet-driven ``QToolTip { ... }`` rule is unreliable:
+    when a child widget has its own ``setStyleSheet`` (as several do
+    in our stem rows), Qt can show tooltips spawned from that widget
+    using the *system* palette instead of the app stylesheet -- which
+    on Windows Light themes surfaces near-black-on-near-black text.
+
+    Setting the ``ToolTipBase`` / ``ToolTipText`` palette roles
+    directly on the QApplication bypasses the stylesheet entirely and
+    applies globally regardless of child widget stylesheet scope.
+    """
+    from PySide6.QtWidgets import QApplication
+    from PySide6.QtGui import QColor, QPalette
+
+    app = QApplication.instance()
+    if app is None:
+        return
+    c = get_colors(theme)
+    palette = app.palette()
+    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(c["surface0"]))
+    palette.setColor(QPalette.ColorRole.ToolTipText, QColor(c["text"]))
+    app.setPalette(palette)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,3 +27,22 @@ def sample_audio_path(tmp_dir):
     silence = np.zeros((44100, 2), dtype=np.float32)
     sf.write(path, silence, 44100)
     return path
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _collect_qt_garbage_between_modules():
+    """Run a full garbage collection at every test-module boundary.
+
+    CPython's cyclic GC otherwise destroys unreferenced QObject trees
+    (old MainWindows, players, dialogs from earlier tests) at arbitrary
+    later moments -- sometimes while the interpreter is inside a Qt
+    call such as QWidget.show(). Deleting top-level windows reentrantly
+    from within Qt's own stack intermittently corrupts native state and
+    crashes with an access violation in whichever test touches Qt next.
+    Collecting at module boundaries destroys that garbage at a quiescent
+    point instead. (Per-test collection also works but adds ~70s to the
+    suite; module scope catches the cross-module garbage that actually
+    crashed.)"""
+    yield
+    import gc
+    gc.collect()

--- a/tests/test_beat_detector.py
+++ b/tests/test_beat_detector.py
@@ -19,6 +19,7 @@ from src.beat_detector import (
     _sigmoid,
     _viterbi_smooth,
     detect_bpm_and_key,
+    transpose_key,
 )
 
 
@@ -459,3 +460,44 @@ class TestDetectChords:
         labels = [c for _, c in chords]
         # The set of unique labels should have more than 1 entry.
         assert len(set(labels)) >= 2
+
+
+# ---------------------------------------------------------------------------
+# transpose_key
+# ---------------------------------------------------------------------------
+
+class TestTransposeKey:
+    def test_zero_steps_is_identity(self):
+        assert transpose_key("A minor", 0) == "A minor"
+
+    def test_up_two_semitones_major(self):
+        assert transpose_key("C major", 2) == "D major"
+
+    def test_up_one_semitone_minor(self):
+        assert transpose_key("A minor", 1) == "Bb minor"
+
+    def test_down_semitone(self):
+        assert transpose_key("C major", -1) == "B major"
+
+    def test_wrap_around_twelve(self):
+        assert transpose_key("C major", 12) == "C major"
+        assert transpose_key("C major", -12) == "C major"
+
+    def test_flat_spelling_accepted(self):
+        # Detector uses "Bb"; ensure aliases (e.g. A#) also parse.
+        assert transpose_key("A# minor", 1) == "B minor"
+
+    def test_empty_string_unchanged(self):
+        assert transpose_key("", 3) == ""
+
+    def test_unparseable_unchanged(self):
+        assert transpose_key("nonsense", 2) == "nonsense"
+        assert transpose_key("C", 2) == "C"
+        assert transpose_key("Q major", 2) == "Q major"
+
+    def test_mode_preserved(self):
+        assert transpose_key("F# minor", 3).endswith("minor")
+        assert transpose_key("F major", 5).endswith("major")
+
+    def test_case_insensitive_mode(self):
+        assert transpose_key("C MAJOR", 2) == "D major"

--- a/tests/test_library_playback.py
+++ b/tests/test_library_playback.py
@@ -307,7 +307,8 @@ class TestNextSongResolution:
 
 
 class TestMasterVolumeAdjust:
-    """_adjust_master_volume delegates to the player and clamps correctly."""
+    """_adjust_master_volume routes through PlayerControls.set_master_volume
+    so the transport-row slider/label stay in sync with the player."""
 
     def test_adjust_adds_delta(self, app):
         from src.ui.main_window import MainWindow
@@ -315,7 +316,7 @@ class TestMasterVolumeAdjust:
         stub = MagicMock()
         stub._player.master_volume = 1.0
         MainWindow._adjust_master_volume(stub, 0.1)
-        stub._player.set_master_volume.assert_called_once_with(
+        stub._player_controls.set_master_volume.assert_called_once_with(
             pytest.approx(1.1)
         )
 
@@ -326,7 +327,7 @@ class TestMasterVolumeAdjust:
         stub._player.master_volume = 1.95
         MainWindow._adjust_master_volume(stub, 0.1)
         # Caller clamps to 2.0 before calling set_master_volume.
-        stub._player.set_master_volume.assert_called_once_with(2.0)
+        stub._player_controls.set_master_volume.assert_called_once_with(2.0)
 
     def test_adjust_clamps_lower(self, app):
         from src.ui.main_window import MainWindow
@@ -334,7 +335,7 @@ class TestMasterVolumeAdjust:
         stub = MagicMock()
         stub._player.master_volume = 0.02
         MainWindow._adjust_master_volume(stub, -0.1)
-        stub._player.set_master_volume.assert_called_once_with(0.0)
+        stub._player_controls.set_master_volume.assert_called_once_with(0.0)
 
     def test_adjust_shows_toast(self, app):
         from src.ui.main_window import MainWindow

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -10,6 +10,7 @@ Covers:
   - Recording cannot be armed when pitch != 0
   - Stretch lifecycle signals (started / progress / finished) emit correctly
   - Detached workers are kept alive on ``_detached_workers`` until finished
+  - ``_on_stretch_error`` recomputes beat frames after restoring originals
 """
 
 from unittest.mock import MagicMock, patch
@@ -605,3 +606,52 @@ class TestCancelStretch:
         # Non-running worker is not "rendering", so no finished signal.
         assert finished == []
         assert loaded_player._stretch_worker is None
+
+
+# -----------------------------------------------------------------------
+# Regression: _on_stretch_error must recompute beat frames
+# -----------------------------------------------------------------------
+
+class TestStretchErrorBeatsReset:
+    """After a render error, beat frames must reflect the restored (original-
+    length) stems — not the stretched indices that were active before the
+    error."""
+
+    def test_error_recomputes_beat_frames(self, loaded_player):
+        """beat_frames are recalculated after an error restores identity.
+
+        _recompute_beat_frames() uses _playback_speed as a divisor.  If
+        speed was 0.5x before the error, beat_frames hold 2× the 1.0x
+        frame indices.  The error handler resets _playback_speed to 1.0
+        but, without the _recompute_beat_frames() call, the stale indices
+        remain -- making the metronome click in the wrong places.
+        """
+        sr = loaded_player._sample_rate
+
+        # Set up a beat grid at 0.5x speed (indices are 2× the 1.0x values).
+        loaded_player._beat_times = [0.5, 1.0]
+        loaded_player._playback_speed = 0.5
+        loaded_player._recompute_beat_frames()
+        slow_beat_frames = list(loaded_player._beat_frames)  # e.g. [44100, 88200]
+
+        # Sanity: at 1.0x the indices should be half as large.
+        loaded_player._playback_speed = 1.0
+        loaded_player._recompute_beat_frames()
+        normal_beat_frames = list(loaded_player._beat_frames)  # e.g. [22050, 44100]
+        assert slow_beat_frames != normal_beat_frames, (
+            "sanity: beat frames at 0.5x vs 1.0x must differ"
+        )
+
+        # Restore slow-speed indices (as they would be when a render is in
+        # flight and _playback_speed is still 0.5).
+        loaded_player._playback_speed = 0.5
+        loaded_player._recompute_beat_frames()
+        assert list(loaded_player._beat_frames) == slow_beat_frames
+
+        # Trigger error recovery — should reset speed AND recompute frames.
+        loaded_player._on_stretch_error("boom", ("speed",))
+
+        assert loaded_player._playback_speed == 1.0
+        assert np.array_equal(
+            loaded_player._beat_frames, normal_beat_frames
+        ), "_beat_frames not recomputed after error; metronome would misfire"

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -172,10 +172,13 @@ class TestStretchWorkerCombined:
         assert ps.call_count == 2  # Once per channel.
         ts.assert_not_called()
 
-    def test_pitch_uses_fast_res_type(self, app):
-        """The worker passes the fast resample kernel and a tuned hop_length
-        to librosa so renders complete in a usable time during interactive
-        use."""
+    def test_pitch_uses_high_quality_resampler(self, app):
+        """The worker uses soxr_hq -- dropping to soxr_mq gives a big
+        speedup but introduces an audible metallic timbre on transient
+        material (drums, plucked strings), which defeats the point of a
+        faithful-playback tool.  Speed wins come from parallel stem
+        rendering instead.
+        """
         stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
         worker = StretchWorker(stems, 44100, 1.0, 2)
         with patch(
@@ -183,11 +186,27 @@ class TestStretchWorkerCombined:
             side_effect=lambda y, sr, n_steps, **kw: y,
         ) as ps:
             worker.run()
-        # All calls must have passed res_type=soxr_mq (~3-4x faster than
-        # soxr_hq) and hop_length=_HOP_LENGTH (~2-3x faster per benchmark).
+        assert ps.call_count > 0
         for call in ps.call_args_list:
-            assert call.kwargs.get("res_type") == "soxr_mq"
-            assert call.kwargs.get("hop_length") == StretchWorker._HOP_LENGTH
+            assert call.kwargs.get("res_type") == "soxr_hq"
+            # hop_length must be librosa's default (i.e. not overridden);
+            # enlarging it was tried and rejected -- it caused phase
+            # smearing on drums.
+            assert "hop_length" not in call.kwargs
+
+    def test_time_stretch_uses_default_hop_length(self, app):
+        """time_stretch also uses librosa's default hop.  Larger hops
+        are faster but smear transients."""
+        stems = {"vocals": np.random.randn(8820, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 0.75, 0)
+        with patch(
+            "src.player.librosa.effects.time_stretch",
+            side_effect=lambda y, rate, **kw: y,
+        ) as ts:
+            worker.run()
+        assert ts.call_count > 0
+        for call in ts.call_args_list:
+            assert "hop_length" not in call.kwargs
 
     def test_speed_only_calls_time_stretch(self, app):
         stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -173,8 +173,9 @@ class TestStretchWorkerCombined:
         ts.assert_not_called()
 
     def test_pitch_uses_fast_res_type(self, app):
-        """The worker passes a fast resample kernel to librosa so renders
-        complete in a usable time during interactive use."""
+        """The worker passes the fast resample kernel and a tuned hop_length
+        to librosa so renders complete in a usable time during interactive
+        use."""
         stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
         worker = StretchWorker(stems, 44100, 1.0, 2)
         with patch(
@@ -182,18 +183,18 @@ class TestStretchWorkerCombined:
             side_effect=lambda y, sr, n_steps, **kw: y,
         ) as ps:
             worker.run()
-        # All calls must have passed res_type.  soxr_mq is ~3-4x faster
-        # than the default soxr_hq and sounds identical on music.
+        # All calls must have passed res_type=soxr_mq (~3-4x faster than
+        # soxr_hq) and hop_length=_HOP_LENGTH (~2-3x faster per benchmark).
         for call in ps.call_args_list:
-            assert "res_type" in call.kwargs
-            assert call.kwargs["res_type"] == "soxr_mq"
+            assert call.kwargs.get("res_type") == "soxr_mq"
+            assert call.kwargs.get("hop_length") == StretchWorker._HOP_LENGTH
 
     def test_speed_only_calls_time_stretch(self, app):
         stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
         worker = StretchWorker(stems, 44100, 0.75, 0)
         with patch("src.player.librosa.effects.pitch_shift") as ps, \
              patch("src.player.librosa.effects.time_stretch",
-                   side_effect=lambda y, rate: y) as ts:
+                   side_effect=lambda y, rate, **kw: y) as ts:
             worker.run()
         ps.assert_not_called()
         assert ts.call_count == 2
@@ -208,7 +209,7 @@ class TestStretchWorkerCombined:
             call_order.append("pitch")
             return y
 
-        def fake_ts(y, rate):
+        def fake_ts(y, rate, **kw):
             call_order.append("speed")
             return y
 
@@ -284,7 +285,7 @@ class TestRecordingPitchSync:
         worker = StretchWorker(stems, 44100, 0.5, 0, sync_recording_pitch=False)
         stretches: list[int] = []
 
-        def fake_ts(y, rate):
+        def fake_ts(y, rate, **kw):
             stretches.append(1)
             return y
 

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -8,9 +8,11 @@ Covers:
   - Recording-take stems skip pitch by default; sync toggle includes them
   - ``sync_recording_pitch`` re-renders only when pitch is active
   - Recording cannot be armed when pitch != 0
+  - Stretch lifecycle signals (started / progress / finished) emit correctly
+  - Detached workers are kept alive on ``_detached_workers`` until finished
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -163,11 +165,27 @@ class TestStretchWorkerCombined:
         stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
         worker = StretchWorker(stems, 44100, 1.0, 2)
         with patch("src.player.librosa.effects.pitch_shift",
-                   side_effect=lambda y, sr, n_steps: y) as ps, \
+                   side_effect=lambda y, sr, n_steps, **kw: y) as ps, \
              patch("src.player.librosa.effects.time_stretch") as ts:
             worker.run()
         assert ps.call_count == 2  # Once per channel.
         ts.assert_not_called()
+
+    def test_pitch_uses_fast_res_type(self, app):
+        """The worker passes a fast resample kernel to librosa so renders
+        complete in a usable time during interactive use."""
+        stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 1.0, 2)
+        with patch(
+            "src.player.librosa.effects.pitch_shift",
+            side_effect=lambda y, sr, n_steps, **kw: y,
+        ) as ps:
+            worker.run()
+        # All calls must have passed res_type.  soxr_mq is ~3-4x faster
+        # than the default soxr_hq and sounds identical on music.
+        for call in ps.call_args_list:
+            assert "res_type" in call.kwargs
+            assert call.kwargs["res_type"] == "soxr_mq"
 
     def test_speed_only_calls_time_stretch(self, app):
         stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
@@ -185,7 +203,7 @@ class TestStretchWorkerCombined:
         worker = StretchWorker(stems, 44100, 0.75, 2)
         call_order: list[str] = []
 
-        def fake_ps(y, sr, n_steps):
+        def fake_ps(y, sr, n_steps, **kw):
             call_order.append("pitch")
             return y
 
@@ -229,7 +247,7 @@ class TestRecordingPitchSync:
         worker = StretchWorker(stems, 44100, 1.0, 3, sync_recording_pitch=False)
         shifted_names: list[str] = []
 
-        def fake_ps(y, sr, n_steps):
+        def fake_ps(y, sr, n_steps, **kw):
             # Track which stem names the shift is applied to by reading
             # the worker's loop context indirectly: nothing in the call
             # reveals the name, so use call count instead.
@@ -249,7 +267,7 @@ class TestRecordingPitchSync:
         worker = StretchWorker(stems, 44100, 1.0, 3, sync_recording_pitch=True)
         shifts: list[int] = []
 
-        def fake_ps(y, sr, n_steps):
+        def fake_ps(y, sr, n_steps, **kw):
             shifts.append(1)
             return y
 
@@ -326,3 +344,264 @@ class TestLoadStemsResetsPitch:
         sf.write(str(wav_path), np.zeros((4410, 2), dtype=np.float32), 44100)
         loaded_player.load_stems({"vocals": str(wav_path)})
         assert loaded_player.pitch_semitones == 0
+
+
+# -----------------------------------------------------------------------
+# Stretch lifecycle signals (started / progress / finished)
+# -----------------------------------------------------------------------
+
+class TestStretchLifecycleSignals:
+    """stretch_started/progress/finished frame the async render for the UI."""
+
+    def test_started_emits_when_worker_spawns(self, loaded_player):
+        """Spawning a worker emits stretch_started exactly once."""
+        started: list[int] = []
+        loaded_player.stretch_started.connect(lambda: started.append(1))
+        with patch("src.player.StretchWorker") as worker_cls:
+            worker_cls.return_value.isRunning.return_value = False
+            loaded_player.set_pitch(2)
+        assert started == [1]
+
+    def test_started_does_not_emit_on_fast_path(self, loaded_player):
+        """Identity no-op takes the fast path and must not emit."""
+        started: list[int] = []
+        loaded_player.stretch_started.connect(lambda: started.append(1))
+        loaded_player.set_pitch(0)  # Already 0 -- fast path.
+        assert started == []
+
+    def test_finished_emits_on_success(self, loaded_player):
+        """Successful render emits stretch_finished via _on_stretch_ready."""
+        finished: list[int] = []
+        loaded_player.stretch_finished.connect(lambda: finished.append(1))
+        loaded_player._on_stretch_ready(
+            dict(loaded_player._original_stems), ("pitch",)
+        )
+        assert finished == [1]
+
+    def test_finished_emits_on_error(self, loaded_player):
+        """Worker failure still emits stretch_finished so UI re-enables."""
+        finished: list[int] = []
+        loaded_player.stretch_finished.connect(lambda: finished.append(1))
+        loaded_player._on_stretch_error("boom", ("pitch",))
+        assert finished == [1]
+
+    def test_progress_connected_to_worker(self, loaded_player):
+        """Player wires the worker's per-stem progress through to its own
+        ``stretch_progress`` Signal, so the UI can subscribe once and stay
+        connected across successive renders."""
+        with patch("src.player.StretchWorker") as worker_cls:
+            fake_worker = MagicMock()
+            fake_worker.isRunning.return_value = False
+            worker_cls.return_value = fake_worker
+            loaded_player.set_pitch(3)
+
+        # The player must forward progress to its own signal.
+        fake_worker.progress.connect.assert_called_once_with(
+            loaded_player.stretch_progress
+        )
+
+
+# -----------------------------------------------------------------------
+# Worker keepalive: QThread GC safety
+# -----------------------------------------------------------------------
+
+class TestWorkerKeepalive:
+    """Detached-but-running workers must be held on _detached_workers.
+
+    Without the keepalive list, the Python wrapper refcount can drop to
+    zero while the QThread is still active, triggering the classic
+    "QThread: Destroyed while thread is still running" crash.
+    """
+
+    def test_running_worker_is_detached_to_keepalive(self, loaded_player):
+        """A running worker gets appended to _detached_workers."""
+        fake_worker = MagicMock()
+        fake_worker.isRunning.return_value = True
+        loaded_player._stretch_worker = fake_worker
+
+        assert loaded_player._detach_stretch_worker() is True
+
+        assert fake_worker in loaded_player._detached_workers
+        assert loaded_player._stretch_worker is None
+
+    def test_running_worker_is_cancelled_on_detach(self, loaded_player):
+        """Detach must call ``cancel()`` so the worker exits early
+        instead of wasting CPU on a stale render target."""
+        fake_worker = MagicMock()
+        fake_worker.isRunning.return_value = True
+        loaded_player._stretch_worker = fake_worker
+
+        loaded_player._detach_stretch_worker()
+
+        fake_worker.cancel.assert_called_once()
+
+    def test_detached_worker_defers_setParent(self, loaded_player):
+        """A running worker must not be setParent(None)'d mid-run."""
+        fake_worker = MagicMock()
+        fake_worker.isRunning.return_value = True
+        loaded_player._stretch_worker = fake_worker
+
+        loaded_player._detach_stretch_worker()
+
+        # Qt parent ownership stays intact while the thread is running.
+        fake_worker.setParent.assert_not_called()
+
+    def test_finished_signal_is_connected_to_reaper(self, loaded_player):
+        """The keepalive list is emptied when the worker finishes."""
+        fake_worker = MagicMock()
+        fake_worker.isRunning.return_value = True
+        loaded_player._stretch_worker = fake_worker
+
+        loaded_player._detach_stretch_worker()
+
+        assert fake_worker.finished.connect.called
+
+    def test_reaper_removes_from_keepalive(self, loaded_player):
+        """_reap_detached_worker drops the worker from _detached_workers."""
+        fake_worker = MagicMock()
+        loaded_player._detached_workers.append(fake_worker)
+
+        loaded_player._reap_detached_worker(fake_worker)
+
+        assert fake_worker not in loaded_player._detached_workers
+        fake_worker.setParent.assert_called_once_with(None)
+        fake_worker.deleteLater.assert_called_once()
+
+    def test_reaper_is_idempotent(self, loaded_player):
+        """Calling the reaper twice does not raise on the second call."""
+        fake_worker = MagicMock()
+        loaded_player._detached_workers.append(fake_worker)
+        loaded_player._reap_detached_worker(fake_worker)
+        # Second call: the worker is no longer in the list but should not
+        # raise (protects against double-connections or test re-entry).
+        loaded_player._reap_detached_worker(fake_worker)
+
+    def test_non_running_worker_is_released_immediately(self, loaded_player):
+        """If the worker already stopped, skip the keepalive dance."""
+        fake_worker = MagicMock()
+        fake_worker.isRunning.return_value = False
+        loaded_player._stretch_worker = fake_worker
+
+        assert loaded_player._detach_stretch_worker() is False
+
+        assert fake_worker not in loaded_player._detached_workers
+        fake_worker.setParent.assert_called_once_with(None)
+        fake_worker.deleteLater.assert_called_once()
+
+    def test_multiple_rapid_detaches_accumulate(self, loaded_player):
+        """Two rapid set_pitch calls keep both workers alive."""
+        worker_a = MagicMock()
+        worker_a.isRunning.return_value = True
+        loaded_player._stretch_worker = worker_a
+        loaded_player._detach_stretch_worker()
+
+        worker_b = MagicMock()
+        worker_b.isRunning.return_value = True
+        loaded_player._stretch_worker = worker_b
+        loaded_player._detach_stretch_worker()
+
+        assert worker_a in loaded_player._detached_workers
+        assert worker_b in loaded_player._detached_workers
+        assert len(loaded_player._detached_workers) == 2
+
+    def test_detach_returns_false_when_no_worker(self, loaded_player):
+        """Detach is idempotent and reports 'no render was active'."""
+        loaded_player._stretch_worker = None
+        assert loaded_player._detach_stretch_worker() is False
+
+
+# -----------------------------------------------------------------------
+# StretchWorker.cancel() — early exit semantics
+# -----------------------------------------------------------------------
+
+class TestStretchWorkerCancel:
+    """Cancellation must stop the worker without emitting completion."""
+
+    def test_cancel_sets_flag(self, app):
+        stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 1.0, 2)
+        assert worker.cancelled is False
+        worker.cancel()
+        assert worker.cancelled is True
+
+    def test_cancelled_worker_emits_no_completed(self, app):
+        """If cancelled before run, no completed signal fires."""
+        stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 1.0, 2)
+        worker.cancel()
+        completed: list = []
+        worker.completed.connect(lambda d: completed.append(d))
+        worker.run()
+        assert completed == []
+
+    def test_cancelled_worker_emits_no_progress(self, app):
+        """Progress signals are suppressed once cancelled."""
+        stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 1.0, 2)
+        worker.cancel()
+        progress: list = []
+        worker.progress.connect(lambda c, t: progress.append((c, t)))
+        worker.run()
+        assert progress == []
+
+    def test_cancelled_worker_swallows_errors(self, app):
+        """Errors raised after cancellation are not surfaced (the caller
+        no longer cares; surfacing would confuse the UI, which already
+        moved on)."""
+        stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 1.0, 2)
+        errors: list = []
+        worker.error.connect(lambda m: errors.append(m))
+        worker.cancel()
+
+        # Make librosa blow up; since we're cancelled, no error should
+        # escape.
+        with patch(
+            "src.player.librosa.effects.pitch_shift",
+            side_effect=RuntimeError("oops"),
+        ):
+            worker.run()
+        assert errors == []
+
+
+# -----------------------------------------------------------------------
+# cancel_stretch() — player-level cancel without new render
+# -----------------------------------------------------------------------
+
+class TestCancelStretch:
+    def test_cancel_without_active_worker_is_noop(self, loaded_player):
+        """No worker running → no signal, no crash."""
+        finished: list = []
+        loaded_player.stretch_finished.connect(lambda: finished.append(1))
+        loaded_player._stretch_worker = None
+        loaded_player.cancel_stretch()
+        assert finished == []
+
+    def test_cancel_with_active_worker_emits_finished(self, loaded_player):
+        """Cancelling a live render lets the UI clear its indicator."""
+        fake_worker = MagicMock()
+        fake_worker.isRunning.return_value = True
+        loaded_player._stretch_worker = fake_worker
+
+        finished: list = []
+        loaded_player.stretch_finished.connect(lambda: finished.append(1))
+        loaded_player.cancel_stretch()
+
+        fake_worker.cancel.assert_called_once()
+        assert finished == [1]
+
+    def test_cancel_with_non_running_worker_still_releases(
+        self, loaded_player,
+    ):
+        """If the worker exists but already finished, clean up quietly."""
+        fake_worker = MagicMock()
+        fake_worker.isRunning.return_value = False
+        loaded_player._stretch_worker = fake_worker
+
+        finished: list = []
+        loaded_player.stretch_finished.connect(lambda: finished.append(1))
+        loaded_player.cancel_stretch()
+
+        # Non-running worker is not "rendering", so no finished signal.
+        assert finished == []
+        assert loaded_player._stretch_worker is None

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -1,0 +1,328 @@
+"""Tests for pitch transposition on MultiTrackPlayer + StretchWorker.
+
+Covers:
+  - Clamping of the semitone range
+  - Fast path (speed=1.0 AND pitch=0 skips the worker)
+  - ``pitch_changed`` signal fires on real changes and not on no-ops
+  - Pitch + speed render in a single pass (not chained)
+  - Recording-take stems skip pitch by default; sync toggle includes them
+  - ``sync_recording_pitch`` re-renders only when pitch is active
+  - Recording cannot be armed when pitch != 0
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from src.player import (
+    MultiTrackPlayer,
+    PITCH_MAX_SEMITONES,
+    PITCH_MIN_SEMITONES,
+    RECORDING_STEM_PREFIX,
+    StretchWorker,
+)
+
+
+@pytest.fixture(scope="module")
+def app():
+    instance = QApplication.instance()
+    if instance is None:
+        instance = QApplication([])
+    return instance
+
+
+@pytest.fixture
+def loaded_player(app):
+    """Player with fake stems already loaded (no worker will spawn audio IO)."""
+    p = MultiTrackPlayer()
+    sr = 44100
+    frames = sr  # 1 second
+    p._stems = {"vocals": np.zeros((frames, 2), dtype=np.float32)}
+    p._original_stems = dict(p._stems)
+    p._sample_rate = sr
+    p._total_frames = frames
+    return p
+
+
+# -----------------------------------------------------------------------
+# Player API: clamping and no-op behaviour
+# -----------------------------------------------------------------------
+
+class TestPitchClamping:
+    def test_default_pitch_is_zero(self, loaded_player):
+        assert loaded_player.pitch_semitones == 0
+
+    def test_set_pitch_clamps_high(self, loaded_player):
+        loaded_player.set_pitch(99)
+        assert loaded_player.pitch_semitones == PITCH_MAX_SEMITONES
+
+    def test_set_pitch_clamps_low(self, loaded_player):
+        loaded_player.set_pitch(-99)
+        assert loaded_player.pitch_semitones == PITCH_MIN_SEMITONES
+
+    def test_set_pitch_ignores_non_int(self, loaded_player):
+        """Non-numeric input is silently rejected (no crash)."""
+        loaded_player.set_pitch("bogus")  # type: ignore[arg-type]
+        assert loaded_player.pitch_semitones == 0
+
+    def test_set_pitch_coerces_float_to_int(self, loaded_player):
+        loaded_player.set_pitch(2.7)
+        assert loaded_player.pitch_semitones == 2
+
+
+# -----------------------------------------------------------------------
+# Fast path: speed=1.0 AND pitch=0 should never spawn a StretchWorker
+# -----------------------------------------------------------------------
+
+class TestPitchFastPath:
+    def test_setting_pitch_zero_with_speed_one_skips_worker(
+        self, loaded_player,
+    ):
+        """Identity state must not spawn a stretch worker."""
+        with patch("src.player.StretchWorker") as worker_cls:
+            loaded_player.set_pitch(0)  # Already 0 -- no-op entirely.
+            worker_cls.assert_not_called()
+
+    def test_setting_nonzero_pitch_spawns_worker(self, loaded_player):
+        """A real pitch change with speed=1.0 still requires rendering."""
+        with patch("src.player.StretchWorker") as worker_cls:
+            worker_cls.return_value.isRunning.return_value = False
+            loaded_player.set_pitch(3)
+            assert worker_cls.called
+
+    def test_returning_to_identity_restores_originals_fast(
+        self, loaded_player,
+    ):
+        """pitch=+2 -> pitch=0 with speed=1.0 takes the fast path."""
+        # Start from pitch=+2 WITHOUT actually rendering (skip the worker).
+        loaded_player._pitch_semitones = 2
+
+        with patch("src.player.StretchWorker") as worker_cls:
+            loaded_player.set_pitch(0)
+            # Fast path: no worker spawned when returning to identity.
+            worker_cls.assert_not_called()
+
+        # And the stems dict was swapped back to the originals object.
+        assert loaded_player._stems is not loaded_player._original_stems
+        # But their contents match.
+        for k, v in loaded_player._original_stems.items():
+            assert np.array_equal(loaded_player._stems[k], v)
+
+
+# -----------------------------------------------------------------------
+# pitch_changed signal
+# -----------------------------------------------------------------------
+
+class TestPitchSignal:
+    def test_emits_on_change(self, loaded_player):
+        received = []
+        loaded_player.pitch_changed.connect(lambda n: received.append(n))
+
+        # Skip the worker by patching it out.
+        with patch("src.player.StretchWorker") as worker_cls:
+            worker_cls.return_value.isRunning.return_value = False
+            loaded_player.set_pitch(2)
+
+        # Worker was spawned but we never fire `completed` manually, so the
+        # signal only fires via the fast path. In this case, speed=1 AND
+        # pitch=+2 is NOT the fast path, so nothing fires yet.
+        # Emulate completion:
+        loaded_player._on_stretch_ready(
+            dict(loaded_player._original_stems), ("pitch",)
+        )
+        assert received == [2]
+
+    def test_no_emit_on_noop(self, loaded_player):
+        received = []
+        loaded_player.pitch_changed.connect(lambda n: received.append(n))
+        loaded_player.set_pitch(0)  # Already 0.
+        assert received == []
+
+    def test_fast_path_returning_to_zero_emits(self, loaded_player):
+        """Going pitch=+2 -> pitch=0 via fast path emits pitch_changed."""
+        loaded_player._pitch_semitones = 2  # Pretend.
+        received = []
+        loaded_player.pitch_changed.connect(lambda n: received.append(n))
+
+        with patch("src.player.StretchWorker"):
+            loaded_player.set_pitch(0)
+
+        assert received == [0]
+
+
+# -----------------------------------------------------------------------
+# Combined speed+pitch rendering: one pass, not chained
+# -----------------------------------------------------------------------
+
+class TestStretchWorkerCombined:
+    """The StretchWorker applies pitch_shift once, then time_stretch once."""
+
+    def test_pitch_only_calls_pitch_shift(self, app):
+        stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 1.0, 2)
+        with patch("src.player.librosa.effects.pitch_shift",
+                   side_effect=lambda y, sr, n_steps: y) as ps, \
+             patch("src.player.librosa.effects.time_stretch") as ts:
+            worker.run()
+        assert ps.call_count == 2  # Once per channel.
+        ts.assert_not_called()
+
+    def test_speed_only_calls_time_stretch(self, app):
+        stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 0.75, 0)
+        with patch("src.player.librosa.effects.pitch_shift") as ps, \
+             patch("src.player.librosa.effects.time_stretch",
+                   side_effect=lambda y, rate: y) as ts:
+            worker.run()
+        ps.assert_not_called()
+        assert ts.call_count == 2
+
+    def test_both_calls_pitch_then_speed(self, app):
+        """When both are non-identity, pitch runs first, then speed."""
+        stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 0.75, 2)
+        call_order: list[str] = []
+
+        def fake_ps(y, sr, n_steps):
+            call_order.append("pitch")
+            return y
+
+        def fake_ts(y, rate):
+            call_order.append("speed")
+            return y
+
+        with patch("src.player.librosa.effects.pitch_shift", side_effect=fake_ps), \
+             patch("src.player.librosa.effects.time_stretch", side_effect=fake_ts):
+            worker.run()
+
+        # Per-channel order: pitch, speed, pitch, speed
+        assert call_order == ["pitch", "speed", "pitch", "speed"]
+
+    def test_identity_reuses_input_buffers(self, app):
+        """speed=1.0 AND pitch=0 means no work -- output IS input."""
+        stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
+        worker = StretchWorker(stems, 44100, 1.0, 0)
+        results: dict = {}
+        worker.completed.connect(lambda d: results.update(d))
+        worker.run()
+        assert results["vocals"] is stems["vocals"]
+
+
+# -----------------------------------------------------------------------
+# Recording stems and sync_recording_pitch
+# -----------------------------------------------------------------------
+
+class TestRecordingPitchSync:
+    def _make_stems(self):
+        return {
+            "vocals": np.random.randn(4410, 2).astype(np.float32),
+            f"{RECORDING_STEM_PREFIX}1": (
+                np.random.randn(4410, 2).astype(np.float32)
+            ),
+        }
+
+    def test_recording_skips_pitch_by_default(self, app):
+        """By default, recording stems are not pitch-shifted."""
+        stems = self._make_stems()
+        worker = StretchWorker(stems, 44100, 1.0, 3, sync_recording_pitch=False)
+        shifted_names: list[str] = []
+
+        def fake_ps(y, sr, n_steps):
+            # Track which stem names the shift is applied to by reading
+            # the worker's loop context indirectly: nothing in the call
+            # reveals the name, so use call count instead.
+            shifted_names.append("x")
+            return y
+
+        with patch("src.player.librosa.effects.pitch_shift", side_effect=fake_ps):
+            worker.run()
+
+        # Only the "vocals" stem (2 channels) should be shifted.
+        # The recording stem reuses the original buffer.
+        assert len(shifted_names) == 2
+
+    def test_sync_true_shifts_recording_too(self, app):
+        """With sync_recording_pitch=True, recording stems are shifted."""
+        stems = self._make_stems()
+        worker = StretchWorker(stems, 44100, 1.0, 3, sync_recording_pitch=True)
+        shifts: list[int] = []
+
+        def fake_ps(y, sr, n_steps):
+            shifts.append(1)
+            return y
+
+        with patch("src.player.librosa.effects.pitch_shift", side_effect=fake_ps):
+            worker.run()
+
+        # Both stems, both channels: 4 calls.
+        assert len(shifts) == 4
+
+    def test_recording_always_gets_speed(self, app):
+        """Speed applies to recordings regardless of sync flag (timing)."""
+        stems = self._make_stems()
+        worker = StretchWorker(stems, 44100, 0.5, 0, sync_recording_pitch=False)
+        stretches: list[int] = []
+
+        def fake_ts(y, rate):
+            stretches.append(1)
+            return y
+
+        with patch("src.player.librosa.effects.time_stretch", side_effect=fake_ts):
+            worker.run()
+
+        # Both stems, both channels: 4 calls.
+        assert len(stretches) == 4
+
+
+class TestPlayerSyncRecordingPitch:
+    def test_toggle_off_at_pitch_zero_is_noop(self, loaded_player):
+        """Toggling sync without an active pitch shift does not render."""
+        with patch("src.player.StretchWorker") as worker_cls:
+            loaded_player.set_sync_recording_pitch(True)
+            loaded_player.set_sync_recording_pitch(False)
+            worker_cls.assert_not_called()
+
+    def test_toggle_when_pitch_active_triggers_rerender(self, loaded_player):
+        """Toggling the sync flag while pitch is active re-renders stems."""
+        loaded_player._pitch_semitones = 2  # Pretend an active shift.
+        with patch("src.player.StretchWorker") as worker_cls:
+            worker_cls.return_value.isRunning.return_value = False
+            loaded_player.set_sync_recording_pitch(True)
+            assert worker_cls.called
+
+    def test_default_is_false(self, loaded_player):
+        assert loaded_player.sync_recording_pitch is False
+
+
+# -----------------------------------------------------------------------
+# Recording arming guarded by pitch state
+# -----------------------------------------------------------------------
+
+class TestRecordingArmGuard:
+    def test_arm_refused_when_pitch_nonzero(self, loaded_player):
+        loaded_player._pitch_semitones = 2
+        loaded_player.arm_recording(True)
+        assert loaded_player.recording_armed is False
+
+    def test_arm_allowed_at_pitch_zero(self, loaded_player):
+        loaded_player._pitch_semitones = 0
+        loaded_player.arm_recording(True)
+        assert loaded_player.recording_armed is True
+
+
+# -----------------------------------------------------------------------
+# load_stems resets pitch to 0
+# -----------------------------------------------------------------------
+
+class TestLoadStemsResetsPitch:
+    def test_load_stems_resets_pitch(self, loaded_player, tmp_path):
+        """Loading a new song resets the pitch to 0."""
+        import soundfile as sf
+        loaded_player._pitch_semitones = 4
+        # Write a tiny WAV and load it.
+        wav_path = tmp_path / "fake.wav"
+        sf.write(str(wav_path), np.zeros((4410, 2), dtype=np.float32), 44100)
+        loaded_player.load_stems({"vocals": str(wav_path)})
+        assert loaded_player.pitch_semitones == 0

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -893,3 +893,141 @@ class TestPlayerShutdown:
         loaded_player._stretch_worker = None
         loaded_player._detached_workers = []
         loaded_player.shutdown(wait_ms=0)  # should not raise
+
+
+# -----------------------------------------------------------------------
+# Regression: a render discarded by cancel_stretch() must not be lost
+# -----------------------------------------------------------------------
+
+class TestCancelledRenderNotLost:
+    """set_speed/set_pitch used to no-op purely on the requested value.
+
+    The knobs are set optimistically before the render lands, and
+    cancel_stretch() can discard that render -- after which "value
+    unchanged" does not mean "nothing to do". The player now tracks the
+    applied render state and re-renders when the stems are stale.
+    """
+
+    def test_set_pitch_same_value_rerenders_when_stems_stale(
+        self, loaded_player,
+    ):
+        """Speed knob is ahead of the stems; a pitch no-op must render."""
+        loaded_player._playback_speed = 0.75  # knob turned, render lost
+        with patch("src.player.StretchWorker") as worker_cls:
+            worker_cls.return_value.isRunning.return_value = False
+            loaded_player.set_pitch(0)  # unchanged pitch value
+            assert worker_cls.called
+        args = worker_cls.call_args[0]
+        assert args[2] == 0.75  # the owed speed render is included
+
+    def test_set_speed_same_value_rerenders_when_stems_stale(
+        self, loaded_player,
+    ):
+        """Pitch knob is ahead of the stems; a speed no-op must render."""
+        loaded_player._pitch_semitones = 2
+        with patch("src.player.StretchWorker") as worker_cls:
+            worker_cls.return_value.isRunning.return_value = False
+            loaded_player.set_speed(1.0)  # unchanged speed value
+            assert worker_cls.called
+        args = worker_cls.call_args[0]
+        assert args[3] == 2  # the owed pitch render is included
+
+    def test_scrub_back_during_speed_render_still_applies_speed(
+        self, loaded_player,
+    ):
+        """Full UI flow: speed render in flight, pitch scrubbed away and
+        back (the UI cancels on every tick), debounce flush lands on the
+        current pitch value -- the speed render must still happen."""
+        with patch("src.player.StretchWorker") as worker_cls:
+            live = MagicMock()
+            live.isRunning.return_value = True
+            worker_cls.return_value = live
+            loaded_player.set_speed(0.75)
+        loaded_player.cancel_stretch()
+        assert live in loaded_player._detached_workers
+
+        with patch("src.player.StretchWorker") as worker_cls2:
+            worker_cls2.return_value.isRunning.return_value = False
+            loaded_player.set_pitch(0)
+            # The cancelled worker is still draining: the render queues...
+            assert loaded_player._pending_render_emit is not None
+            # ...and dispatches once the drain finishes.
+            loaded_player._reap_detached_worker(live)
+            assert worker_cls2.called
+            args = worker_cls2.call_args[0]
+            assert args[2] == 0.75
+
+    def test_true_noop_still_skips_render(self, loaded_player):
+        """With stems current, unchanged values spawn nothing."""
+        with patch("src.player.StretchWorker") as worker_cls:
+            loaded_player.set_pitch(0)
+            loaded_player.set_speed(1.0)
+            worker_cls.assert_not_called()
+
+    def test_sync_toggle_at_pitch_zero_does_not_mark_stale(
+        self, loaded_player,
+    ):
+        """The sync flag is inaudible at pitch 0; toggling it must not
+        make the next no-op set_speed/set_pitch re-render."""
+        loaded_player.set_sync_recording_pitch(True)
+        with patch("src.player.StretchWorker") as worker_cls:
+            loaded_player.set_pitch(0)
+            loaded_player.set_speed(1.0)
+            worker_cls.assert_not_called()
+
+    def test_apply_stretched_stems_records_applied_state(
+        self, loaded_player,
+    ):
+        loaded_player._playback_speed = 0.75
+        loaded_player._pitch_semitones = 2
+        loaded_player._apply_stretched_stems(
+            dict(loaded_player._original_stems)
+        )
+        assert loaded_player._applied_render_state == (0.75, 2, False)
+
+    def test_load_stems_resets_applied_state(self, loaded_player, tmp_path):
+        import soundfile as sf
+        loaded_player._applied_render_state = (0.75, 2, False)
+        wav_path = tmp_path / "fake.wav"
+        sf.write(str(wav_path), np.zeros((4410, 2), dtype=np.float32), 44100)
+        loaded_player.load_stems({"vocals": str(wav_path)})
+        assert loaded_player._applied_render_state == (1.0, 0, False)
+
+
+# -----------------------------------------------------------------------
+# Regression: worker finishing between isRunning() and connect() must
+# not wedge the render queue
+# -----------------------------------------------------------------------
+
+class TestDetachReapRace:
+    def test_detach_reaps_worker_that_finished_before_connect(
+        self, loaded_player,
+    ):
+        """isRunning flips False right after the keepalive connect: the
+        finished signal fired unheard, so detach must reap directly --
+        otherwise _detached_workers never drains and every queued render
+        waits forever."""
+        fake = MagicMock()
+        fake.isRunning.side_effect = [True, False]
+        loaded_player._stretch_worker = fake
+
+        loaded_player._detach_stretch_worker()
+
+        assert fake not in loaded_player._detached_workers
+        fake.deleteLater.assert_called_once()
+
+    def test_reaper_double_call_does_not_touch_worker_again(
+        self, loaded_player,
+    ):
+        """Second delivery (manual reap plus the queued finished signal)
+        must not poke a wrapper that may already be deleteLater'd."""
+        fake = MagicMock()
+        loaded_player._detached_workers.append(fake)
+        loaded_player._reap_detached_worker(fake)
+        fake.setParent.reset_mock()
+        fake.deleteLater.reset_mock()
+
+        loaded_player._reap_detached_worker(fake)
+
+        fake.setParent.assert_not_called()
+        fake.deleteLater.assert_not_called()

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -38,7 +38,15 @@ def app():
 
 @pytest.fixture
 def loaded_player(app):
-    """Player with fake stems already loaded (no worker will spawn audio IO)."""
+    """Player with fake stems already loaded (no worker will spawn audio IO).
+
+    Teardown shuts the player down: tests that call set_pitch/set_speed
+    without patching StretchWorker spawn a real QThread rendering via
+    librosa, and letting the garbage collector delete the player (and
+    its child QThread) while that render is still running corrupts the
+    Qt heap -- the crash then surfaces in whichever later test touches
+    Qt next.
+    """
     p = MultiTrackPlayer()
     sr = 44100
     frames = sr  # 1 second
@@ -46,7 +54,8 @@ def loaded_player(app):
     p._original_stems = dict(p._stems)
     p._sample_rate = sr
     p._total_frames = frames
-    return p
+    yield p
+    p.shutdown(wait_ms=5000)
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -675,3 +675,221 @@ class TestStretchErrorBeatsReset:
         assert np.array_equal(
             loaded_player._beat_frames, normal_beat_frames
         ), "_beat_frames not recomputed after error; metronome would misfire"
+
+
+# -----------------------------------------------------------------------
+# Render serialization — at most one live worker at a time
+# -----------------------------------------------------------------------
+
+class TestRenderSerialization:
+    """A draining worker must block new spawns to bound peak memory use.
+
+    The disk-fill bug: rapid speed/pitch knob twirls spawned a fresh
+    ``StretchWorker`` every time.  Each worker runs a ``ThreadPoolExecutor``
+    with up to 8 librosa calls holding float32 intermediates; stacking
+    them serialized into ~10GB of pagefile swap on ~60s stems before the
+    drain caught up.  The fix is a single queued-render slot that the
+    reaper drains once the previous worker's cancellation settles.
+    """
+
+    def test_second_render_queues_instead_of_spawning(self, loaded_player):
+        """While a worker drains, a new _render_stretch must not start a
+        second thread."""
+        # Simulate an in-flight worker that was just cancelled.
+        draining = MagicMock()
+        draining.isRunning.return_value = True
+        loaded_player._detached_workers.append(draining)
+        loaded_player._stretch_worker = None
+
+        loaded_player._playback_speed = 0.75
+        loaded_player._pitch_semitones = 0
+
+        with patch.object(loaded_player, "_spawn_stretch_worker") as spawn:
+            loaded_player._render_stretch(emit=("speed",))
+            spawn.assert_not_called()
+
+        assert loaded_player._pending_render_emit == ("speed",)
+
+    def test_queued_render_supersedes_previous_queued(self, loaded_player):
+        """A fresh queued render replaces the old emit tuple."""
+        draining = MagicMock()
+        draining.isRunning.return_value = True
+        loaded_player._detached_workers.append(draining)
+        loaded_player._pending_render_emit = ("pitch",)
+        loaded_player._playback_speed = 0.75
+
+        with patch.object(loaded_player, "_spawn_stretch_worker"):
+            loaded_player._render_stretch(emit=("speed",))
+
+        # The newer emit wins; the UI only needs to know the latest knob.
+        assert loaded_player._pending_render_emit == ("speed",)
+
+    def test_reaper_dispatches_queued_render(self, loaded_player):
+        """When the last drain finishes, the queued render fires."""
+        draining = MagicMock()
+        loaded_player._detached_workers = [draining]
+        loaded_player._pending_render_emit = ("speed",)
+        loaded_player._playback_speed = 0.75
+        loaded_player._pitch_semitones = 0
+
+        with patch.object(loaded_player, "_spawn_stretch_worker") as spawn:
+            loaded_player._reap_detached_worker(draining)
+            spawn.assert_called_once_with(("speed",))
+
+        assert loaded_player._pending_render_emit is None
+
+    def test_reaper_dispatch_emits_stretch_started(self, loaded_player):
+        """The queued render must re-light the UI indicator.
+
+        Otherwise the render runs invisibly when cancel_stretch had
+        previously cleared the indicator (common: every UI-driven
+        debounce path calls cancel_stretch first).
+        """
+        draining = MagicMock()
+        loaded_player._detached_workers = [draining]
+        loaded_player._pending_render_emit = ("speed",)
+        loaded_player._playback_speed = 0.75
+        loaded_player._pitch_semitones = 0
+
+        started: list[int] = []
+        loaded_player.stretch_started.connect(lambda: started.append(1))
+
+        # Patch StretchWorker construction so we exercise _spawn_stretch_worker
+        # end-to-end without actually spinning up a QThread.
+        with patch("src.player.StretchWorker") as mock_cls:
+            mock_worker = MagicMock()
+            mock_worker.isRunning.return_value = False
+            mock_cls.return_value = mock_worker
+            loaded_player._reap_detached_worker(draining)
+
+        assert started == [1], (
+            "queued render must re-emit stretch_started so the UI "
+            "indicator lights back up"
+        )
+
+    def test_reaper_does_not_dispatch_while_others_draining(
+        self, loaded_player,
+    ):
+        """If two workers are draining, only the last reap fires the queue."""
+        drain_a = MagicMock()
+        drain_b = MagicMock()
+        loaded_player._detached_workers = [drain_a, drain_b]
+        loaded_player._pending_render_emit = ("speed",)
+
+        with patch.object(loaded_player, "_spawn_stretch_worker") as spawn:
+            loaded_player._reap_detached_worker(drain_a)
+            spawn.assert_not_called()
+
+        # Queue is still armed for when drain_b reaps.
+        assert loaded_player._pending_render_emit == ("speed",)
+
+    def test_reaper_fast_path_when_queued_identity(self, loaded_player):
+        """Queued render at identity settings uses fast path (no spawn)."""
+        draining = MagicMock()
+        loaded_player._detached_workers = [draining]
+        loaded_player._pending_render_emit = ("speed",)
+        loaded_player._playback_speed = 1.0
+        loaded_player._pitch_semitones = 0
+
+        finished: list = []
+        loaded_player.stretch_finished.connect(lambda: finished.append(1))
+
+        with patch.object(loaded_player, "_spawn_stretch_worker") as spawn:
+            loaded_player._reap_detached_worker(draining)
+            spawn.assert_not_called()
+
+        assert finished == [1], "fast-path queued render must close lifecycle"
+        assert loaded_player._pending_render_emit is None
+
+    def test_cancel_stretch_clears_pending(self, loaded_player):
+        """An explicit cancel supersedes a queued render."""
+        loaded_player._pending_render_emit = ("speed",)
+        loaded_player._stretch_worker = None
+
+        finished: list = []
+        loaded_player.stretch_finished.connect(lambda: finished.append(1))
+        loaded_player.cancel_stretch()
+
+        assert loaded_player._pending_render_emit is None
+        # Pending alone (no active worker) still closes the lifecycle so
+        # the UI indicator clears.
+        assert finished == [1]
+
+    def test_load_stems_clears_pending(self, loaded_player, tmp_path):
+        """Switching songs must drop any queued render for the old stems."""
+        loaded_player._pending_render_emit = ("speed",)
+
+        # load_stems with an empty dict is a no-op load but still resets
+        # the pending slot.
+        with patch.object(loaded_player, "_render_stretch"):
+            try:
+                loaded_player.load_stems({})
+            except Exception:  # noqa: BLE001
+                pass
+
+        assert loaded_player._pending_render_emit is None
+
+
+# -----------------------------------------------------------------------
+# Shutdown — cancel in-flight work and wait so atexit doesn't hang
+# -----------------------------------------------------------------------
+
+class TestPlayerShutdown:
+    """``shutdown()`` is called from MainWindow.closeEvent.  Without it
+    the Python atexit handler blocks on the ThreadPoolExecutor inside
+    ``StretchWorker.run``, forcing Ctrl+C to quit the app."""
+
+    def test_shutdown_cancels_active_worker(self, loaded_player):
+        worker = MagicMock()
+        worker.isRunning.return_value = True
+        loaded_player._stretch_worker = worker
+
+        loaded_player.shutdown(wait_ms=10)
+
+        worker.cancel.assert_called_once()
+        worker.wait.assert_called_once_with(10)
+
+    def test_shutdown_cancels_detached_workers(self, loaded_player):
+        a = MagicMock()
+        a.isRunning.return_value = True
+        b = MagicMock()
+        b.isRunning.return_value = True
+        loaded_player._detached_workers = [a, b]
+
+        loaded_player.shutdown(wait_ms=5)
+
+        a.cancel.assert_called_once()
+        b.cancel.assert_called_once()
+        a.wait.assert_called_once_with(5)
+        b.wait.assert_called_once_with(5)
+
+    def test_shutdown_clears_pending_render(self, loaded_player):
+        loaded_player._pending_render_emit = ("speed",)
+        loaded_player.shutdown(wait_ms=0)
+        assert loaded_player._pending_render_emit is None
+
+    def test_shutdown_stops_position_timer(self, loaded_player):
+        loaded_player._timer.start()
+        assert loaded_player._timer.isActive()
+
+        loaded_player.shutdown(wait_ms=0)
+
+        assert not loaded_player._timer.isActive()
+
+    def test_shutdown_no_wait_for_already_stopped(self, loaded_player):
+        """Workers that already finished must not get a .wait() call
+        (Qt thread may be destroyed by then)."""
+        done = MagicMock()
+        done.isRunning.return_value = False
+        loaded_player._stretch_worker = done
+
+        loaded_player.shutdown(wait_ms=10)
+
+        done.cancel.assert_called_once()
+        done.wait.assert_not_called()
+
+    def test_shutdown_is_safe_with_no_workers(self, loaded_player):
+        """Idle-shutdown is a no-op but must not raise."""
+        loaded_player._stretch_worker = None
+        loaded_player._detached_workers = []
+        loaded_player.shutdown(wait_ms=0)  # should not raise

--- a/tests/test_pitch_shift_ui.py
+++ b/tests/test_pitch_shift_ui.py
@@ -1,0 +1,218 @@
+"""UI-level tests for pitch-shift behavior in ``PlayerControls``.
+
+Covers the work done to make rapid spinbox scrolling safe and
+discoverable:
+
+  - A 200ms debounce coalesces rapid ``valueChanged`` emissions into a
+    single ``player.set_pitch`` call.
+  - Scrolling the spinbox cancels any in-flight render immediately so
+    we stop wasting CPU on a stale target.
+  - The pitch spinbox stays enabled during a render (no more frozen UI).
+  - ``stretch_progress`` updates the pitch spinbox suffix
+    (``" st (2/4)"``) so progress is visually attached to the control.
+  - ``stretch_finished`` restores the idle suffix.
+  - Speed-only renders fall back to the floating status label because
+    a QComboBox cannot carry inline suffix text.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from src.player import MultiTrackPlayer
+from src.ui.player_controls import PlayerControls
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.fixture
+def player():
+    return MultiTrackPlayer()
+
+
+@pytest.fixture
+def controls(qapp, player):
+    ctrl = PlayerControls(player)
+    yield ctrl
+    ctrl._cleanup_peak_thread()
+
+
+# -----------------------------------------------------------------------
+# Debounce: rapid spinbox scroll coalesces into a single set_pitch
+# -----------------------------------------------------------------------
+
+class TestPitchDebounce:
+    """``QSpinBox.valueChanged`` only drives a render after the timer fires."""
+
+    def test_single_change_does_not_call_set_pitch_immediately(
+        self, controls, player,
+    ):
+        """valueChanged must not short-circuit into an immediate render."""
+        with patch.object(player, "set_pitch") as mock_set_pitch:
+            controls._on_pitch_changed(2)
+            mock_set_pitch.assert_not_called()
+
+    def test_timer_starts_on_change(self, controls):
+        """The debounce timer should be running after a change."""
+        controls._on_pitch_changed(2)
+        assert controls._pitch_debounce.isActive()
+
+    def test_pending_value_stored(self, controls):
+        """The pending pitch is captured until the timer fires."""
+        controls._on_pitch_changed(3)
+        assert controls._pending_pitch == 3
+
+    def test_rapid_changes_coalesce(self, controls, player):
+        """Scrolling 0 -> 1 -> 2 -> 3 -> 4 yields one set_pitch(4) call."""
+        with patch.object(player, "set_pitch") as mock_set_pitch:
+            for v in (1, 2, 3, 4):
+                controls._on_pitch_changed(v)
+            # Flush manually as if the timer had fired.
+            controls._flush_pending_pitch()
+            mock_set_pitch.assert_called_once_with(4)
+
+    def test_flush_with_no_pending_is_noop(self, controls, player):
+        """Firing the timer with no pending value does nothing."""
+        controls._pending_pitch = None
+        with patch.object(player, "set_pitch") as mock_set_pitch:
+            controls._flush_pending_pitch()
+            mock_set_pitch.assert_not_called()
+
+    def test_flush_clears_pending(self, controls, player):
+        """After flushing, the pending field is reset so the next
+        scroll cycle starts clean."""
+        controls._on_pitch_changed(5)
+        with patch.object(player, "set_pitch"):
+            controls._flush_pending_pitch()
+        assert controls._pending_pitch is None
+
+    def test_change_cancels_running_render(self, controls, player):
+        """Scrolling the spinbox must cancel any in-flight worker
+        immediately -- we don't want to keep burning CPU on a stale
+        pitch while the user is still scrubbing."""
+        with patch.object(player, "cancel_stretch") as mock_cancel:
+            controls._on_pitch_changed(2)
+            mock_cancel.assert_called_once()
+
+
+# -----------------------------------------------------------------------
+# Status indicator driven by stretch_started / stretch_progress / stretch_finished
+# -----------------------------------------------------------------------
+
+class TestStretchStatusIndicator:
+    """The render lifecycle paints progress onto the active control."""
+
+    def test_started_keeps_spinbox_enabled(self, controls, player):
+        """The spinbox MUST stay interactive so the user can cancel
+        a pitch scrub by changing the target again."""
+        player._pitch_semitones = 2
+        controls._on_stretch_started()
+        assert controls._pitch_spin.isEnabled()
+
+    def test_started_keeps_speed_combo_enabled(self, controls, player):
+        player._playback_speed = 0.75
+        controls._on_stretch_started()
+        assert controls._speed_combo.isEnabled()
+
+    def test_pitch_render_updates_spinbox_suffix(self, controls, player):
+        player._pitch_semitones = 2
+        controls._on_stretch_started()
+        # Before any progress ticks, we show a pending state.
+        assert controls._pitch_spin.suffix() != " st"
+
+    def test_pitch_progress_appears_in_spinbox_suffix(
+        self, controls, player,
+    ):
+        player._pitch_semitones = 2
+        controls._on_stretch_progress(2, 4)
+        suffix = controls._pitch_spin.suffix()
+        assert "(2/4)" in suffix
+        assert "st" in suffix
+
+    def test_pitch_progress_does_not_duplicate_in_floating_label(
+        self, controls, player,
+    ):
+        """When pitch is the active transform, the spinbox suffix is the
+        indicator -- the floating label stays empty to avoid duplication."""
+        player._pitch_semitones = 2
+        controls._on_stretch_progress(2, 4)
+        assert controls._speed_status.text() == ""
+
+    def test_speed_only_progress_goes_to_floating_label(
+        self, controls, player,
+    ):
+        """Combos can't carry suffixes, so speed-only renders fall back
+        to the floating label near the speed combo."""
+        player._pitch_semitones = 0
+        player._playback_speed = 0.75
+        controls._on_stretch_progress(2, 4)
+        text = controls._speed_status.text()
+        assert "Time-stretching" in text
+        assert "(2/4)" in text
+        # And the spinbox suffix stays at its idle state.
+        assert controls._pitch_spin.suffix() == " st"
+
+    def test_finished_restores_spinbox_suffix(self, controls, player):
+        player._pitch_semitones = 2
+        controls._on_stretch_progress(2, 4)
+        controls._on_stretch_finished()
+        assert controls._pitch_spin.suffix() == " st"
+
+    def test_finished_clears_floating_label(self, controls, player):
+        player._playback_speed = 0.75
+        controls._on_stretch_progress(1, 4)
+        controls._on_stretch_finished()
+        assert controls._speed_status.text() == ""
+
+
+# -----------------------------------------------------------------------
+# Label verb selection based on active transforms (helper function)
+# -----------------------------------------------------------------------
+
+class TestRenderStatusLabel:
+    """``_render_status_label`` composes status text for the floating
+    label. Kept for the speed-only case; the pitch case uses the spinbox
+    suffix directly."""
+
+    def test_pitch_only(self, controls, player):
+        player._pitch_semitones = 3
+        player._playback_speed = 1.0
+        assert "Transposing" in controls._render_status_label(0, 0)
+
+    def test_speed_only(self, controls, player):
+        player._pitch_semitones = 0
+        player._playback_speed = 0.75
+        assert "Time-stretching" in controls._render_status_label(0, 0)
+
+    def test_both(self, controls, player):
+        player._pitch_semitones = 3
+        player._playback_speed = 0.5
+        label = controls._render_status_label(0, 0)
+        assert "Transposing and time-stretching" in label
+
+    def test_identity_falls_back_to_rendering(self, controls, player):
+        """Returning to identity (fast path) rarely triggers the worker,
+        but the label must still be sensible if it does."""
+        player._pitch_semitones = 0
+        player._playback_speed = 1.0
+        label = controls._render_status_label(0, 0)
+        assert "Rendering" in label
+
+    def test_progress_numbers_appear_when_total_positive(
+        self, controls, player,
+    ):
+        player._pitch_semitones = 3
+        assert "(2/4)" in controls._render_status_label(2, 4)
+
+    def test_progress_numbers_omitted_at_total_zero(self, controls, player):
+        """Before any progress ticks arrive, we show the bare verb."""
+        player._pitch_semitones = 3
+        label = controls._render_status_label(0, 0)
+        assert "(" not in label

--- a/tests/test_pitch_shift_ui.py
+++ b/tests/test_pitch_shift_ui.py
@@ -216,3 +216,87 @@ class TestRenderStatusLabel:
         player._pitch_semitones = 3
         label = controls._render_status_label(0, 0)
         assert "(" not in label
+
+
+# -----------------------------------------------------------------------
+# Record button guard includes pitch (regression: was speed-only)
+# -----------------------------------------------------------------------
+
+class TestRecordButtonPitchGuard:
+    """Record button must be disabled (and auto-unarm) whenever pitch ≠ 0,
+    mirroring the player-level guard in arm_recording()."""
+
+    def test_record_button_disabled_at_nonzero_pitch(self, controls, player):
+        """Button must be disabled when pitch is non-zero."""
+        player._stems = {"vocals": None}  # make has_stems True
+        player._pitch_semitones = 2
+        player._playback_speed = 1.0
+        controls.update_record_button_state()
+        assert not controls._record_btn.isEnabled()
+
+    def test_record_button_enabled_at_identity(self, controls, player):
+        """Button must be enabled at speed=1.0 AND pitch=0."""
+        player._stems = {"vocals": None}
+        player._pitch_semitones = 0
+        player._playback_speed = 1.0
+        controls.update_record_button_state()
+        assert controls._record_btn.isEnabled()
+
+    def test_record_button_tooltip_mentions_pitch(self, controls, player):
+        """Tooltip must explain why recording is disabled when pitch != 0."""
+        player._stems = {"vocals": None}
+        player._pitch_semitones = 3
+        player._playback_speed = 1.0
+        controls.update_record_button_state()
+        assert "pitch" in controls._record_btn.toolTip().lower()
+
+    def test_record_button_unarms_on_pitch_change(self, controls, player):
+        """If the button was checked (armed) and pitch changes, it must
+        uncheck automatically so the UI stays consistent."""
+        player._stems = {"vocals": None}
+        player._pitch_semitones = 0
+        player._playback_speed = 1.0
+        controls.update_record_button_state()
+
+        # Arm it manually (bypass player so we can isolate the UI logic).
+        controls._record_btn.blockSignals(True)
+        controls._record_btn.setChecked(True)
+        controls._record_btn.blockSignals(False)
+
+        # Now pitch changes.
+        player._pitch_semitones = 1
+        with patch.object(player, "arm_recording") as mock_arm:
+            controls.update_record_button_state()
+        assert not controls._record_btn.isChecked()
+        mock_arm.assert_called_once_with(False)
+
+
+# -----------------------------------------------------------------------
+# Debounce state cleared when loading a new song (regression)
+# -----------------------------------------------------------------------
+
+class TestDebounceResetOnSongLoad:
+    """Pending pitch scroll must not carry over to the next loaded song."""
+
+    def test_pending_pitch_cleared_on_set_stem_names(self, controls):
+        """set_stem_names must discard any pending pitch value."""
+        controls._on_pitch_changed(5)
+        assert controls._pending_pitch == 5
+        controls.set_stem_names([])
+        assert controls._pending_pitch is None
+
+    def test_debounce_timer_stopped_on_set_stem_names(self, controls):
+        """set_stem_names must stop the debounce timer."""
+        controls._on_pitch_changed(3)
+        assert controls._pitch_debounce.isActive()
+        controls.set_stem_names([])
+        assert not controls._pitch_debounce.isActive()
+
+    def test_no_spurious_set_pitch_after_song_load(self, controls, player):
+        """Timer firing after set_stem_names must not call set_pitch."""
+        controls._on_pitch_changed(4)
+        controls.set_stem_names([])
+        with patch.object(player, "set_pitch") as mock_set_pitch:
+            # Manually flush as if the timer fired.
+            controls._flush_pending_pitch()
+            mock_set_pitch.assert_not_called()

--- a/tests/test_pitch_shift_ui.py
+++ b/tests/test_pitch_shift_ui.py
@@ -225,6 +225,29 @@ class TestPitchSpinBoxText:
         assert "+2 semitones" in text
         assert "(processing 1/4)" in text
 
+    def test_size_hint_shrinks_with_shorter_text(self, controls):
+        """Width must adapt to content -- no wasted space when the
+        text is short ("original") vs long ("+12 semitones ...")."""
+        spin = controls._pitch_spin
+        spin.setValue(0)  # "original"
+        short_w = spin.sizeHint().width()
+        spin.setValue(12)  # "+12 semitones"
+        long_w = spin.sizeHint().width()
+        assert long_w > short_w, (
+            f"sizeHint should grow with longer text ({short_w} vs {long_w})"
+        )
+
+    def test_size_hint_grows_with_processing_suffix(self, controls, player):
+        """The processing suffix must expand the spinbox width so it
+        doesn't clip mid-render."""
+        spin = controls._pitch_spin
+        spin.setValue(2)
+        idle_w = spin.sizeHint().width()
+        player._pitch_semitones = 2
+        controls._on_stretch_progress(1, 4)
+        processing_w = spin.sizeHint().width()
+        assert processing_w > idle_w
+
 
 # -----------------------------------------------------------------------
 # Label verb selection based on active transforms (helper function)

--- a/tests/test_pitch_shift_ui.py
+++ b/tests/test_pitch_shift_ui.py
@@ -8,11 +8,15 @@ discoverable:
   - Scrolling the spinbox cancels any in-flight render immediately so
     we stop wasting CPU on a stale target.
   - The pitch spinbox stays enabled during a render (no more frozen UI).
-  - ``stretch_progress`` updates the pitch spinbox suffix
-    (``" st (2/4)"``) so progress is visually attached to the control.
-  - ``stretch_finished`` restores the idle suffix.
+  - ``stretch_progress`` updates the pitch spinbox with a processing
+    suffix (e.g. ``"+2 semitones (processing 2/4)"``) so progress is
+    visually attached to the control that spawned the render.
+  - ``stretch_finished`` clears the suffix.
   - Speed-only renders fall back to the floating status label because
     a QComboBox cannot carry inline suffix text.
+  - The spinbox itself renders human-readable text via
+    ``PitchSpinBox.textFromValue`` -- "original" at 0, "+N semitone(s)"
+    otherwise.
 """
 
 from unittest.mock import patch
@@ -124,8 +128,8 @@ class TestStretchStatusIndicator:
     def test_pitch_render_updates_spinbox_suffix(self, controls, player):
         player._pitch_semitones = 2
         controls._on_stretch_started()
-        # Before any progress ticks, we show a pending state.
-        assert controls._pitch_spin.suffix() != " st"
+        # Before any progress ticks, we show a pending state (non-empty).
+        assert controls._pitch_spin.suffix() != ""
 
     def test_pitch_progress_appears_in_spinbox_suffix(
         self, controls, player,
@@ -133,8 +137,8 @@ class TestStretchStatusIndicator:
         player._pitch_semitones = 2
         controls._on_stretch_progress(2, 4)
         suffix = controls._pitch_spin.suffix()
-        assert "(2/4)" in suffix
-        assert "st" in suffix
+        assert "2/4" in suffix
+        assert "processing" in suffix.lower()
 
     def test_pitch_progress_does_not_duplicate_in_floating_label(
         self, controls, player,
@@ -156,20 +160,70 @@ class TestStretchStatusIndicator:
         text = controls._speed_status.text()
         assert "Time-stretching" in text
         assert "(2/4)" in text
-        # And the spinbox suffix stays at its idle state.
-        assert controls._pitch_spin.suffix() == " st"
+        # And the spinbox suffix stays empty (its main text already
+        # reads "original" when pitch is 0).
+        assert controls._pitch_spin.suffix() == ""
 
-    def test_finished_restores_spinbox_suffix(self, controls, player):
+    def test_finished_clears_spinbox_suffix(self, controls, player):
         player._pitch_semitones = 2
         controls._on_stretch_progress(2, 4)
         controls._on_stretch_finished()
-        assert controls._pitch_spin.suffix() == " st"
+        assert controls._pitch_spin.suffix() == ""
 
     def test_finished_clears_floating_label(self, controls, player):
         player._playback_speed = 0.75
         controls._on_stretch_progress(1, 4)
         controls._on_stretch_finished()
         assert controls._speed_status.text() == ""
+
+
+# -----------------------------------------------------------------------
+# PitchSpinBox human-readable text
+# -----------------------------------------------------------------------
+
+class TestPitchSpinBoxText:
+    """``textFromValue`` produces human-readable labels rather than a
+    bare integer + unit suffix.  This is what the user sees in the UI."""
+
+    def test_zero_reads_as_original(self, controls):
+        controls._pitch_spin.setValue(0)
+        assert "original" in controls._pitch_spin.text()
+
+    def test_positive_one_is_singular(self, controls):
+        controls._pitch_spin.setValue(1)
+        text = controls._pitch_spin.text()
+        assert "+1 semitone" in text
+        assert "semitones" not in text  # not plural
+
+    def test_positive_two_is_plural(self, controls):
+        controls._pitch_spin.setValue(2)
+        assert "+2 semitones" in controls._pitch_spin.text()
+
+    def test_negative_one_is_singular(self, controls):
+        controls._pitch_spin.setValue(-1)
+        text = controls._pitch_spin.text()
+        assert "-1 semitone" in text
+        assert "semitones" not in text
+
+    def test_negative_three_is_plural(self, controls):
+        controls._pitch_spin.setValue(-3)
+        assert "-3 semitones" in controls._pitch_spin.text()
+
+    def test_idle_spinbox_has_no_suffix_parens(self, controls):
+        """When the spinbox is idle we only show the core label --
+        the processing tail is added only during a render."""
+        controls._pitch_spin.setValue(2)
+        assert "(processing" not in controls._pitch_spin.text()
+
+    def test_processing_suffix_appended_during_render(
+        self, controls, player,
+    ):
+        player._pitch_semitones = 2
+        controls._pitch_spin.setValue(2)
+        controls._on_stretch_progress(1, 4)
+        text = controls._pitch_spin.text()
+        assert "+2 semitones" in text
+        assert "(processing 1/4)" in text
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_pitch_shift_ui.py
+++ b/tests/test_pitch_shift_ui.py
@@ -38,7 +38,11 @@ def qapp():
 
 @pytest.fixture
 def player():
-    return MultiTrackPlayer()
+    p = MultiTrackPlayer()
+    yield p
+    # Deterministic teardown: never let the GC delete a player whose
+    # render QThread may still be running (heap corruption otherwise).
+    p.shutdown(wait_ms=5000)
 
 
 @pytest.fixture

--- a/tests/test_pitch_shift_ui.py
+++ b/tests/test_pitch_shift_ui.py
@@ -137,8 +137,9 @@ class TestStretchStatusIndicator:
         player._pitch_semitones = 2
         controls._on_stretch_progress(2, 4)
         suffix = controls._pitch_spin.suffix()
+        # Compact indicator: just "(current/total)" -- the control
+        # being greyed-out is itself the "this is processing" cue.
         assert "2/4" in suffix
-        assert "processing" in suffix.lower()
 
     def test_pitch_progress_does_not_duplicate_in_floating_label(
         self, controls, player,
@@ -153,13 +154,14 @@ class TestStretchStatusIndicator:
         self, controls, player,
     ):
         """Combos can't carry suffixes, so speed-only renders fall back
-        to the floating label near the speed combo."""
+        to the floating label next to the speed combo.  The compact
+        format matches the spinbox suffix so both indicators read the
+        same way."""
         player._pitch_semitones = 0
         player._playback_speed = 0.75
         controls._on_stretch_progress(2, 4)
         text = controls._speed_status.text()
-        assert "Time-stretching" in text
-        assert "(2/4)" in text
+        assert "2/4" in text
         # And the spinbox suffix stays empty (its main text already
         # reads "original" when pitch is 0).
         assert controls._pitch_spin.suffix() == ""
@@ -183,37 +185,44 @@ class TestStretchStatusIndicator:
 
 class TestPitchSpinBoxText:
     """``textFromValue`` produces human-readable labels rather than a
-    bare integer + unit suffix.  This is what the user sees in the UI."""
+    bare integer + unit suffix.  This is what the user sees in the UI.
+
+    The text is kept intentionally compact ("+2 semi" rather than
+    "+2 semitones") because the progress suffix is appended during
+    renders and the combined string has to fit the spinbox width
+    without clipping.  "semi" is short for "semitone" and is
+    unambiguous in the context of a "Pitch:" label.
+    """
 
     def test_zero_reads_as_original(self, controls):
         controls._pitch_spin.setValue(0)
         assert "original" in controls._pitch_spin.text()
 
-    def test_positive_one_is_singular(self, controls):
+    def test_positive_value_shows_plus_sign(self, controls):
         controls._pitch_spin.setValue(1)
         text = controls._pitch_spin.text()
-        assert "+1 semitone" in text
-        assert "semitones" not in text  # not plural
+        assert "+1 semi" in text
 
-    def test_positive_two_is_plural(self, controls):
+    def test_positive_multi_semitone(self, controls):
         controls._pitch_spin.setValue(2)
-        assert "+2 semitones" in controls._pitch_spin.text()
+        assert "+2 semi" in controls._pitch_spin.text()
 
-    def test_negative_one_is_singular(self, controls):
+    def test_negative_value_shows_minus_sign(self, controls):
         controls._pitch_spin.setValue(-1)
         text = controls._pitch_spin.text()
-        assert "-1 semitone" in text
-        assert "semitones" not in text
+        assert "-1 semi" in text
 
-    def test_negative_three_is_plural(self, controls):
+    def test_negative_multi_semitone(self, controls):
         controls._pitch_spin.setValue(-3)
-        assert "-3 semitones" in controls._pitch_spin.text()
+        assert "-3 semi" in controls._pitch_spin.text()
 
-    def test_idle_spinbox_has_no_suffix_parens(self, controls):
+    def test_idle_spinbox_has_no_processing_suffix(self, controls):
         """When the spinbox is idle we only show the core label --
         the processing tail is added only during a render."""
         controls._pitch_spin.setValue(2)
-        assert "(processing" not in controls._pitch_spin.text()
+        text = controls._pitch_spin.text()
+        # No "(N/M)" fragment when idle.
+        assert "/" not in text
 
     def test_processing_suffix_appended_during_render(
         self, controls, player,
@@ -222,31 +231,36 @@ class TestPitchSpinBoxText:
         controls._pitch_spin.setValue(2)
         controls._on_stretch_progress(1, 4)
         text = controls._pitch_spin.text()
-        assert "+2 semitones" in text
-        assert "(processing 1/4)" in text
+        assert "+2 semi" in text
+        # Compact progress format: just "(current/total)", no word.
+        assert "(1/4)" in text
 
-    def test_size_hint_shrinks_with_shorter_text(self, controls):
-        """Width must adapt to content -- no wasted space when the
-        text is short ("original") vs long ("+12 semitones ...")."""
-        spin = controls._pitch_spin
-        spin.setValue(0)  # "original"
-        short_w = spin.sizeHint().width()
-        spin.setValue(12)  # "+12 semitones"
-        long_w = spin.sizeHint().width()
-        assert long_w > short_w, (
-            f"sizeHint should grow with longer text ({short_w} vs {long_w})"
-        )
+    def test_size_hint_fits_widest_processing_text(self, controls):
+        """sizeHint must be wide enough for the worst-case text so
+        the processing suffix never clips the ``semi`` or the counter.
 
-    def test_size_hint_grows_with_processing_suffix(self, controls, player):
-        """The processing suffix must expand the spinbox width so it
-        doesn't clip mid-render."""
+        Sizing is now fixed at construction (not dynamic) for
+        layout-stability reasons -- see PitchSpinBox docstring.
+        """
+        from PySide6.QtGui import QFontMetrics
         spin = controls._pitch_spin
-        spin.setValue(2)
-        idle_w = spin.sizeHint().width()
-        player._pitch_semitones = 2
-        controls._on_stretch_progress(1, 4)
-        processing_w = spin.sizeHint().width()
-        assert processing_w > idle_w
+        fm = QFontMetrics(spin.font())
+        # Longest text the spinbox can ever show at ±7 semitones
+        # with a progress counter capped at two digits per stem.
+        widest_text_w = fm.horizontalAdvance("+7 semi (10/10)")
+        assert spin.sizeHint().width() >= widest_text_w
+
+    def test_size_hint_is_stable_across_values(self, controls):
+        """Width must not jitter as the value / suffix changes --
+        the layout was previously thrashing on every render start."""
+        spin = controls._pitch_spin
+        spin.setValue(0)
+        w_at_zero = spin.sizeHint().width()
+        spin.setValue(7)
+        w_at_seven = spin.sizeHint().width()
+        spin.setSuffix(" (3/10)")
+        w_processing = spin.sizeHint().width()
+        assert w_at_zero == w_at_seven == w_processing
 
 
 # -----------------------------------------------------------------------
@@ -377,3 +391,134 @@ class TestDebounceResetOnSongLoad:
             # Manually flush as if the timer fired.
             controls._flush_pending_pitch()
             mock_set_pitch.assert_not_called()
+
+
+# -----------------------------------------------------------------------
+# Speed debounce — mirrors the pitch debounce
+# -----------------------------------------------------------------------
+
+class TestSpeedDebounce:
+    """Rapid speed combo changes coalesce into one render just like pitch.
+
+    Before this, Shift+Up/Down cycling through presets would spawn a new
+    worker per step, feeding the same disk-fill bug that motivated the
+    render-serialization fix on the player side.
+    """
+
+    def test_speed_change_defers_set_speed(self, controls, player):
+        """Selecting a preset does not synchronously call set_speed."""
+        with patch.object(player, "set_speed") as mock_set_speed:
+            # Find the index for 0.75 and select it.
+            idx = controls._speed_combo.findData(0.75)
+            assert idx >= 0, "0.75 preset should exist"
+            controls._speed_combo.setCurrentIndex(idx)
+            mock_set_speed.assert_not_called()
+
+    def test_speed_debounce_timer_starts(self, controls):
+        """Speed change should arm the 100ms debounce timer."""
+        idx = controls._speed_combo.findData(0.75)
+        controls._speed_combo.setCurrentIndex(idx)
+        assert controls._speed_debounce.isActive()
+        assert controls._pending_speed == 0.75
+
+    def test_speed_change_cancels_in_flight(self, controls, player):
+        """A fresh change cancels any running render for CPU relief."""
+        with patch.object(player, "cancel_stretch") as mock_cancel:
+            idx = controls._speed_combo.findData(0.5)
+            controls._speed_combo.setCurrentIndex(idx)
+            mock_cancel.assert_called_once()
+
+    def test_speed_rapid_changes_coalesce(self, controls, player):
+        """Cycling through 1.0 -> 0.9 -> 0.75 -> 0.5 yields one set_speed(0.5)."""
+        with patch.object(player, "set_speed") as mock_set_speed:
+            for target in (0.9, 0.75, 0.5):
+                idx = controls._speed_combo.findData(target)
+                if idx < 0:
+                    continue
+                controls._speed_combo.setCurrentIndex(idx)
+            controls._flush_pending_speed()
+            # Final call is whatever the last preset was.
+            mock_set_speed.assert_called_once()
+            (called_speed,), _ = mock_set_speed.call_args
+            assert called_speed == controls._speed_combo.currentData()
+
+    def test_speed_flush_clears_pending(self, controls, player):
+        """After flush, _pending_speed resets for the next cycle."""
+        idx = controls._speed_combo.findData(0.75)
+        controls._speed_combo.setCurrentIndex(idx)
+        with patch.object(player, "set_speed"):
+            controls._flush_pending_speed()
+        assert controls._pending_speed is None
+
+    def test_speed_flush_no_pending_is_noop(self, controls, player):
+        """Timer fire with no pending change does nothing."""
+        controls._pending_speed = None
+        with patch.object(player, "set_speed") as mock_set_speed:
+            controls._flush_pending_speed()
+            mock_set_speed.assert_not_called()
+
+    def test_load_stems_resets_speed_debounce(self, controls):
+        """Switching songs drops any queued speed change."""
+        idx = controls._speed_combo.findData(0.75)
+        controls._speed_combo.setCurrentIndex(idx)
+        assert controls._speed_debounce.isActive()
+
+        controls.set_stem_names([])
+
+        assert not controls._speed_debounce.isActive()
+        assert controls._pending_speed is None
+
+
+# -----------------------------------------------------------------------
+# Master volume slider — transport-row indicator
+# -----------------------------------------------------------------------
+
+class TestMasterVolumeSlider:
+    """The slider mirrors the player's master volume and is the single
+    entry point for shortcut-driven volume changes."""
+
+    def test_default_value_is_full(self, controls):
+        assert controls._master_volume_slider.value() == 100
+        assert controls._master_volume_label.text() == "100%"
+
+    def test_slider_drag_calls_player(self, controls, player):
+        """Moving the slider propagates into the player."""
+        with patch.object(player, "set_master_volume") as mock_set:
+            controls._master_volume_slider.setValue(75)
+            mock_set.assert_called_once_with(0.75)
+
+    def test_slider_drag_updates_label(self, controls):
+        controls._master_volume_slider.setValue(125)
+        assert controls._master_volume_label.text() == "125%"
+
+    def test_set_master_volume_updates_slider(self, controls):
+        """External callers (shortcuts, session restore) use set_master_volume."""
+        controls.set_master_volume(0.5)
+        assert controls._master_volume_slider.value() == 50
+        assert controls._master_volume_label.text() == "50%"
+
+    def test_set_master_volume_clamps(self, controls):
+        """Out-of-range values are clamped to the 0-200% range."""
+        controls.set_master_volume(5.0)
+        assert controls._master_volume_slider.value() == 200
+
+        controls.set_master_volume(-1.0)
+        assert controls._master_volume_slider.value() == 0
+
+    def test_set_master_volume_blocks_signal_recursion(self, controls, player):
+        """set_master_volume must not recurse through the slider signal
+        (which would call set_master_volume again via
+        _on_master_volume_slider_changed -> player.set_master_volume)."""
+        calls: list[float] = []
+        with patch.object(
+            player, "set_master_volume", side_effect=calls.append,
+        ):
+            controls.set_master_volume(0.6)
+            # Exactly one player call -- not the slider's valueChanged
+            # bouncing back through the handler.
+            assert calls == [0.6]
+
+    def test_set_master_volume_propagates_to_player(self, controls, player):
+        with patch.object(player, "set_master_volume") as mock_set:
+            controls.set_master_volume(1.5)
+            mock_set.assert_called_once_with(1.5)

--- a/tests/test_speed_control.py
+++ b/tests/test_speed_control.py
@@ -5,7 +5,7 @@ import pytest
 
 from PySide6.QtWidgets import QApplication
 
-from src.player import MultiTrackPlayer, SpeedWorker
+from src.player import MultiTrackPlayer, StretchWorker
 
 
 @pytest.fixture(scope="module")
@@ -24,16 +24,16 @@ def player(app):
 
 
 # -----------------------------------------------------------------------
-# SpeedWorker
+# StretchWorker -- time-stretch only (pitch=0)
 # -----------------------------------------------------------------------
 
-class TestSpeedWorker:
-    """SpeedWorker stretches stems via librosa in a background thread."""
+class TestStretchWorkerSpeed:
+    """StretchWorker time-stretches stems via librosa in a background thread."""
 
     def test_stretch_produces_different_frame_count(self, app):
         """Stretching at 0.5x should roughly double the frame count."""
         stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
-        worker = SpeedWorker(stems, 0.5)
+        worker = StretchWorker(stems, 44100, 0.5, 0)
         results = {}
         worker.completed.connect(lambda d: results.update(d))
         worker.run()  # Run synchronously for testing.
@@ -42,20 +42,20 @@ class TestSpeedWorker:
         assert results["vocals"].shape[0] > 4410 * 1.5
         assert results["vocals"].shape[1] == 2
 
-    def test_stretch_at_1x_returns_same_length(self, app):
-        """Stretching at 1.0x should return approximately the same length."""
+    def test_stretch_at_1x_returns_same_buffer(self, app):
+        """Stretching at 1.0x with pitch=0 is the fast path -- buffer reused."""
         stems = {"vocals": np.random.randn(4410, 2).astype(np.float32)}
-        worker = SpeedWorker(stems, 1.0)
+        worker = StretchWorker(stems, 44100, 1.0, 0)
         results = {}
         worker.completed.connect(lambda d: results.update(d))
         worker.run()
-        # Should be very close to original length.
-        assert abs(results["vocals"].shape[0] - 4410) < 100
+        # Identity transform: worker should reuse the original buffer.
+        assert results["vocals"] is stems["vocals"]
 
     def test_stretch_at_2x_halves_frames(self, app):
         """Stretching at 2.0x should roughly halve the frame count."""
         stems = {"vocals": np.random.randn(8820, 2).astype(np.float32)}
-        worker = SpeedWorker(stems, 2.0)
+        worker = StretchWorker(stems, 44100, 2.0, 0)
         results = {}
         worker.completed.connect(lambda d: results.update(d))
         worker.run()
@@ -67,7 +67,7 @@ class TestSpeedWorker:
             "vocals": np.random.randn(4410, 2).astype(np.float32),
             "drums": np.random.randn(4410, 2).astype(np.float32),
         }
-        worker = SpeedWorker(stems, 0.75)
+        worker = StretchWorker(stems, 44100, 0.75, 0)
         results = {}
         worker.completed.connect(lambda d: results.update(d))
         worker.run()
@@ -80,7 +80,7 @@ class TestSpeedWorker:
             "vocals": np.random.randn(4410, 2).astype(np.float32),
             "drums": np.random.randn(4410, 2).astype(np.float32),
         }
-        worker = SpeedWorker(stems, 0.75)
+        worker = StretchWorker(stems, 44100, 0.75, 0)
         progress = []
         worker.progress.connect(lambda cur, tot: progress.append((cur, tot)))
         worker.run()

--- a/tests/test_speed_control.py
+++ b/tests/test_speed_control.py
@@ -84,7 +84,9 @@ class TestStretchWorkerSpeed:
         progress = []
         worker.progress.connect(lambda cur, tot: progress.append((cur, tot)))
         worker.run()
-        assert len(progress) == 2
+        # Expect: initial (0, 2) + one tick per completed stem → 3 total.
+        assert len(progress) == 3
+        assert progress[0] == (0, 2)   # immediate "started" tick
         assert progress[-1] == (2, 2)
 
 

--- a/tests/test_speed_control.py
+++ b/tests/test_speed_control.py
@@ -20,7 +20,11 @@ def app():
 @pytest.fixture
 def player(app):
     """A MultiTrackPlayer with no stems loaded."""
-    return MultiTrackPlayer()
+    p = MultiTrackPlayer()
+    yield p
+    # Deterministic teardown: never let the GC delete a player whose
+    # render QThread may still be running (heap corruption otherwise).
+    p.shutdown(wait_ms=5000)
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
-from PySide6.QtCore import QSettings
+from PySide6.QtCore import Qt, QSettings
 from PySide6.QtWidgets import QApplication, QWidget
 
 from src.app_settings import read_startup_play_sound
@@ -26,6 +26,30 @@ def app():
     if instance is None:
         instance = QApplication([])
     return instance
+
+
+@pytest.fixture(autouse=True)
+def _headless_safe_show(monkeypatch):
+    """Prevent native window creation during splash tests.
+
+    Calling ``show()`` on a QWidget on a headless Windows CI runner can
+    trigger a synchronous WM_PAINT that fatally faults without a display
+    driver (access violation).  ``WA_DontShowOnScreen`` is Qt's designated
+    attribute for this: it skips native window creation while leaving
+    ``isVisible()``/``setVisible()`` semantics intact.
+
+    Rather than patch every test, we wrap ``QWidget.show`` so the
+    attribute is applied immediately before any show() call -- covering
+    both the SplashScreen and any QWidget instances that ``finish()``
+    may try to show.
+    """
+    original_show = QWidget.show
+
+    def safe_show(self):
+        self.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen, True)
+        original_show(self)
+
+    monkeypatch.setattr(QWidget, "show", safe_show)
 
 
 @pytest.fixture

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
-from PySide6.QtCore import Qt, QSettings
+from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication, QWidget
 
 from src.app_settings import read_startup_play_sound
@@ -26,30 +26,6 @@ def app():
     if instance is None:
         instance = QApplication([])
     return instance
-
-
-@pytest.fixture(autouse=True)
-def _headless_safe_show(monkeypatch):
-    """Prevent native window creation during splash tests.
-
-    Calling ``show()`` on a QWidget on a headless Windows CI runner can
-    trigger a synchronous WM_PAINT that fatally faults without a display
-    driver (access violation).  ``WA_DontShowOnScreen`` is Qt's designated
-    attribute for this: it skips native window creation while leaving
-    ``isVisible()``/``setVisible()`` semantics intact.
-
-    Rather than patch every test, we wrap ``QWidget.show`` so the
-    attribute is applied immediately before any show() call -- covering
-    both the SplashScreen and any QWidget instances that ``finish()``
-    may try to show.
-    """
-    original_show = QWidget.show
-
-    def safe_show(self):
-        self.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen, True)
-        original_show(self)
-
-    monkeypatch.setattr(QWidget, "show", safe_show)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- ±7 semitone pitch transposition via spinbox in the transport bar and `Shift+Left`/`Shift+Right` shortcuts (layout-safe, no symbol keys).
- `StretchWorker` replaces `SpeedWorker`: applies pitch + speed in a single pass per stem from the original buffers (no chained artefacts). Identity state is a fast-path no-op that reuses buffers. Renders are serialized (one worker at a time; superseded requests coalesce into a pending slot) to bound peak memory, and the per-stem pool uses daemon threads so closing the app mid-render doesn't hang in atexit.
- Effective key display in the detection badge: shows `<detected> → <transposed>` when pitch ≠ 0 (e.g. `A minor → B minor`).
- Recording takes skip pitch by default (so playback matches what was performed); new "Pitch-shift recording takes with the stems" checkbox in Edit > Preferences > Playback toggles opt-in sync. Recording cannot be armed while pitch ≠ 0.
- Session persistence for pitch alongside speed (single session key, same semantics as speed: the last song's pitch restores at startup; loading a different song resets pitch to 0).
- The player tracks the applied render state, so a render discarded by `cancel_stretch()` (spinbox scrubbing) is re-run instead of silently skipped — fixes a desync where the knobs claimed 0.75x/+2 st while the stems still played the previous render.
- Worker keepalive (`_detached_workers`) fixes a latent main-branch crash: detaching an in-flight worker dropped the last Python reference to a running QThread (GC then deletes it mid-run → access violation). A reap race that could permanently wedge queued renders is also fixed.
- `MultiTrackPlayer.shutdown()` and peak-pool shutdown wired into `closeEvent`.
- CI runs the suite under Qt's offscreen platform — the hosted runner intermittently access-violated or hung inside native `show()`; actions bumped for Node 24.
- Root-caused the full-suite teardown flake (was blamed on numba/shiboken6): a test spawned a real render QThread that the GC later deleted mid-run, plus lazy cyclic GC destroying old widget trees reentrantly inside Qt calls. Player fixtures now join render threads at teardown and conftest collects garbage at module boundaries.

## Test plan
- [x] Full suite: 802 passed, 5 skipped on Python 3.14 / PySide6 6.10.2 (native windows platform), 5/5 consecutive clean runs
- [x] CI-parity venv (Python 3.12 / PySide6 6.11.1 / offscreen): 798 passed
- [x] New regression tests: cancelled-render staleness, detach/reap race, render serialization, shutdown lifecycle, transpose_key
- [x] Manual: spinbox up/down adjusts pitch; `Shift+Right` adds a semitone; key badge transposes; toggling sync preference with pitch active re-renders; arming record while pitched is refused; session survives restart with pitch intact.