### PR TITLE
fix: v2.4.1 -- stability pass (recording, callback, export, downloads, library)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,16 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        # pytest lives in requirements-dev.txt (runtime/dev split); the
+        # test job needs both.
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Run fast tests
         # The offscreen QPA platform keeps Qt away from the runner's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,10 +35,10 @@ stemma/
   PROJECT.md           # Detailed spec and roadmap (reference doc)
   AGENTS.md            # This file (AI context, living document)
   CHANGELOG.md         # Append-only session history
-  stemma.spec              # PyInstaller one-file build spec
+  stemma.spec              # PyInstaller one-folder (COLLECT) build spec
   requirements-dev.txt     # Dev/build dependencies (pyinstaller)
   .github/workflows/ci.yml      # CI: fast tests on push
-  .github/workflows/release.yml # On v* tags: sync version + manifest, fast tests, .exe/.msix, GitHub Release
+  .github/workflows/release.yml # On v* tags: sync version + manifest, fast tests, stemma.zip + stemma.msix, GitHub Release
   .github/workflows/partner-center-submit.yml # Optional manual Partner Center API (default: credentials check only)
   src/
     app.py             # QApplication setup
@@ -48,7 +48,9 @@ stemma/
     version.py         # __version__ string
     import_messages.py # User-facing import / download / separation error text
     metronome.py       # Tap tempo / BPM helpers for metronome UI
+    click_utils.py     # Metronome click sample generation
     separator.py       # ONNX stem separation engine
+    beat_detector.py   # BPM/key/chord detection + beat_this ONNX beat tracking
     model_manager.py   # Download/cache ONNX models
     player.py          # Multi-track audio player
     library.py         # Song library (JSON-based)
@@ -71,7 +73,7 @@ stemma/
       wav_playback.py    # Logo SFX entry (lazy-loads Qt Multimedia impl)
       _wav_playback_impl.py  # QSoundEffect + winsound fallback
       styles.py          # Dark / light themes
-  tests/               # pytest test suite (~498 fast + 5 slow + 1 hardware)
+  tests/               # pytest test suite (~825 fast + slow/hardware deselected by default)
     conftest.py        # Shared fixtures
     test_separator.py
     test_model_manager.py
@@ -137,7 +139,9 @@ Runtime library and models default to the per-user folder (e.g. `%LOCALAPPDATA%\
 
 ## Current Status
 
-Last updated: 2026-04-03
+Last updated: 2026-07-09
+
+Current version: **v2.4.1** — v2.4.0 shipped pitch shift / key transposition (#117); v2.4.1 is a stability pass on top of it.
 
 ### Phase 1 (MVP) -- Complete
 All core functionality implemented and tested:
@@ -149,7 +153,7 @@ All core functionality implemented and tested:
 
 ### Phase 2 (Polish) -- Complete
 - MP3 export (lameenc, 320kbps)
-- Keyboard shortcuts (Space, S, arrows, 1-6, A/B/L, [ / ], M, C; Help > Keyboard Shortcuts)
+- Keyboard shortcuts (Space, S, arrows, Ctrl+1-6, A/B/L, Shift+Up/Down speed, Shift+Left/Right pitch, M, C; Help > Keyboard Shortcuts)
 - Per-stem volume sliders
 - Window state persistence
 - Wiener filter + soft gate post-processing
@@ -190,8 +194,10 @@ All core functionality implemented and tested:
 
 ### Post-2.0 Backlog
 - [x] Tempo/key detection & beat-synced metronome (#42)
+- [x] Pitch shift / key transposition (#117, shipped v2.4.0)
 - [ ] Experimental DSP (#28)
 - [ ] Real-time streaming (#13)
+- [ ] GPU separation via DirectML re-export (#125)
 
 ### v2.1.0 Release -- Shipped
 - [x] Metronome beat-sync nudge (±500ms spinbox, all click sources)
@@ -210,9 +216,9 @@ All core functionality implemented and tested:
 ## Test Suite
 
 ```
-pytest                                    # ~625 fast tests (~25s)
-pytest -m slow                            # 5 ONNX inference tests (~20s, needs model)
-pytest -m hardware                        # 1 audible playback test (~30s, needs speakers)
+pytest                                    # ~825 fast tests (~25s)
+pytest -m slow                            # ONNX inference tests (needs model)
+pytest -m hardware                        # audible playback test (needs speakers)
 set STEMMA_TEST_SONG=path/to/song.mp3     # Required for slow/hardware tests
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-07-09 -- v2.4.1 Stability Pass
+
+A returning-from-dormancy audit (deep review of the whole project plus PR #124) turned up a batch of correctness bugs; this session fixes them and gets CI green again.
+
+### Player / audio callback
+- **Silent recording takes (critical):** `add_recording_stem` never invalidated the active-stems cache, so a freshly recorded take mixed at gain 0 — visible in the mixer but inaudible — until a mute/solo toggle. Now invalidated on add/remove.
+- **Callback vs. GUI-thread races:** recording-stem add/remove now replaces the stems dict copy-on-write (deleting a take mid-playback used to abort the stream with `dictionary changed size`); the callback snapshots the stems dict and loop frames once per block so `clear_loop` can't null a frame mid-read.
+- **`chord_at` speed mapping:** inverted the stretch factor — at 0.5x the chord badge read the chord from 4× the playhead time. Fixed and tested.
+- **Render desync (from #124 follow-up):** a render discarded by `cancel_stretch` (spinbox scrubbing) could leave the knobs claiming a speed/pitch the audio didn't have; the player now tracks the applied render state and re-renders when stale.
+
+### Recording lifecycle
+- Empty takes (stop during count-in) no longer save a full-length silent WAV that eats a take slot.
+- Speed/pitch changes are refused while recording (they rescaled the playhead under the live input stream).
+- The take limit and speed/pitch guards can no longer be bypassed via the `R` shortcut; opening a song already at the take limit disables recording.
+- Close Song and removing the loaded song now fully unload the player (`unload()`) instead of leaving it playing invisibly.
+
+### Export
+- Refuse a second export while one runs (double-start dropped the last reference to a live QThread and crashed Qt).
+- Loop-region export now maps stretched-timeline loop points back to original time, so it exports the right region at non-1.0x speed.
+- The count-in export option only appears when count-in is actually enabled.
+
+### Robustness
+- **Model downloads** stream to a `.partial` file, verify the byte count, and rename into place atomically, with a 30s socket timeout — a killed download can no longer masquerade as a cached (but truncated) model. Previously untested; now covered.
+- **Library** recovery preserves a corrupt index as `library.json.bak` and rebuilds from `songs/` on disk instead of destroying it; `_load` handles `OSError`/non-UTF-8; writes fsync before rename.
+- Detection/peak workers are drained on close (`PlayerControls.shutdown`), fixing a crash-on-exit when quitting during beat detection.
+- Re-detection (key/tempo) badges clear on failure instead of sticking on "detecting…".
+
+### CI / packaging
+- Tests run under Qt's offscreen platform; the splash-show test no longer crashes/hangs the hosted Windows runner. Root-caused the long-standing full-suite teardown flake (a test spawned a real render QThread the GC deleted mid-run; lazy GC destroyed old widget trees reentrantly inside Qt calls) — player fixtures join render threads at teardown and conftest collects garbage at module boundaries.
+- `actions/checkout@v5`, `actions/setup-python@v6` (Node 24).
+- Dropped unused `pydub`; split pytest deps into `requirements-dev.txt` (CI installs both).
+
+### Investigations
+- **DirectML GPU separation (#125):** verified on an RTX 4070 Ti that both HTDemucs ONNX exports fail DML kernel compilation and fall back to CPU, so shipping `onnxruntime-directml` would add ~200 MB for no separation speedup. Kept plain `onnxruntime`; filed #125 with diagnostics for a future model re-export. Docs corrected to stop claiming GPU-accelerated separation.
+
+### Metrics
+- 825 fast tests pass (834 collected, 9 slow/hardware deselected); clean full-suite runs on Python 3.14/PySide6 6.10.2 and a CI-parity venv (3.12/6.11.1). +~45 new tests.
+
+---
+
 ## 2026-04-18 -- v2.4.0 Pitch Shift / Transposition
 
 ### Done

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -23,7 +23,7 @@ A Windows desktop music player with AI stem separation. Import a song, separate 
 | **Platform** | Windows desktop only | No mobile/web for now |
 | **GPU** | NVIDIA RTX 4070 Ti | DirectML acceleration via ONNX Runtime |
 | **Stems** | 4-stem and 6-stem models | Both available per song |
-| **Distribution** | Single `.exe` via GitHub Releases | Models download on first run |
+| **Distribution** | Microsoft Store (primary); portable `stemma.zip` + `stemma.msix` on GitHub Releases | Models download on first run |
 | **Python** | 3.14 | All deps confirmed compatible (March 2026) |
 
 ---
@@ -40,7 +40,7 @@ A Windows desktop music player with AI stem separation. Import a song, separate 
 | **Audio Processing** | `numpy` | Efficient buffer manipulation |
 | **Export** | `soundfile` (WAV), `lameenc` (MP3) | Individual stems or custom mix |
 | **YouTube Import** | `yt-dlp` + `ffmpeg` | Download audio from YouTube URLs |
-| **Packaging** | PyInstaller | Single `.exe` (~150-250MB without models) |
+| **Packaging** | PyInstaller | One-folder (COLLECT) build shipped as `stemma.zip` + `stemma.msix` (~150-250MB without models) |
 | **Future** | `librosa` / other | Key transposition (pitch-shift); tempo stretch is implemented via librosa |
 
 ### Why HTDemucs v4?
@@ -66,7 +66,7 @@ A Windows desktop music player with AI stem separation. Import a song, separate 
 ```
 stemma/
 ├── main.py                    # App entry point
-├── stemma.spec                # PyInstaller one-file build spec
+├── stemma.spec                # PyInstaller one-folder (COLLECT) build spec
 ├── requirements.txt
 ├── requirements-dev.txt       # Dev/build deps (pyinstaller)
 ├── pyproject.toml             # pytest config
@@ -74,7 +74,7 @@ stemma/
 ├── LICENSE                    # MIT
 ├── .gitignore
 ├── .github/workflows/ci.yml      # CI: fast tests on every push
-├── .github/workflows/release.yml # Build .exe + GitHub Release on v* tags
+├── .github/workflows/release.yml # Build one-folder app -> stemma.zip + stemma.msix, GitHub Release on v* tags
 ├── src/
 │   ├── __init__.py
 │   ├── app.py                 # QApplication setup
@@ -82,9 +82,12 @@ stemma/
 │   ├── data_paths.py          # Per-user data directory resolution
 │   ├── import_messages.py     # User-facing text for import/download failures
 │   ├── metronome.py           # Tap tempo helper for metronome UI
+│   ├── click_utils.py         # Metronome click sample generation
 │   ├── paths.py               # app_root(): frozen-build-aware root dir
+│   ├── qt_signal_utils.py     # PySide6 helpers (safe signal disconnect)
 │   ├── version.py             # __version__ string
 │   ├── separator.py           # ONNX Runtime stem separation
+│   ├── beat_detector.py       # BPM/key/chord detection + beat_this ONNX beat tracking
 │   ├── model_manager.py       # Download/cache ONNX models on first run
 │   ├── player.py              # Multi-track audio player (sounddevice)
 │   ├── library.py             # Song library (JSON-based)
@@ -100,13 +103,21 @@ stemma/
 │       ├── library_panel.py   # Song list with remove
 │       ├── import_dialog.py   # Import songs + YouTube URL + model download
 │       ├── preferences_dialog.py  # Data dir, audio device, defaults
+│       ├── audio_sync.py      # Splash/logo audio-visual timing constants
+│       ├── animated_logo.py   # Animated main logo (notes + waves, click Easter egg)
+│       ├── animated_arpeggio.py # Animated footer arpeggio logo (letter glow, click Easter egg)
+│       ├── splash_screen.py   # Animated startup splash with arpeggio logo
+│       ├── wav_playback.py    # Logo SFX entry (lazy-loads Qt Multimedia impl)
+│       ├── _wav_playback_impl.py  # QSoundEffect + winsound fallback
 │       └── styles.py          # Dark / light themes
-├── tests/
+├── tests/                     # 32 test files (825 fast tests; not all listed here)
 │   ├── conftest.py            # Shared fixtures
 │   ├── test_separator.py      # 22 tests
+│   ├── test_beat_detector.py  # BPM/key/chord detection + beat tracking
 │   ├── test_model_manager.py  # 9 tests
 │   ├── test_player.py         # Player, A-B loop, metronome-related behaviour
 │   ├── test_library.py        # 22 tests
+│   ├── test_library_playback.py
 │   ├── test_downloader.py     # 26 tests
 │   ├── test_exporter.py       # 18 tests
 │   ├── test_post_processing.py # 17 tests
@@ -118,6 +129,8 @@ stemma/
 │   ├── test_app_settings.py
 │   ├── test_metronome.py
 │   ├── test_count_in.py
+│   ├── test_pitch_shift.py
+│   ├── test_pitch_shift_ui.py
 │   ├── test_theme.py
 │   └── test_integration.py    # includes slow + hardware markers
 └── data/                      # Created at runtime
@@ -143,6 +156,12 @@ stemma/
 - Handles STFT/iSTFT pre/post-processing in NumPy (stripped from ONNX model)
 - Runs in background `QThread`, emits progress signals
 - Supports both `htdemucs` (4-stem) and `htdemucs_6s` (6-stem)
+
+### `beat_detector.py` — Musical Analysis
+- BPM detection and beat/downbeat tracking via the `beat_this` ONNX model (chunked inference)
+- Key detection using Krumhansl-Schmuckler profiles
+- Chord detection (major/minor) with Viterbi smoothing
+- `transpose_key()` helper for shifting a detected key by semitones (used by pitch shift)
 
 ### `model_manager.py` — Model Download & Cache
 - Checks if ONNX model files exist under the app data directory (`models/`)
@@ -222,7 +241,7 @@ stemma/
 ### Phase 2 — Polish (complete)
 - [x] MP3 export support (lameenc, 320kbps)
 - [x] Separation progress bar (in import dialog)
-- [x] Keyboard shortcuts (Space=play/pause, S=stop, arrows=seek, 1-6=mute stems, A/B/L=loop)
+- [x] Keyboard shortcuts (Space=play/pause, S=stop, arrows=seek, Ctrl+1-6=mute stems, A/B/L=loop)
 - [x] Per-stem volume sliders (0-200%)
 - [x] Window state persistence (QSettings)
 - [x] Audio post-processing (Wiener filter + soft gating)
@@ -238,11 +257,12 @@ stemma/
 - [x] PyInstaller packaging + GitHub Release workflow (#56)
 
 ### Post-2.0 backlog (see GitHub issues)
-Shipped in 2.x: session persistence (#55), metronome (#57), count-in (#78), recording (#79), animated startup (#76), MSIX / Store (#74), UI redesign and export extras (#92, #97, #98, #99, #100), release tooling (tag-driven `version.py` + manifest sync, CI on tags), automatic BPM/key detection and beat-synced metronome (#42), time signature detection and real-time chord display (#118).
+Shipped in 2.x: session persistence (#55), metronome (#57), count-in (#78), recording (#79), animated startup (#76), MSIX / Store (#74), UI redesign and export extras (#92, #97, #98, #99, #100), release tooling (tag-driven `version.py` + manifest sync, CI on tags), automatic BPM/key detection and beat-synced metronome (#42), time signature detection and real-time chord display (#118), pitch shift / key transposition (#117, shipped v2.4.0).
 
 Open (all labeled `v3.0` on GitHub):
 - [ ] Experimental DSP extensions (#28)
 - [ ] Real-time streaming stem separation (#13)
+- [ ] GPU separation via DirectML re-export (#125)
 
 For the live checklist, prefer `AGENTS.md` and the GitHub issue list over this section if they disagree.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Import a song, separate it into stems (vocals, drums, bass, guitar, piano, other
 ## Features
 
 - AI-powered stem separation using HTDemucs v4 (4-stem and 6-stem models)
-- GPU-accelerated inference via ONNX Runtime + DirectML
+- ONNX Runtime inference; DirectML GPU acceleration is attempted per model with automatic CPU fallback (separation currently runs on CPU — see issue #125)
 - Multi-track player with per-stem mute/solo/volume controls
 - Audio post-processing: Wiener filter and soft gating for cleaner stems
 - Real-time chord detection (major/minor) with Viterbi smoothing, updated 4×/s during playback
@@ -31,11 +31,12 @@ Import a song, separate it into stems (vocals, drums, bass, guitar, piano, other
 - Export individual stems or custom mixes as WAV or MP3
 - Waveform visualization with click-to-seek, playback cursor, and loop markers
 - A-B loop for practice sections (Stop returns to loop A while looping; seek stays inside the loop); pitch-preserving playback speed presets
+- Pitch transposition (±7 semitones), rendered in a single pass with the speed change; the Key badge shows the transposed key
 - Metronome with BPM entry, tap tempo, and beat-sync nudge (±500ms)
 - Optional count-in beats before playback (and optionally before each loop repeat)
 - Session persistence: restore last song, position, mixer, loop, speed, metronome, count-in, and recording take state after restart
 - Library panel shows artist and title on separate lines with teal selection highlight
-- Keyboard shortcuts for transport, stems, loop, speed, metronome, and count-in; full list under **Help > Keyboard Shortcuts**
+- Keyboard shortcuts for transport, stems, loop, speed, pitch, metronome, count-in, and recording; full list under **Help > Keyboard Shortcuts**
 - Dark / light Qt themes; window geometry/state persistence; configurable data folder and audio device (Edit > Preferences)
 - 100% local processing -- no cloud, no subscriptions
 
@@ -58,7 +59,7 @@ python main.py
 ## Running Tests
 
 ```bash
-# Fast tests (~25 seconds, ~625 tests)
+# Fast tests (~25 seconds, ~825 tests)
 pytest
 
 # Include ONNX inference tests (~20 seconds, needs model file)
@@ -76,13 +77,19 @@ pytest -m hardware
 | Space | Play / Pause |
 | S | Stop |
 | Left / Right | Seek -/+ 5 seconds |
-| 1-6 | Toggle mute on stem |
-| A | Set loop start point |
-| B | Set loop end point |
+| Home / End | Jump to start / end |
+| 0-9 | Jump to 0%–90% position |
+| Up / Down | Master volume |
+| Shift+Up / Down | Speed up / down |
+| Shift+Left / Right | Transpose -/+ 1 semitone |
+| Ctrl+1-6 | Toggle mute on stem |
+| A / B | Set loop point A / B |
 | L | Toggle A-B loop |
-| [ / ] | Slower / faster playback speed |
 | M | Toggle metronome |
 | C | Toggle count-in |
+| R | Arm / disarm recording |
+| N / P | Next / previous song |
+| F1 | Keyboard shortcuts dialog |
 
 Use **Help > Keyboard Shortcuts** in the app for the authoritative list (same bindings as above).
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,4 @@
 pyinstaller>=6.0
+pytest>=8.0.0
+pytest-cov>=4.1.0
+pytest-timeout>=2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,16 @@
 PySide6>=6.6.0
+# CPU ONNX Runtime. The DirectML build was evaluated (see issue: GPU
+# separation via DirectML) but both HTDemucs ONNX exports fail DML
+# kernel compilation on real hardware and fall back to CPU anyway, so
+# the plain wheel is used to keep the installer ~200 MB smaller.
+# separator._create_session() still attempts DmlExecutionProvider first,
+# so a future DML-compatible model export would light up GPU with no
+# code change.
 onnxruntime>=1.24.4
 sounddevice>=0.4.6
 soundfile>=0.12.1
 numpy>=1.26.0
-pydub>=0.25.1
 lameenc>=1.7.0
 librosa>=0.10.1
 yt-dlp>=2024.1.0
 imageio-ffmpeg>=0.4.9
-
-# Development dependencies
-pytest>=8.0.0
-pytest-cov>=4.1.0
-pytest-timeout>=2.3.0

--- a/src/beat_detector.py
+++ b/src/beat_detector.py
@@ -606,7 +606,10 @@ def detect_bpm_and_key(
     return DetectionResult(
         bpm=bpm,
         bpm_confidence=_bpm_confidence(beat_times),
-        key=key_name if _key_confidence(key_corr) != "low" else key_name,
+        # Low-confidence keys are still surfaced; the UI dims the badge by
+        # confidence rather than hiding it. (Was a no-op ternary that
+        # returned key_name on both branches.)
+        key=key_name,
         key_confidence=_key_confidence(key_corr),
         beat_times=beat_times,
         downbeat_times=downbeat_times,

--- a/src/downloader.py
+++ b/src/downloader.py
@@ -18,8 +18,13 @@ class DownloadError(Exception):
 
 
 _YOUTUBE_PATTERN = re.compile(
-    r"^(https?://)?(www\.)?"
-    r"(youtube\.com/watch\?v=|youtu\.be/|music\.youtube\.com/watch\?v=)"
+    r"^(https?://)?"
+    # Optional youtube subdomains (www/m/music), in any combination, so
+    # m.youtube.com and www.music.youtube.com both parse. The chain is
+    # restricted to these labels so lookalikes (fakeyoutube.com) are
+    # still rejected.
+    r"(?:(?:www|m|music)\.)*"
+    r"(youtube\.com/(watch\?v=|shorts/|live/|embed/)|youtu\.be/)"
 )
 
 

--- a/src/library.py
+++ b/src/library.py
@@ -170,21 +170,68 @@ class SongLibrary:
     def _load(self) -> None:
         """Read the JSON index from disk.
 
-        If the file is corrupted or contains malformed entries, starts
-        with an empty library rather than crashing.
+        If the file is corrupted, malformed, unreadable, or not valid
+        UTF-8, the bad index is preserved as ``library.json.bak`` and the
+        library is rebuilt by scanning ``songs/`` so imported stems that
+        still exist on disk are recovered instead of silently orphaned.
         """
         try:
             with open(self._json_path, encoding="utf-8") as f:
                 data = json.load(f)
             self._songs = [Song.from_dict(entry) for entry in data]
-        except (json.JSONDecodeError, TypeError, KeyError):
-            # Corrupted or malformed — start fresh and overwrite.
-            self._songs = []
+        except (
+            json.JSONDecodeError, TypeError, KeyError,
+            OSError, UnicodeDecodeError, ValueError,
+        ):
+            # Preserve the corrupt index for post-mortem instead of
+            # destroying it, then recover what we can from disk.
+            try:
+                os.replace(self._json_path, self._json_path + ".bak")
+            except OSError:
+                pass
+            self._songs = self._rebuild_from_disk()
             self._save()
+
+    def _rebuild_from_disk(self) -> list["Song"]:
+        """Reconstruct library entries by scanning the songs directory.
+
+        Used when the JSON index is lost or corrupt. Each ``songs/<id>/``
+        that contains an ``original.*`` file becomes a minimally-populated
+        Song; titles fall back to the id and metadata that only lived in
+        the index (artist, model) is left blank.
+        """
+        recovered: list[Song] = []
+        try:
+            entries = sorted(os.listdir(self._songs_dir))
+        except OSError:
+            return recovered
+        for song_id in entries:
+            song_dir = os.path.join(self._songs_dir, song_id)
+            if not os.path.isdir(song_dir):
+                continue
+            original = None
+            for fname in os.listdir(song_dir):
+                if fname.startswith("original."):
+                    original = os.path.join(song_dir, fname)
+                    break
+            if original is None:
+                continue
+            recovered.append(Song(
+                id=song_id,
+                title=song_id,
+                artist="",
+                original_path=original,
+                stems_path=song_dir,
+                model_used="",
+                date_added=datetime.now(timezone.utc).isoformat(),
+            ))
+        return recovered
 
     def _save(self) -> None:
         """Write the current song list to the JSON index atomically."""
         tmp_path = self._json_path + ".tmp"
         with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump([s.to_dict() for s in self._songs], f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
         os.replace(tmp_path, self._json_path)

--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -16,6 +16,16 @@ import urllib.request
 
 from PySide6.QtCore import QObject, QThread, Signal
 
+# Connection/read timeout for model downloads, in seconds. A stalled TCP
+# connection would otherwise hang the download thread forever -- the
+# cancel flag is only checked between chunks, so a dead socket that
+# never delivers another chunk can't be interrupted without a timeout.
+_DOWNLOAD_TIMEOUT_S = 30
+
+# Streaming read size. 64 KiB balances progress-update granularity
+# against per-chunk Python overhead on ~180 MB model files.
+_CHUNK_SIZE = 1 << 16
+
 
 # HuggingFace repository hosting the pre-converted ONNX models.
 _REPO_URL = "https://huggingface.co/rysertio/Demucs-onnx/resolve/main"
@@ -63,6 +73,7 @@ class ModelDownloader(QThread):
         self._is_cancelled = False
         self._url = url
         self._file_name = file_name
+        self._current_partial_path: str | None = None
 
     def cancel(self) -> None:
         """Request cancellation of the active download."""
@@ -73,10 +84,63 @@ class ModelDownloader(QThread):
         try:
             self._download()
         except Exception as exc:
-            dest = getattr(self, "_current_dest_path", None)
-            if dest and os.path.exists(dest):
-                os.remove(dest)
+            # Clean up the in-progress ``.partial`` file so a later run
+            # doesn't resume from a corrupt prefix. Guard the removal:
+            # if it fails (AV lock, permissions) we still want to surface
+            # the original error rather than mask it with a second one.
+            partial = getattr(self, "_current_partial_path", None)
+            if partial and os.path.exists(partial):
+                try:
+                    os.remove(partial)
+                except OSError:
+                    pass
             self.error.emit(str(exc))
+
+    def _download_file(self, url: str, dest: str, on_progress) -> None:
+        """Download *url* to *dest* atomically.
+
+        Streams the body into ``dest + '.partial'`` and renames it into
+        place only after the whole response arrives and (when the server
+        advertises a length) the byte count matches. A partial or stalled
+        download therefore never leaves a file at the final path, so
+        ``is_model_downloaded`` cannot mistake an interrupted transfer
+        for a complete, usable model.
+
+        *on_progress* is called as ``on_progress(downloaded, total)`` with
+        byte counts (``total`` is 0 when the server sends no
+        Content-Length).
+        """
+        partial = dest + ".partial"
+        self._current_partial_path = partial
+        # Drop any stale partial from a previously aborted attempt.
+        if os.path.exists(partial):
+            os.remove(partial)
+
+        req = urllib.request.Request(url, headers={"User-Agent": "stemma"})
+        with urllib.request.urlopen(
+            req, timeout=_DOWNLOAD_TIMEOUT_S,
+        ) as resp:
+            total = int(resp.headers.get("Content-Length", 0) or 0)
+            downloaded = 0
+            with open(partial, "wb") as fh:
+                while True:
+                    if self._is_cancelled:
+                        raise InterruptedError("Download cancelled by user.")
+                    chunk = resp.read(_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    fh.write(chunk)
+                    downloaded += len(chunk)
+                    on_progress(downloaded, total)
+
+        if total > 0 and downloaded != total:
+            raise OSError(
+                f"Incomplete download: received {downloaded} of {total} "
+                f"bytes for {os.path.basename(dest)}."
+            )
+
+        os.replace(partial, dest)
+        self._current_partial_path = None
 
     def _download(self) -> None:
         """Core download logic."""
@@ -89,18 +153,16 @@ class ModelDownloader(QThread):
                 self.progress.emit(100, f"{self._file_name} already cached.")
                 self.download_complete.emit(dest)
                 return
-            self._current_dest_path = dest
             self.progress.emit(0, f"Downloading {self._file_name}...")
 
-            def _hook(block: int, block_size: int, total: int) -> None:
-                if self._is_cancelled:
-                    raise InterruptedError("Download cancelled by user.")
+            def _on_progress(downloaded: int, total: int) -> None:
                 if total > 0:
-                    pct = min(99, int(block * block_size * 100.0 / total))
-                    self.progress.emit(pct, f"Downloading {self._file_name}... {pct}%")
+                    pct = min(99, int(downloaded * 100 / total))
+                    self.progress.emit(
+                        pct, f"Downloading {self._file_name}... {pct}%",
+                    )
 
-            urllib.request.urlretrieve(self._url, dest, reporthook=_hook)
-            self._current_dest_path = None
+            self._download_file(self._url, dest, _on_progress)
             self.progress.emit(100, "Download complete.")
             self.download_complete.emit(dest)
             return
@@ -119,46 +181,27 @@ class ModelDownloader(QThread):
                 continue
 
             url = f"{_REPO_URL}/{file_name}"
-            self._current_dest_path = dest_path
             self.progress.emit(
                 int(i / n * 100),
                 f"Downloading {file_name}...",
             )
 
-            def _make_hook(
-                idx: int,
-                name: str,
-            ):
-                def _report_hook(
-                    block_num: int, block_size: int, total_size: int
-                ) -> None:
-                    if self._is_cancelled:
-                        raise InterruptedError("Download cancelled by user.")
-                    if total_size > 0:
-                        file_pct = min(
-                            100.0,
-                            (block_num * block_size * 100.0) / total_size,
-                        )
-                        overall = int(((idx + file_pct / 100.0) / n) * 100)
-                        overall = min(99, overall)
-                        self.progress.emit(
-                            overall,
-                            f"Downloading {name}... {int(file_pct)}%",
-                        )
-                    else:
-                        self.progress.emit(
-                            int(idx / n * 100),
-                            f"Downloading {name}...",
-                        )
+            def _on_progress(
+                downloaded: int, total: int, idx: int = i, name: str = file_name,
+            ) -> None:
+                if total > 0:
+                    file_pct = min(100.0, downloaded * 100.0 / total)
+                    overall = min(99, int(((idx + file_pct / 100.0) / n) * 100))
+                    self.progress.emit(
+                        overall, f"Downloading {name}... {int(file_pct)}%",
+                    )
+                else:
+                    self.progress.emit(
+                        int(idx / n * 100), f"Downloading {name}...",
+                    )
 
-                return _report_hook
+            self._download_file(url, dest_path, _on_progress)
 
-            urllib.request.urlretrieve(
-                url, dest_path, reporthook=_make_hook(i, file_name)
-            )
-            self._current_dest_path = None
-
-        self._current_dest_path = None
         self.progress.emit(100, "Download complete.")
         self.download_complete.emit(primary_path)
 

--- a/src/player.py
+++ b/src/player.py
@@ -428,6 +428,10 @@ class MultiTrackPlayer(QObject):
         self._recording: bool = False
         self._recording_buffer: np.ndarray | None = None
         self._indata_capture: np.ndarray | None = None
+        # Input frames actually written to the buffer this take. Guards
+        # against saving a full-length silent WAV when playback is
+        # stopped before any input was captured (e.g. during count-in).
+        self._recording_frames_captured: int = 0
         self._input_device: int | None = None
         self._latency_offset_frames: int = 0
         self._recording_song_dir: str | None = None
@@ -760,6 +764,7 @@ class MultiTrackPlayer(QObject):
         self._recording_buffer = np.zeros(
             (self._total_frames, 2), dtype=np.float32
         )
+        self._recording_frames_captured = 0
 
     def set_recording_song_dir(self, song_dir: str | None) -> None:
         """Set the directory where recording takes are saved."""
@@ -768,10 +773,17 @@ class MultiTrackPlayer(QObject):
     def save_recording(self, song_dir: str) -> str | None:
         """Write the recording buffer to a WAV file in *song_dir*.
 
-        Returns the path to the saved file, or None if there is no recording.
+        Returns the path to the saved file, or None if there is no recording
+        or no input was ever captured (playback stopped during count-in, or
+        play was pressed and stopped without the input stream delivering
+        anything) -- saving would produce a full-length silent take that
+        eats one of the take slots.
         The take number auto-increments based on existing files.
         """
         if self._recording_buffer is None:
+            return None
+        if self._recording_frames_captured == 0:
+            self._recording_buffer = None
             return None
 
         buf = self._recording_buffer
@@ -883,11 +895,10 @@ class MultiTrackPlayer(QObject):
         )
         self._current_frame = min(self._current_frame, self._total_frames)
 
-    def load_stems(self, stem_paths: dict[str, str]) -> None:
-        """Load all stem WAV files into memory.
+    def _reset_song_state(self) -> None:
+        """Stop playback and clear all per-song state.
 
-        Args:
-            stem_paths: Dictionary mapping stem names to file paths.
+        Shared prologue of ``load_stems`` and ``unload``.
         """
         self.stop()
         self._pending_render_emit = None
@@ -916,6 +927,27 @@ class MultiTrackPlayer(QObject):
         self._recording = False
         self._recording_buffer = None
         self._nudge_offsets.clear()
+
+    def unload(self) -> None:
+        """Unload the current song entirely.
+
+        Close Song (and removing the currently loaded song) must leave
+        the player truly empty: previously only the UI was cleared, so
+        ``has_stems`` stayed True and global shortcuts (Space, R, loop
+        keys) kept operating on the invisible, closed song.
+        """
+        self._reset_song_state()
+        self._total_frames = 0
+        self._current_frame = 0
+        self.position_changed.emit(0.0)
+
+    def load_stems(self, stem_paths: dict[str, str]) -> None:
+        """Load all stem WAV files into memory.
+
+        Args:
+            stem_paths: Dictionary mapping stem names to file paths.
+        """
+        self._reset_song_state()
 
         max_frames = 0
         sample_rate = 0
@@ -1263,7 +1295,14 @@ class MultiTrackPlayer(QObject):
         Clamps *speed* to [0.5, 2.0]. Stretching runs in a background
         thread; the ``speed_changed`` signal fires when the stretched
         audio is ready.
+
+        Refused while a recording is in progress: the render swap
+        rescales the playhead against the new stem length while the
+        duplex stream keeps writing input at the old positions, which
+        scrambles the take.
         """
+        if self._recording:
+            return
         speed = max(0.5, min(speed, 2.0))
         if speed == self._playback_speed and self._stems_render_current():
             return
@@ -1276,7 +1315,12 @@ class MultiTrackPlayer(QObject):
         Clamps to [PITCH_MIN_SEMITONES, PITCH_MAX_SEMITONES]. Rendering
         runs in a background thread; ``pitch_changed`` fires when the
         transposed audio is ready (or immediately, on the fast path).
+
+        Refused while a recording is in progress, for the same reason
+        as ``set_speed``.
         """
+        if self._recording:
+            return
         try:
             semitones = int(semitones)
         except (TypeError, ValueError):
@@ -1870,6 +1914,7 @@ class MultiTrackPlayer(QObject):
                         self._recording_buffer[
                             start:start + actual
                         ] = chunk[:actual, :2]
+                        self._recording_frames_captured += actual
 
                 # Mix synced metronome for this segment before advancing.
                 if (self._metronome_enabled and self._beat_sync_enabled

--- a/src/player.py
+++ b/src/player.py
@@ -361,7 +361,7 @@ class MultiTrackPlayer(QObject):
         self._volumes: dict[str, float] = {}  # Per-stem gain, 0.0–2.0
         self._master_volume: float = 1.0     # Master gain, 0.0–2.0
         self._applied_gains: dict[str, float] = {}  # Last gain per stem (for ramping)
-        self._active_stems_cache: list[str] | None = None
+        self._active_stems_cache: set[str] | None = None
 
         # A-B loop state.
         self._loop_a_frame: int | None = None
@@ -793,21 +793,41 @@ class MultiTrackPlayer(QObject):
         """Add a recording take as a playable stem.
 
         Validates sample rate compatibility and forces stereo.
+
+        The stems dict is replaced, not mutated: the audio callback may
+        be iterating the old dict on the PortAudio thread. The active-
+        stems cache is invalidated so the new take is audible on the
+        next play without requiring a mute/solo toggle.
         """
         if data.shape[1] == 1:
             data = np.repeat(data, 2, axis=1)
-        self._stems[name] = data
-        self._original_stems[name] = data
+        stems = dict(self._stems)
+        stems[name] = data
+        self._stems = stems
+        originals = dict(self._original_stems)
+        originals[name] = data
+        self._original_stems = originals
         self._total_frames = max(self._total_frames, data.shape[0])
+        self._active_stems_cache = None
 
     def remove_recording_stem(self, name: str) -> None:
-        """Remove a recording stem and recalculate total frames."""
-        self._stems.pop(name, None)
-        self._original_stems.pop(name, None)
+        """Remove a recording stem and recalculate total frames.
+
+        Same copy-on-write discipline as ``add_recording_stem``: the
+        audio callback may be mid-iteration over the current dict, so
+        it is replaced rather than popped in place.
+        """
+        stems = dict(self._stems)
+        stems.pop(name, None)
+        self._stems = stems
+        originals = dict(self._original_stems)
+        originals.pop(name, None)
+        self._original_stems = originals
         self._muted_stems.discard(name)
         self._soloed_stems.discard(name)
         self._volumes.pop(name, None)
         self._nudge_offsets.pop(name, None)
+        self._active_stems_cache = None
         self._recalculate_total_frames()
 
     def nudge_stem(self, name: str, offset_ms: float) -> None:
@@ -1742,14 +1762,23 @@ class MultiTrackPlayer(QObject):
 
         # -- Normal playback -------------------------------------------------
 
+        # Snapshot cross-thread state once per callback. The GUI thread
+        # replaces the stems dict (copy-on-write) and can null the loop
+        # frames at any moment (clear_loop); reading them repeatedly
+        # mid-callback risks a None arithmetic TypeError that aborts the
+        # stream.
+        stems = self._stems
+        loop_a = self._loop_a_frame
+        loop_b = self._loop_b_frame
+
         # If at or past end and not looping, stop playback.
         looping = (self._looping
-                   and self._loop_a_frame is not None
-                   and self._loop_b_frame is not None
-                   and self._loop_b_frame > self._loop_a_frame)
+                   and loop_a is not None
+                   and loop_b is not None
+                   and loop_b > loop_a)
         if self._current_frame >= self._total_frames:
             if looping:
-                self._current_frame = self._loop_a_frame
+                self._current_frame = loop_a
             else:
                 outdata.fill(0.0)
                 raise sd.CallbackStop
@@ -1758,18 +1787,20 @@ class MultiTrackPlayer(QObject):
         outdata.fill(0.0)
 
         # Determine which stems should be audible (cached between changes).
+        # Stored as a set so the per-segment membership tests below don't
+        # allocate.
         active_stems = self._active_stems_cache
         if active_stems is None:
             if self._soloed_stems:
-                active_stems = [
-                    name for name in self._stems
+                active_stems = {
+                    name for name in stems
                     if name in self._soloed_stems
-                ]
+                }
             else:
-                active_stems = [
-                    name for name in self._stems
+                active_stems = {
+                    name for name in stems
                     if name not in self._muted_stems
-                ]
+                }
             self._active_stems_cache = active_stems
 
         # Fill the output buffer, handling loop wraps as needed.
@@ -1778,7 +1809,7 @@ class MultiTrackPlayer(QObject):
 
         while remaining > 0:
             if looping:
-                boundary = self._loop_b_frame
+                boundary = loop_b
             else:
                 boundary = self._total_frames
 
@@ -1789,10 +1820,9 @@ class MultiTrackPlayer(QObject):
                 start = self._current_frame
                 end = start + frames_to_read
 
-                active_set = set(active_stems)
-                for name, stem_data in self._stems.items():
+                for name, stem_data in stems.items():
                     target = (self._volumes.get(name, 1.0) * self._master_volume
-                              if name in active_set else 0.0)
+                              if name in active_stems else 0.0)
                     prev = self._applied_gains.get(name, target)
                     if target == 0.0 and prev == 0.0:
                         continue
@@ -1854,7 +1884,7 @@ class MultiTrackPlayer(QObject):
             # Check if we hit the boundary.
             if self._current_frame >= boundary:
                 if looping:
-                    self._current_frame = self._loop_a_frame
+                    self._current_frame = loop_a
                     if (self._count_in_enabled
                             and self._count_in_on_repeats):
                         self._arm_count_in()

--- a/src/player.py
+++ b/src/player.py
@@ -592,9 +592,10 @@ class MultiTrackPlayer(QObject):
             return ""
         speed = self._playback_speed if self._playback_speed > 0 else 1.0
         # Frame is in the stretched timeline; chord onsets are in original
-        # audio time.  Divide by speed to map back (same convention as
-        # _recompute_beat_frames).
-        time_sec = frame / self._sample_rate / speed
+        # audio time. _recompute_beat_frames maps original time t to
+        # stretched frame t / speed * sr, so the inverse is
+        # frame / sr * speed.
+        time_sec = frame / self._sample_rate * speed
         idx = int(np.searchsorted(self._chord_times, time_sec, side="right")) - 1
         if idx < 0:
             return ""

--- a/src/ui/import_dialog.py
+++ b/src/ui/import_dialog.py
@@ -494,7 +494,9 @@ class ImportDialog(QDialog):
             is_6_stem=is_6_stem,
         )
         self._worker.progress.connect(self._on_progress)
-        self._worker.finished.connect(lambda _: self._on_finished(song.id))
+        self._worker.finished.connect(
+            lambda _: self._on_finished(song.id, is_6_stem)
+        )
         self._worker.error.connect(self._on_error)
         self._worker.start()
 
@@ -532,11 +534,14 @@ class ImportDialog(QDialog):
         self._progress_bar.setValue(percent)
         self._status_label.setText(message)
 
-    def _on_finished(self, song_id: str) -> None:
+    def _on_finished(self, song_id: str, is_6_stem: bool) -> None:
         self._import_song_id = None
-        model_used = (
-            "htdemucs_6s" if self._pending_separation_is_6_stem else "htdemucs"
-        )
+        # Use the actual model that ran this separation, threaded through
+        # from _start_separation_worker. Reading
+        # _pending_separation_is_6_stem here was wrong: it is only set on
+        # the download path, so a cached-model import recorded whatever
+        # the previous download left behind.
+        model_used = "htdemucs_6s" if is_6_stem else "htdemucs"
         self._library.update_song(song_id, model_used=model_used)
         self.accept()
 

--- a/src/ui/library_panel.py
+++ b/src/ui/library_panel.py
@@ -362,6 +362,7 @@ class LibraryPanel(QWidget):
     """
 
     song_selected = Signal(str)
+    song_removed = Signal(str)  # emitted with the removed song's id
     repeat_mode_changed = Signal(str)
     shuffle_toggled = Signal(bool)
     previous_requested = Signal()
@@ -674,3 +675,9 @@ class LibraryPanel(QWidget):
                 if reply == QMessageBox.StandardButton.Yes:
                     self._library.remove_song(song_id)
                     self.refresh()
+                    # Let the main window unload the player if the
+                    # removed song is the one currently loaded --
+                    # otherwise it keeps playing from RAM and stopping
+                    # would try to save recordings into the deleted
+                    # directory.
+                    self.song_removed.emit(song_id)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -949,6 +949,10 @@ class MainWindow(QMainWindow):
         # (librosa pitch/time-stretch is uninterruptible mid-call, so
         # the pool threads can't exit until the current stem finishes).
         self._player.shutdown()
+        # Drain detection/peak QThreads owned by the controls too, so
+        # closing during a fresh song's beat detection doesn't crash on
+        # exit with a still-running QThread.
+        self._player_controls.shutdown()
         shutdown_peak_pool()
 
         super().closeEvent(event)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -956,6 +956,7 @@ class MainWindow(QMainWindow):
     def _connect_signals(self) -> None:
         """Wire up signals between panels."""
         self._library_panel.song_selected.connect(self._on_song_selected)
+        self._library_panel.song_removed.connect(self._on_song_removed)
         self._library_panel.previous_requested.connect(
             lambda: self._advance_song(-1)
         )
@@ -1124,6 +1125,11 @@ class MainWindow(QMainWindow):
             except ValueError:
                 display = stem_name
             self._add_recording_stem(stem_name, take_path, display)
+
+        # A song opened with the maximum number of takes must start with
+        # the record button disabled (previously only recording/deleting
+        # within the session refreshed this).
+        self._update_record_button_for_take_limit()
 
         # Restore saved state for recording stems.
         try:
@@ -1301,12 +1307,18 @@ class MainWindow(QMainWindow):
         self._update_record_button_for_take_limit()
 
     def _on_close_song(self) -> None:
-        """Stop playback and return to the empty logo state."""
-        self._player.stop()
+        """Unload the song and return to the empty logo state."""
+        self._player.unload()
         self._player.set_recording_song_dir(None)
         self._player_controls.clear_song()
+        self._library_panel.set_playing_song(None)
         self._current_song_id = None
         self.setWindowTitle("stemma")
+
+    def _on_song_removed(self, song_id: str) -> None:
+        """Unload the player if the removed song is the one loaded."""
+        if song_id == self._current_song_id:
+            self._on_close_song()
 
     def _on_import(self) -> None:
         """Open the import dialog."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1385,6 +1385,18 @@ class MainWindow(QMainWindow):
             )
             return
 
+        # Refuse a second export while one is running: ExportWorker is
+        # parentless, so reassigning self._export_worker would drop the
+        # last reference to the live QThread and crash Qt with
+        # "QThread: Destroyed while thread is still running".
+        if self._export_worker is not None and self._export_worker.isRunning():
+            QMessageBox.information(
+                self, "Export",
+                "An export is already in progress. Please wait for it "
+                "to finish.",
+            )
+            return
+
         song = self._library.get_song(self._current_song_id) if self._current_song_id else None
         if song is None:
             return
@@ -1407,7 +1419,10 @@ class MainWindow(QMainWindow):
         loop_a = self._player.loop_a
         loop_b = self._player.loop_b
         has_loop = loop_a is not None and loop_b is not None and loop_b > loop_a
-        has_bpm = self._player.metronome_bpm > 0
+        # Only offer the count-in export option when count-in is actually
+        # enabled -- metronome_bpm is always > 0 (clamped 20-300), so the
+        # old check surfaced the dialog on every single export.
+        has_bpm = self._player.count_in_enabled
 
         start_frame: int | None = None
         end_frame: int | None = None
@@ -1423,8 +1438,13 @@ class MainWindow(QMainWindow):
                 return
             if opts.get("loop_region") and has_loop:
                 sr = self._player.sample_rate
-                start_frame = int(loop_a * sr)
-                end_frame = int(loop_b * sr)
+                # loop_a/loop_b are in the *stretched* timeline (the loop
+                # frames are rescaled by _apply_stretched_stems), but the
+                # exporter reads the original on-disk WAVs. Map back to
+                # original time: original_t = stretched_t * speed.
+                speed = self._player.speed
+                start_frame = int(loop_a * speed * sr)
+                end_frame = int(loop_b * speed * sr)
             if opts.get("count_in"):
                 count_in_beats = self._player.count_in_beats
 

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -686,6 +686,23 @@ class PlayerControls(QWidget):
             self._detection_worker.wait(2000)
             self._detection_worker = None
 
+    def shutdown(self) -> None:
+        """Drain all background workers before the app tears down.
+
+        Called from MainWindow.closeEvent. Detection runs on every song
+        load and takes seconds (ONNX beat tracking over the full mix);
+        closing the app shortly after selecting a song used to leave a
+        running parentless QThread to be reaped at interpreter exit,
+        crashing with 'QThread: Destroyed while thread is still running'.
+        """
+        self._pitch_debounce.stop()
+        self._speed_debounce.stop()
+        self._cleanup_peak_thread()
+        # Join any orphaned detection workers still finishing up.
+        for worker in list(self._orphaned_workers):
+            worker.wait(2000)
+        self._orphaned_workers.clear()
+
     def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 8, 12, 8)
@@ -2033,9 +2050,16 @@ class PlayerControls(QWidget):
             model_path=self._beat_model_path,
         )
         worker.completed.connect(self._on_key_only_completed)
+        worker.error.connect(self._on_key_only_error)
         worker.finished.connect(self._on_detect_finished)
         self._detection_worker = worker
         worker.start()
+
+    def _on_key_only_error(self, msg: str) -> None:
+        """Clear the key badge if re-detection fails (was stuck on
+        'detecting...' because no error handler was connected)."""
+        self._key_label.setText("")
+        self._key_label.setStyleSheet("")
 
     def _on_key_only_completed(self, result: DetectionResult) -> None:
         """Update only the key label from a re-detection."""
@@ -2068,9 +2092,16 @@ class PlayerControls(QWidget):
             model_path=self._beat_model_path,
         )
         worker.completed.connect(self._on_bpm_only_completed)
+        worker.error.connect(self._on_bpm_only_error)
         worker.finished.connect(self._on_detect_finished)
         self._detection_worker = worker
         worker.start()
+
+    def _on_bpm_only_error(self, msg: str) -> None:
+        """Clear the tempo badge if re-detection fails (was stuck on
+        'detecting...' because no error handler was connected)."""
+        self._detected_bpm_label.setText("")
+        self._detected_bpm_label.setStyleSheet("")
 
     def _on_bpm_only_completed(self, result: DetectionResult) -> None:
         """Update only the BPM label from a re-detection."""

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -2324,7 +2324,14 @@ class PlayerControls(QWidget):
             self._record_btn.blockSignals(False)
 
     def toggle_record(self) -> None:
-        """Toggle recording arm (for keyboard shortcut)."""
+        """Toggle recording arm (for keyboard shortcut).
+
+        setChecked works even on a disabled button, so the shortcut
+        must respect the disabled state itself -- otherwise R bypasses
+        the take-limit and speed/pitch guards that disable the button.
+        """
+        if not self._record_btn.isEnabled():
+            return
         self._record_btn.setChecked(not self._record_btn.isChecked())
 
     def add_recording_row(

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -30,6 +30,20 @@ class TestURLValidation:
     def test_youtube_no_scheme(self):
         assert is_supported_url("youtube.com/watch?v=dQw4w9WgXcQ")
 
+    def test_youtube_shorts_url(self):
+        assert is_supported_url("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+
+    def test_youtube_mobile_url(self):
+        assert is_supported_url("https://m.youtube.com/watch?v=dQw4w9WgXcQ")
+
+    def test_youtube_live_url(self):
+        assert is_supported_url("https://www.youtube.com/live/dQw4w9WgXcQ")
+
+    def test_youtube_www_music_url(self):
+        assert is_supported_url(
+            "https://www.music.youtube.com/watch?v=dQw4w9WgXcQ"
+        )
+
     def test_empty_string(self):
         assert not is_supported_url("")
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -141,6 +141,50 @@ class TestSongLibraryInit:
         lib = SongLibrary(data_dir=library_dir)
         assert len(lib.songs) == 0
 
+    def test_corrupt_index_is_preserved_as_bak(self, library_dir):
+        """A corrupt index must be kept for post-mortem, not destroyed."""
+        os.makedirs(library_dir, exist_ok=True)
+        json_path = os.path.join(library_dir, "library.json")
+        with open(json_path, "w") as f:
+            f.write("{not valid json")
+
+        SongLibrary(data_dir=library_dir)
+        bak = json_path + ".bak"
+        assert os.path.isfile(bak)
+        assert open(bak).read() == "{not valid json"
+
+    def test_rebuilds_from_disk_when_index_corrupt(self, library_dir):
+        """Songs whose dirs still hold an original.* file are recovered
+        even when the index is unreadable."""
+        songs_dir = os.path.join(library_dir, "songs")
+        os.makedirs(os.path.join(songs_dir, "abc123"), exist_ok=True)
+        with open(
+            os.path.join(songs_dir, "abc123", "original.mp3"), "wb"
+        ) as f:
+            f.write(b"audio")
+        # A dir with no original.* is skipped.
+        os.makedirs(os.path.join(songs_dir, "empty"), exist_ok=True)
+
+        json_path = os.path.join(library_dir, "library.json")
+        with open(json_path, "w") as f:
+            f.write("garbage")
+
+        lib = SongLibrary(data_dir=library_dir)
+        ids = {s.id for s in lib.songs}
+        assert ids == {"abc123"}
+        assert lib.songs[0].original_path.endswith("original.mp3")
+
+    def test_recovers_from_non_utf8_index(self, library_dir):
+        """A non-UTF-8 index (disk corruption) must not crash startup."""
+        os.makedirs(library_dir, exist_ok=True)
+        json_path = os.path.join(library_dir, "library.json")
+        with open(json_path, "wb") as f:
+            f.write(b"\xff\xfe\x00garbage")
+
+        lib = SongLibrary(data_dir=library_dir)
+        assert lib.songs == []
+        assert os.path.isfile(json_path + ".bak")
+
 
 class TestSongLibraryCRUD:
 

--- a/tests/test_library_playback.py
+++ b/tests/test_library_playback.py
@@ -454,3 +454,48 @@ class TestShortcutFocusGuard:
             "src.ui.main_window.QApplication.focusWidget", return_value=w
         ):
             assert MainWindow._text_input_has_focus(stub) is True
+
+
+class TestExportDoubleStartGuard:
+    """A second export while one is running must be refused, not crash.
+
+    ExportWorker is parentless; reassigning self._export_worker would
+    drop the last reference to the live QThread and crash Qt.
+    """
+
+    def test_running_export_blocks_second(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        stub._player.has_stems = True
+        stub._export_worker.isRunning.return_value = True
+
+        with patch(
+            "src.ui.main_window.QMessageBox.information"
+        ) as info, patch(
+            "src.ui.main_window.ExportWorker"
+        ) as worker_cls:
+            MainWindow._on_export(stub)
+
+        info.assert_called_once()
+        worker_cls.assert_not_called()
+
+    def test_no_running_export_proceeds_past_guard(self, app):
+        """With no worker running the guard is not the thing that stops
+        us -- has_stems True + a real song lookup would continue; here
+        we only assert the guard message is not shown."""
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        stub._player.has_stems = True
+        stub._export_worker = None
+        stub._current_song_id = None  # get_song(None) -> stop later, no crash
+
+        with patch(
+            "src.ui.main_window.QMessageBox.information"
+        ) as info:
+            MainWindow._on_export(stub)
+
+        # The "already in progress" message must not have fired.
+        for call in info.call_args_list:
+            assert "already in progress" not in str(call)

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,10 +1,30 @@
 """Tests for the model download and cache manager."""
 
+import io
 import os
+from unittest.mock import patch
 
 import pytest
 
 from src.model_manager import ModelDownloader, ModelManager, _MODEL_FILES
+
+
+class _FakeResponse:
+    """Minimal stand-in for the urlopen context manager."""
+
+    def __init__(self, body: bytes, content_length: int | None = None):
+        self._buf = io.BytesIO(body)
+        length = len(body) if content_length is None else content_length
+        self.headers = {"Content-Length": str(length)} if length is not None else {}
+
+    def read(self, size: int = -1) -> bytes:
+        return self._buf.read(size)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
 
 
 class TestModelManager:
@@ -96,3 +116,110 @@ class TestModelFiles:
     def test_6_stem_artifacts(self):
         assert _MODEL_FILES["htdemucs_6s"][0] == "htdemucs_6s.onnx"
         assert _MODEL_FILES["htdemucs_6s"][1] == "htdemucs_6s.onnx.data"
+
+
+class TestDownloadFile:
+    """Exercise the atomic streaming download (previously untested)."""
+
+    def test_downloads_to_final_path_via_partial(self, tmp_dir):
+        dl = ModelDownloader("beat_this", tmp_dir,
+                             url="http://x/m.onnx", file_name="m.onnx")
+        os.makedirs(tmp_dir, exist_ok=True)
+        dest = os.path.join(tmp_dir, "m.onnx")
+        body = b"onnx-bytes" * 5000
+
+        with patch("src.model_manager.urllib.request.urlopen",
+                   return_value=_FakeResponse(body)):
+            dl._download_file("http://x/m.onnx", dest, lambda d, t: None)
+
+        assert os.path.isfile(dest)
+        assert open(dest, "rb").read() == body
+        # The .partial scratch file must not survive a success.
+        assert not os.path.exists(dest + ".partial")
+        assert dl._current_partial_path is None
+
+    def test_incomplete_download_raises_and_leaves_no_final_file(self, tmp_dir):
+        """Server promises more bytes than it delivers -> error, and the
+        final path stays empty so it isn't mistaken for a cached model."""
+        dl = ModelDownloader("beat_this", tmp_dir,
+                             url="http://x/m.onnx", file_name="m.onnx")
+        os.makedirs(tmp_dir, exist_ok=True)
+        dest = os.path.join(tmp_dir, "m.onnx")
+        truncated = _FakeResponse(b"only-half", content_length=1000)
+
+        with patch("src.model_manager.urllib.request.urlopen",
+                   return_value=truncated):
+            with pytest.raises(OSError, match="Incomplete download"):
+                dl._download_file("http://x/m.onnx", dest, lambda d, t: None)
+
+        assert not os.path.exists(dest)
+
+    def test_run_cleans_up_partial_on_error(self, tmp_dir):
+        """A mid-stream failure must leave neither the final nor the
+        .partial file, and must surface via the error signal."""
+        dl = ModelDownloader("beat_this", tmp_dir,
+                             url="http://x/m.onnx", file_name="m.onnx")
+        dest = os.path.join(tmp_dir, "models", "m.onnx")
+        dl.models_dir = os.path.join(tmp_dir, "models")
+
+        errors = []
+        dl.error.connect(lambda m: errors.append(m))
+
+        with patch("src.model_manager.urllib.request.urlopen",
+                   side_effect=OSError("connection reset")):
+            dl.run()
+
+        assert errors and "connection reset" in errors[0]
+        assert not os.path.exists(dest)
+        assert not os.path.exists(dest + ".partial")
+
+    def test_cancel_mid_stream_stops_and_leaves_no_final_file(self, tmp_dir):
+        dl = ModelDownloader("beat_this", tmp_dir,
+                             url="http://x/m.onnx", file_name="m.onnx")
+        os.makedirs(tmp_dir, exist_ok=True)
+        dest = os.path.join(tmp_dir, "m.onnx")
+
+        def _cancel_after_first_chunk(downloaded, total):
+            dl.cancel()
+
+        with patch("src.model_manager.urllib.request.urlopen",
+                   return_value=_FakeResponse(b"x" * (1 << 18))):
+            with pytest.raises(InterruptedError):
+                dl._download_file("http://x/m.onnx", dest,
+                                  _cancel_after_first_chunk)
+
+        assert not os.path.exists(dest)
+
+    def test_stale_partial_is_removed_before_new_download(self, tmp_dir):
+        dl = ModelDownloader("beat_this", tmp_dir,
+                             url="http://x/m.onnx", file_name="m.onnx")
+        os.makedirs(tmp_dir, exist_ok=True)
+        dest = os.path.join(tmp_dir, "m.onnx")
+        # Leave a stale partial from a hypothetical previous run.
+        with open(dest + ".partial", "wb") as f:
+            f.write(b"garbage-prefix")
+
+        with patch("src.model_manager.urllib.request.urlopen",
+                   return_value=_FakeResponse(b"fresh-bytes")):
+            dl._download_file("http://x/m.onnx", dest, lambda d, t: None)
+
+        assert open(dest, "rb").read() == b"fresh-bytes"
+
+    def test_full_multi_artifact_download_completes(self, tmp_dir):
+        """The two-artifact htdemucs path renames both files and emits
+        download_complete with the graph path."""
+        manager_dir = os.path.join(tmp_dir, "models")
+        dl = ModelDownloader("htdemucs", manager_dir)
+        done = []
+        dl.download_complete.connect(lambda p: done.append(p))
+
+        with patch("src.model_manager.urllib.request.urlopen",
+                   side_effect=lambda *a, **k: _FakeResponse(b"data" * 100)):
+            dl.run()
+
+        assert done and done[0].endswith("htdemucs.onnx")
+        for fname in _MODEL_FILES["htdemucs"]:
+            assert os.path.isfile(os.path.join(manager_dir, fname))
+            assert not os.path.exists(
+                os.path.join(manager_dir, fname + ".partial")
+            )

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -593,6 +593,10 @@ class TestRecordingSave:
         player._recording_buffer = np.full(
             (44100, 2), 0.5, dtype=np.float32
         )
+        # Simulate input having been captured into the buffer (the
+        # callback increments this; without it save_recording treats
+        # the buffer as an untouched count-in remnant and skips it).
+        player._recording_frames_captured = 44100
 
         song_dir = str(tmp_path / "song")
         os.makedirs(song_dir)
@@ -629,6 +633,7 @@ class TestRecordingSave:
         buf = np.zeros((44100, 2), dtype=np.float32)
         buf[441:541] = 0.8
         player._recording_buffer = buf
+        player._recording_frames_captured = 44100
         player.set_latency_offset_ms(10.0)
 
         song_dir = str(tmp_path / "song")
@@ -765,6 +770,10 @@ class TestStopOnlyFinalization:
         player._recording_buffer = np.full(
             (44100, 2), 0.5, dtype=np.float32
         )
+        # Simulate input having been captured into the buffer (the
+        # callback increments this; without it save_recording treats
+        # the buffer as an untouched count-in remnant and skips it).
+        player._recording_frames_captured = 44100
         player._recording = True
         player._is_playing = True
         player.set_recording_song_dir(str(tmp_path))
@@ -783,6 +792,10 @@ class TestStopOnlyFinalization:
         player._recording_buffer = np.full(
             (44100, 2), 0.5, dtype=np.float32
         )
+        # Simulate input having been captured into the buffer (the
+        # callback increments this; without it save_recording treats
+        # the buffer as an untouched count-in remnant and skips it).
+        player._recording_frames_captured = 44100
         player._recording = True
         player._is_playing = True
         player.set_recording_song_dir(str(tmp_path))
@@ -1186,3 +1199,88 @@ class TestCallbackSafety:
         outdata = np.zeros((100, 2), dtype=np.float32)
         player._audio_callback(outdata, 100, {}, sd.CallbackFlags())
         assert player._current_frame == 100
+
+
+class TestEmptyTakeGuard:
+    """stop() used to save a full-length all-zeros WAV when playback was
+    stopped before any input was captured (e.g. during count-in),
+    silently consuming one of the take slots."""
+
+    def test_save_skipped_when_no_frames_captured(
+        self, tmp_path, mock_stems,
+    ):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._allocate_recording_buffer()
+
+        path = player.save_recording(str(tmp_path))
+
+        assert path is None
+        assert player._recording_buffer is None
+        assert list(tmp_path.glob("*.wav")) == []
+
+    def test_save_proceeds_when_frames_captured(self, tmp_path, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._allocate_recording_buffer()
+        player._recording_buffer[:100] = 0.5
+        player._recording_frames_captured = 100
+
+        path = player.save_recording(str(tmp_path))
+
+        assert path is not None
+        assert os.path.isfile(path)
+
+    def test_allocate_resets_captured_counter(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._recording_frames_captured = 500
+        player._allocate_recording_buffer()
+        assert player._recording_frames_captured == 0
+
+
+class TestTransformGuardsDuringRecording:
+    """Speed/pitch changes are refused mid-recording: the render swap
+    rescales the playhead while the duplex stream keeps writing input
+    at the old positions, scrambling the take."""
+
+    def test_set_speed_refused_while_recording(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._recording = True
+        player.set_speed(0.5)
+        assert player.speed == 1.0
+
+    def test_set_pitch_refused_while_recording(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._recording = True
+        player.set_pitch(3)
+        assert player.pitch_semitones == 0
+
+
+class TestUnload:
+    """Close Song must leave the player truly empty -- previously only
+    the UI cleared, and Space kept playing the invisible song."""
+
+    def test_unload_clears_stems_and_state(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._loop_a_frame = 100
+        player._loop_b_frame = 200
+        player._looping = True
+        player._pitch_semitones = 3
+
+        player.unload()
+
+        assert not player.has_stems
+        assert player._total_frames == 0
+        assert player._current_frame == 0
+        assert player.pitch_semitones == 0
+        assert player._loop_a_frame is None
+        assert not player._looping
+
+    def test_unload_on_empty_player_is_safe(self):
+        player = MultiTrackPlayer()
+        player.unload()
+        assert not player.has_stems

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1098,3 +1098,73 @@ class TestMasterVolume:
         assert player.master_volume == 0.0
         player.set_master_volume(2.0)
         assert player.master_volume == 2.0
+
+
+class TestCallbackSafety:
+    """Regressions for GUI-thread mutations racing the audio callback."""
+
+    def _playing_player(self, mock_stems):
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        player._is_playing = True
+        return player
+
+    def test_new_recording_take_is_audible_without_mute_toggle(
+        self, mock_stems,
+    ):
+        """add_recording_stem must invalidate the active-stems cache.
+
+        The callback builds the cache on first playback; recording
+        requires playback, so the cache always exists before the take
+        lands. Without invalidation the take mixed at gain 0 -- visible
+        in the mixer but silent -- until any mute/solo was toggled.
+        """
+        player = self._playing_player(mock_stems)
+        outdata = np.zeros((100, 2), dtype=np.float32)
+        player._audio_callback(outdata, 100, {}, sd.CallbackFlags())
+        assert player._active_stems_cache is not None
+
+        take = np.ones((44100, 2), dtype=np.float32) * 0.05
+        player.add_recording_stem("recording_take1", take)
+
+        outdata = np.zeros((100, 2), dtype=np.float32)
+        player._audio_callback(outdata, 100, {}, sd.CallbackFlags())
+        # 0.1 + 0.2 + 0.3 + 0.05 -- the take is mixed in.
+        assert np.allclose(outdata, 0.65, atol=1e-3)
+
+    def test_remove_recording_stem_invalidates_cache(self, mock_stems):
+        player = self._playing_player(mock_stems)
+        take = np.ones((44100, 2), dtype=np.float32) * 0.05
+        player.add_recording_stem("recording_take1", take)
+        outdata = np.zeros((100, 2), dtype=np.float32)
+        player._audio_callback(outdata, 100, {}, sd.CallbackFlags())
+
+        player.remove_recording_stem("recording_take1")
+        assert player._active_stems_cache is None
+
+    def test_recording_stem_mutations_replace_stems_dict(self, mock_stems):
+        """Copy-on-write: the callback may be iterating the old dict on
+        the PortAudio thread, so mutations must swap in a new dict
+        instead of popping/inserting in place."""
+        player = self._playing_player(mock_stems)
+        take = np.ones((44100, 2), dtype=np.float32) * 0.05
+
+        before = player._stems
+        player.add_recording_stem("recording_take1", take)
+        assert player._stems is not before
+
+        before = player._stems
+        player.remove_recording_stem("recording_take1")
+        assert player._stems is not before
+
+    def test_callback_survives_inconsistent_loop_state(self, mock_stems):
+        """clear_loop() can null the loop frames between the callback's
+        reads; the callback snapshots them once so a mid-block clear
+        cannot produce None arithmetic."""
+        player = self._playing_player(mock_stems)
+        player._looping = True
+        player._loop_a_frame = None
+        player._loop_b_frame = None
+        outdata = np.zeros((100, 2), dtype=np.float32)
+        player._audio_callback(outdata, 100, {}, sd.CallbackFlags())
+        assert player._current_frame == 100

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1069,6 +1069,24 @@ class TestChordSequence:
         player.load_stems(mock_stems)
         assert player.chord_sequence == []
 
+    def test_chord_at_maps_stretched_frames_back_to_original_time(
+        self, mock_stems,
+    ):
+        """At 0.5x the audio is twice as long: original time t sits at
+        stretched frame t / speed * sr, so the inverse mapping must
+        multiply by speed. The old code divided, looking up the chord
+        at 4x the playhead time."""
+        player = MultiTrackPlayer()
+        player.load_stems(mock_stems)
+        chords = [(0.0, "Am"), (0.5, "G")]
+        player.set_chord_sequence(chords)
+        sr = player.sample_rate
+        player._playback_speed = 0.5
+        # Original t=0.25s ("Am") sits at stretched frame 0.25/0.5*sr.
+        assert player.chord_at(int(0.25 / 0.5 * sr)) == "Am"
+        # Original t=0.75s ("G") sits at stretched frame 0.75/0.5*sr.
+        assert player.chord_at(int(0.75 / 0.5 * sr)) == "G"
+
 
 class TestMasterVolume:
     """Master volume multiplier for all stems."""


### PR DESCRIPTION
## Summary

Post-dormancy stability pass from a deep review of the whole project. Fixes a batch of correctness bugs found across the player, UI, and support modules; no new features.

### Player / audio callback
- **Silent recording takes (critical):** `add_recording_stem` never invalidated the active-stems cache, so a freshly recorded take mixed at gain 0 — visible in the mixer, inaudible — until a mute/solo toggle. Now invalidated on add/remove.
- **Callback vs. GUI-thread races:** recording-stem add/remove replaces the stems dict copy-on-write (deleting a take mid-playback used to abort the stream with `dictionary changed size`); the callback snapshots the stems dict and loop frames once per block so `clear_loop` can't null a frame mid-read.
- **`chord_at` speed mapping:** inverted the stretch factor — at 0.5x the chord badge read the chord from 4× the playhead time.

### Recording lifecycle
- Empty takes (stop during count-in) no longer save a full-length silent WAV that eats a take slot.
- Speed/pitch changes refused while recording (they rescaled the playhead under the live input stream).
- Take-limit and speed/pitch guards can no longer be bypassed via the `R` shortcut; opening a song already at the take limit disables recording.
- Close Song / removing the loaded song fully unload the player (`unload()`), not leaving it playing invisibly.

### Export
- Refuse a second export while one runs (double-start dropped the last reference to a live QThread → Qt crash).
- Loop-region export maps stretched-timeline loop points back to original time (right region at non-1.0x speed).
- Count-in export option only appears when count-in is enabled.

### Robustness
- **Model downloads** stream to `.partial`, verify byte count, rename atomically, 30s socket timeout — a killed download can't masquerade as a cached (truncated) model. Previously untested; now covered (7 tests).
- **Library** recovery preserves a corrupt index as `.bak` and rebuilds from disk instead of destroying it; `_load` handles `OSError`/non-UTF-8; writes fsync before rename.
- Detection/peak workers drained on close (`PlayerControls.shutdown`) — fixes crash-on-exit when quitting during beat detection.
- Re-detection badges clear on failure instead of sticking on "detecting…".
- `import_dialog` records the model that actually ran the separation (cached-model imports recorded the wrong model).

### CI / packaging / docs
- `actions/checkout@v5`, `setup-python@v6` (Node 24); tests run under offscreen Qt.
- Dropped unused `pydub`; pytest deps moved to `requirements-dev.txt` (CI installs both).
- Docs corrected: shortcut tables, test counts (~825), distribution (Store/zip/MSIX, one-folder), roadmap; stop claiming GPU-accelerated separation.
- YouTube URL matching now accepts shorts/live/embed, m.youtube.com, www.music.youtube.com.

### Investigation
- **DirectML GPU separation (#125):** verified on RTX 4070 Ti that both HTDemucs ONNX exports fail DML kernel compilation and fall back to CPU, so `onnxruntime-directml` would add ~200 MB for no separation speedup. Kept plain `onnxruntime`; filed #125 with diagnostics for a future model re-export.

## Test plan
- [x] 833 pass / 1 skip on Python 3.14 / PySide6 6.10.2 (native)
- [x] 825 pass on CI-parity venv (Python 3.12 / PySide6 6.11.1 / offscreen)
- [x] +~45 regression tests (callback safety, empty-take guard, transform-during-record guards, unload, export double-start, atomic downloads, library recovery, YouTube URLs)
- [x] End-to-end smoke test: real MainWindow + real separated song — playback callback, recording-take audibility, delete-during-playback, chord_at@0.5x, unload