### PR TITLE
feat: v2.5.0 -- Loop Trainer (auto speed ramp per loop repeat)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ For full technical specs, module descriptions, and the phased roadmap, see `PROJ
 
 - Python 3.14 (local dev; GitHub Actions CI uses 3.12 per `.github/workflows/ci.yml`)
 - PySide6 (Qt 6) for GUI
-- ONNX Runtime + DirectML for GPU-accelerated inference (no PyTorch)
+- ONNX Runtime for inference (no PyTorch); DirectML GPU path attempted with CPU fallback — separation runs on CPU today, see issue #125
 - HTDemucs v4 ONNX models (4-stem and 6-stem)
 - sounddevice + soundfile for audio playback
 - numpy for audio buffer processing
@@ -73,7 +73,7 @@ stemma/
       wav_playback.py    # Logo SFX entry (lazy-loads Qt Multimedia impl)
       _wav_playback_impl.py  # QSoundEffect + winsound fallback
       styles.py          # Dark / light themes
-  tests/               # pytest test suite (~825 fast + slow/hardware deselected by default)
+  tests/               # pytest test suite (~845 fast + slow/hardware deselected by default)
     conftest.py        # Shared fixtures
     test_separator.py
     test_model_manager.py
@@ -141,7 +141,7 @@ Runtime library and models default to the per-user folder (e.g. `%LOCALAPPDATA%\
 
 Last updated: 2026-07-09
 
-Current version: **v2.4.1** — v2.4.0 shipped pitch shift / key transposition (#117); v2.4.1 is a stability pass on top of it.
+Current version: **v2.5.0** — v2.4.0 shipped pitch shift / key transposition (#117); v2.4.1 was a stability pass; v2.5.0 adds the Loop Trainer (auto speed ramp per loop repeat).
 
 ### Phase 1 (MVP) -- Complete
 All core functionality implemented and tested:
@@ -216,7 +216,7 @@ All core functionality implemented and tested:
 ## Test Suite
 
 ```
-pytest                                    # ~825 fast tests (~25s)
+pytest                                    # ~845 fast tests (~25s)
 pytest -m slow                            # ONNX inference tests (needs model)
 pytest -m hardware                        # audible playback test (needs speakers)
 set STEMMA_TEST_SONG=path/to/song.mp3     # Required for slow/hardware tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-07-09 -- v2.5.0 Loop Trainer
+
+### Done
+- **Loop Trainer:** New "Loop Trainer" toggle in the transport area. With an A-B loop active, it steps playback speed up one preset each time the loop repeats — from a chosen start speed (0.5x / 0.75x / 0.85x) up to 1.0x, then holds — so a passage can be learned slow and worked up to tempo hands-free. Start speed and enabled state persist across restarts (reset per song).
+- **Player loop-wrap signal:** `MultiTrackPlayer` now exposes a `loop_wrapped` signal. A realtime-safe wrap counter is incremented in the audio callback and surfaced from the GUI-thread position timer, so loop-driven UI logic (the trainer) never runs on the audio thread. Reuses the existing render serialization, so rapid ramps don't pile up librosa workers.
+
+### Metrics
+- 846 fast tests pass, 1 skipped. +13 new tests (wrap counter/signal, ramp progression and 1.0x cap, reset-on-load, session round-trip).
+
+---
+
 ## 2026-07-09 -- v2.4.1 Stability Pass
 
 A returning-from-dormancy audit (deep review of the whole project plus PR #124) turned up a batch of correctness bugs; this session fixes them and gets CI green again.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -257,7 +257,7 @@ stemma/
 - [x] PyInstaller packaging + GitHub Release workflow (#56)
 
 ### Post-2.0 backlog (see GitHub issues)
-Shipped in 2.x: session persistence (#55), metronome (#57), count-in (#78), recording (#79), animated startup (#76), MSIX / Store (#74), UI redesign and export extras (#92, #97, #98, #99, #100), release tooling (tag-driven `version.py` + manifest sync, CI on tags), automatic BPM/key detection and beat-synced metronome (#42), time signature detection and real-time chord display (#118), pitch shift / key transposition (#117, shipped v2.4.0).
+Shipped in 2.x: session persistence (#55), metronome (#57), count-in (#78), recording (#79), animated startup (#76), MSIX / Store (#74), UI redesign and export extras (#92, #97, #98, #99, #100), release tooling (tag-driven `version.py` + manifest sync, CI on tags), automatic BPM/key detection and beat-synced metronome (#42), time signature detection and real-time chord display (#118), pitch shift / key transposition (#117, shipped v2.4.0), Loop Trainer speed ramp (shipped v2.5.0).
 
 Open (all labeled `v3.0` on GitHub):
 - [ ] Experimental DSP extensions (#28)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Import a song, separate it into stems (vocals, drums, bass, guitar, piano, other
 - Waveform visualization with click-to-seek, playback cursor, and loop markers
 - A-B loop for practice sections (Stop returns to loop A while looping; seek stays inside the loop); pitch-preserving playback speed presets
 - Pitch transposition (±7 semitones), rendered in a single pass with the speed change; the Key badge shows the transposed key
+- Loop Trainer: with an A-B loop active, playback speed steps up one preset each repeat, from a chosen start speed up to 1.0x — learn a passage slow and work it up to tempo hands-free
 - Metronome with BPM entry, tap tempo, and beat-sync nudge (±500ms)
 - Optional count-in beats before playback (and optionally before each loop repeat)
 - Session persistence: restore last song, position, mixer, loop, speed, metronome, count-in, and recording take state after restart
@@ -59,7 +60,7 @@ python main.py
 ## Running Tests
 
 ```bash
-# Fast tests (~25 seconds, ~825 tests)
+# Fast tests (~25 seconds, ~845 tests)
 pytest
 
 # Include ONNX inference tests (~20 seconds, needs model file)

--- a/src/player.py
+++ b/src/player.py
@@ -344,6 +344,7 @@ class MultiTrackPlayer(QObject):
     stretch_finished = Signal()  # render completed (success or error)
     playback_failed = Signal(str)
     recording_saved = Signal(str)  # emitted with the saved WAV path
+    loop_wrapped = Signal()  # A-B loop repeated (wrapped back to A)
 
     def __init__(self) -> None:
         super().__init__()
@@ -367,6 +368,12 @@ class MultiTrackPlayer(QObject):
         self._loop_a_frame: int | None = None
         self._loop_b_frame: int | None = None
         self._looping: bool = False
+        # Incremented in the audio callback each time the loop wraps back
+        # to A (a plain int write -- realtime-safe). _emit_position (GUI
+        # thread) diffs it against _loop_wrap_seen and emits loop_wrapped
+        # so trainer/UI logic runs on the GUI thread, never the callback.
+        self._loop_wrap_count: int = 0
+        self._loop_wrap_seen: int = 0
 
         # Speed / time-stretch / pitch state.
         self._playback_speed: float = 1.0
@@ -920,6 +927,8 @@ class MultiTrackPlayer(QObject):
         self._loop_a_frame = None
         self._loop_b_frame = None
         self._looping = False
+        self._loop_wrap_count = 0
+        self._loop_wrap_seen = 0
         self._playback_speed = 1.0
         self._pitch_semitones = 0
         self._applied_render_state = (1.0, 0, False)
@@ -1653,6 +1662,14 @@ class MultiTrackPlayer(QObject):
                 self._recording_buffer = None
             return
 
+        # Surface loop wraps that happened on the audio thread since the
+        # last tick. Emitted here (GUI thread) so slots can safely touch
+        # Qt objects and spawn render workers.
+        wraps = self._loop_wrap_count
+        if wraps != self._loop_wrap_seen:
+            self._loop_wrap_seen = wraps
+            self.loop_wrapped.emit()
+
         pos_s = self._current_frame / self._sample_rate
         self.position_changed.emit(pos_s)
 
@@ -1931,6 +1948,9 @@ class MultiTrackPlayer(QObject):
             if self._current_frame >= boundary:
                 if looping:
                     self._current_frame = loop_a
+                    # RT-safe int write; surfaced as loop_wrapped from the
+                    # GUI-thread timer (see _emit_position).
+                    self._loop_wrap_count += 1
                     if (self._count_in_enabled
                             and self._count_in_on_repeats):
                         self._arm_count_in()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -650,6 +650,13 @@ class MainWindow(QMainWindow):
         self._settings.setValue(
             "session/count_in_on_repeats", self._player.count_in_on_repeats
         )
+        self._settings.setValue(
+            "session/trainer_enabled", self._player_controls.trainer_enabled
+        )
+        self._settings.setValue(
+            "session/trainer_start_speed",
+            self._player_controls.trainer_start_speed,
+        )
         # Per-song detected key & BPM (keyed by song_id).
         if self._current_song_id:
             prefix = f"detection/{self._current_song_id}"
@@ -886,6 +893,18 @@ class MainWindow(QMainWindow):
         self._player_controls.restore_count_in_state(
             bool(ci_enabled), ci_beats, bool(ci_repeats)
         )
+
+        # Loop trainer state
+        tr_enabled = self._settings.value("session/trainer_enabled", False)
+        if isinstance(tr_enabled, str):
+            tr_enabled = tr_enabled.lower() == "true"
+        try:
+            tr_start = float(
+                self._settings.value("session/trainer_start_speed", 0.75)
+            )
+        except (TypeError, ValueError):
+            tr_start = 0.75
+        self._player_controls.restore_trainer_state(bool(tr_enabled), tr_start)
 
         # Per-song detected key & BPM.
         if self._current_song_id:

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -15,6 +15,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from PySide6.QtCore import QEvent, QPointF, QRectF, QSize, Qt, QTimer, Signal
 from PySide6.QtGui import QColor, QIcon, QPainter, QPen, QPixmap, QPolygonF
 from PySide6.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QFrame,
     QHBoxLayout,
@@ -979,6 +980,44 @@ class PlayerControls(QWidget):
 
         controls_layout.addLayout(loop_speed_bar)
 
+        # -- Loop Trainer bar --
+        # Steps playback speed up one preset each time the A-B loop
+        # repeats, from a chosen start speed up to 1.0x, so a passage can
+        # be learned slow and worked up to tempo hands-free.
+        trainer_bar = QHBoxLayout()
+        self._trainer_enabled = False
+        self._trainer_start_speed = 0.75
+
+        self._trainer_check = QCheckBox("Loop Trainer")
+        self._trainer_check.setToolTip(
+            "Step speed up one preset each loop repeat, from the start "
+            "speed up to 1.0x. Requires an A-B loop."
+        )
+        self._trainer_check.setAccessibleName("Loop trainer")
+        self._trainer_check.toggled.connect(self._on_trainer_toggled)
+        trainer_bar.addWidget(self._trainer_check)
+
+        trainer_bar.addWidget(QLabel("from"))
+        self._trainer_start_combo = QComboBox()
+        for preset in SPEED_PRESETS:
+            if preset < 1.0:
+                self._trainer_start_combo.addItem(f"{preset}x", preset)
+        self._trainer_start_combo.setCurrentText("0.75x")
+        _fit_combo_width(self._trainer_start_combo)
+        self._trainer_start_combo.setToolTip("Trainer start speed")
+        self._trainer_start_combo.setAccessibleName("Trainer start speed")
+        self._trainer_start_combo.currentIndexChanged.connect(
+            self._on_trainer_start_changed
+        )
+        trainer_bar.addWidget(self._trainer_start_combo)
+        trainer_bar.addWidget(QLabel("→ 1.0x"))
+
+        self._trainer_status = QLabel("")
+        self._trainer_status.setObjectName("subtle-label")
+        trainer_bar.addWidget(self._trainer_status)
+        trainer_bar.addStretch()
+        controls_layout.addLayout(trainer_bar)
+
         # -- Metronome bar --
         metro_ci_bar = QHBoxLayout()
 
@@ -1206,6 +1245,7 @@ class PlayerControls(QWidget):
         self._player.stretch_started.connect(self._on_stretch_started)
         self._player.stretch_progress.connect(self._on_stretch_progress)
         self._player.stretch_finished.connect(self._on_stretch_finished)
+        self._player.loop_wrapped.connect(self._on_loop_wrapped)
 
     def set_stem_names(self, stem_names: list[str]) -> None:
         """Populate the stem mixer with rows for each stem."""
@@ -1245,6 +1285,14 @@ class PlayerControls(QWidget):
         self._pitch_spin.blockSignals(True)
         self._pitch_spin.setValue(0)
         self._pitch_spin.blockSignals(False)
+
+        # Reset the trainer for the new song (speed was reset to 1.0x
+        # above); leave the chosen start-speed preset as the user set it.
+        self._trainer_check.blockSignals(True)
+        self._trainer_check.setChecked(False)
+        self._trainer_check.blockSignals(False)
+        self._trainer_enabled = False
+        self._update_trainer_status()
 
         self._record_btn.blockSignals(True)
         self._record_btn.setChecked(False)
@@ -1517,6 +1565,7 @@ class PlayerControls(QWidget):
         self._update_loop_label()
         self._update_waveform_loop_markers()
         self._maybe_redetect_for_loop()
+        self._update_trainer_status()
 
     def set_loop_b(self) -> None:
         """Set loop B to the current playback position."""
@@ -1524,6 +1573,7 @@ class PlayerControls(QWidget):
         self._update_loop_label()
         self._update_waveform_loop_markers()
         self._maybe_redetect_for_loop()
+        self._update_trainer_status()
 
     def _maybe_redetect_for_loop(self) -> None:
         """Re-run detection for the A-B region when both points are set."""
@@ -1542,6 +1592,7 @@ class PlayerControls(QWidget):
         self._loop_toggle_btn.setChecked(False)
         self._update_loop_label()
         self._update_waveform_loop_markers()
+        self._update_trainer_status()
         # Re-detect for the full song after clearing A-B region.
         if self._player.stems:
             self.start_detection()
@@ -1549,6 +1600,108 @@ class PlayerControls(QWidget):
     def toggle_looping(self) -> None:
         """Toggle the loop button state (e.g. from keyboard shortcut)."""
         self._loop_toggle_btn.setChecked(not self._loop_toggle_btn.isChecked())
+
+    # -- Loop Trainer -----------------------------------------------------
+
+    @property
+    def trainer_enabled(self) -> bool:
+        """Whether the loop trainer is currently on."""
+        return self._trainer_enabled
+
+    @property
+    def trainer_start_speed(self) -> float:
+        """The trainer's configured start-speed preset."""
+        return self._trainer_start_speed
+
+    def restore_trainer_state(
+        self, enabled: bool, start_speed: float,
+    ) -> None:
+        """Restore trainer settings from a saved session.
+
+        Sets the start-speed combo and enabled checkbox without letting
+        the toggle immediately re-drop playback speed -- session restore
+        drives speed separately.
+        """
+        idx = self._trainer_start_combo.findText(f"{start_speed}x")
+        if idx >= 0:
+            self._trainer_start_combo.blockSignals(True)
+            self._trainer_start_combo.setCurrentIndex(idx)
+            self._trainer_start_combo.blockSignals(False)
+            self._trainer_start_speed = float(start_speed)
+        self._trainer_check.blockSignals(True)
+        self._trainer_check.setChecked(bool(enabled))
+        self._trainer_check.blockSignals(False)
+        self._trainer_enabled = bool(enabled)
+        self._update_trainer_status()
+
+    def _loop_region_valid(self) -> bool:
+        """True when a usable A-B region (B > A) is set."""
+        a = self._player.loop_a
+        b = self._player.loop_b
+        return a is not None and b is not None and b > a
+
+    def _next_speed_up(self, speed: float) -> float | None:
+        """Smallest speed preset greater than *speed*, capped at 1.0x.
+
+        Returns None once the ramp has reached 1.0x (nothing above it
+        that the trainer should step to).
+        """
+        for preset in SPEED_PRESETS:  # ascending
+            if preset > speed + 1e-6 and preset <= 1.0 + 1e-6:
+                return preset
+        return None
+
+    def _set_speed_preset(self, speed: float) -> None:
+        """Drive the speed combo to *speed* (fires the normal render)."""
+        idx = self._speed_combo.findText(f"{speed}x")
+        if idx >= 0:
+            self._speed_combo.setCurrentIndex(idx)
+
+    def _on_trainer_toggled(self, checked: bool) -> None:
+        """Enable/disable the trainer.
+
+        Enabling with a valid loop region drops playback to the start
+        speed; the ramp then advances one preset per loop repeat.
+        """
+        self._trainer_enabled = checked
+        if checked and self._loop_region_valid():
+            if self._player.speed != self._trainer_start_speed:
+                self._set_speed_preset(self._trainer_start_speed)
+        self._update_trainer_status()
+
+    def _on_trainer_start_changed(self, _index: int) -> None:
+        speed = self._trainer_start_combo.currentData()
+        if speed is None:
+            return
+        self._trainer_start_speed = float(speed)
+        # If the ramp is already above the new start, re-arm from it.
+        if (self._trainer_enabled and self._loop_region_valid()
+                and self._player.speed > self._trainer_start_speed):
+            self._set_speed_preset(self._trainer_start_speed)
+        self._update_trainer_status()
+
+    def _on_loop_wrapped(self) -> None:
+        """A-B loop repeated: step the trainer ramp up one preset."""
+        if not self._trainer_enabled:
+            return
+        nxt = self._next_speed_up(self._player.speed)
+        if nxt is not None:
+            self._set_speed_preset(nxt)
+        self._update_trainer_status()
+
+    def _update_trainer_status(self) -> None:
+        """Refresh the trainer readout next to the start combo."""
+        if not self._trainer_enabled:
+            self._trainer_status.setText("")
+            return
+        if not self._loop_region_valid():
+            self._trainer_status.setText("(set an A-B loop)")
+            return
+        cur = self._player.speed
+        if cur >= 1.0:
+            self._trainer_status.setText("at 1.0x")
+        else:
+            self._trainer_status.setText(f"now {cur:g}x")
 
     def _update_loop_label(self) -> None:
         """Update the loop info label with current A/B points."""
@@ -1595,6 +1748,7 @@ class PlayerControls(QWidget):
         self._speed_combo.blockSignals(False)
         self._do_recompute_peaks()
         self.update_record_button_state()
+        self._update_trainer_status()
 
     def cycle_speed(self, direction: int) -> None:
         """Cycle to the next/previous speed preset.

--- a/tests/test_loop_trainer.py
+++ b/tests/test_loop_trainer.py
@@ -1,0 +1,203 @@
+"""Tests for the Loop Trainer (v2.5.0).
+
+Covers:
+  - Player: the loop-wrap counter increments in the audio callback and
+    _emit_position surfaces it as the loop_wrapped signal exactly once
+    per wrap.
+  - UI: the trainer steps playback speed up one preset per loop wrap,
+    from the start speed up to 1.0x and no further; enabling drops to the
+    start speed only with a valid A-B region; a disabled trainer ignores
+    wraps; song load resets the trainer; session state round-trips.
+"""
+
+import os
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import sounddevice as sd
+from PySide6.QtWidgets import QApplication
+
+from src.player import MultiTrackPlayer, SPEED_PRESETS
+from src.ui.player_controls import PlayerControls
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def player(qapp):
+    p = MultiTrackPlayer()
+    yield p
+    p.shutdown(wait_ms=5000)
+
+
+@pytest.fixture
+def controls(qapp, player):
+    ctrl = PlayerControls(player)
+    yield ctrl
+    ctrl._cleanup_peak_thread()
+    ctrl.setParent(None)
+    ctrl.deleteLater()
+    qapp.processEvents()
+
+
+@pytest.fixture
+def loaded(player, tmp_path):
+    import soundfile as sf
+    sr = 44100
+    path = tmp_path / "s.wav"
+    sf.write(str(path), np.ones((sr, 2), dtype=np.float32) * 0.2, sr)
+    player.load_stems({"vocals": str(path)})
+    return player
+
+
+# -----------------------------------------------------------------------
+# Player: loop-wrap counter + signal
+# -----------------------------------------------------------------------
+
+class TestLoopWrapSignal:
+    def _loop(self, player, a_s, b_s):
+        player.set_loop_a(a_s)
+        player.set_loop_b(b_s)
+        player.set_looping(True)
+
+    def test_callback_increments_wrap_count_on_wrap(self, loaded):
+        """Playing through the B boundary wraps to A and bumps the count."""
+        self._loop(loaded, 0.0, 0.01)  # ~441-frame loop
+        loaded._is_playing = True
+        loaded.seek(0.0)
+        before = loaded._loop_wrap_count
+        out = np.zeros((2048, 2), dtype=np.float32)
+        loaded._audio_callback(out, 2048, {}, sd.CallbackFlags())
+        assert loaded._loop_wrap_count > before
+
+    def test_emit_position_fires_loop_wrapped_once_per_wrap(self, loaded):
+        received = []
+        loaded.loop_wrapped.connect(lambda: received.append(1))
+        # Simulate the callback having wrapped twice.
+        loaded._is_playing = True
+        loaded._loop_wrap_count = 2
+        loaded._emit_position()
+        assert received == [1]  # coalesced: fires once when count changes
+        # No further wrap -> no further emit.
+        loaded._emit_position()
+        assert received == [1]
+        # One more wrap -> one more emit.
+        loaded._loop_wrap_count = 3
+        loaded._emit_position()
+        assert received == [1, 1]
+
+    def test_load_stems_resets_wrap_count(self, loaded):
+        loaded._loop_wrap_count = 5
+        loaded._loop_wrap_seen = 5
+        # Reload.
+        import soundfile as sf
+        loaded._reset_song_state()
+        assert loaded._loop_wrap_count == 0
+        assert loaded._loop_wrap_seen == 0
+
+
+# -----------------------------------------------------------------------
+# UI: trainer speed ramp
+# -----------------------------------------------------------------------
+
+class TestTrainerRamp:
+    def _make_loop(self, controls):
+        controls._player.set_loop_a(0.0)
+        controls._player.set_loop_b(5.0)
+
+    def test_next_speed_up_walks_presets_to_one(self, controls):
+        assert controls._next_speed_up(0.5) == 0.75
+        assert controls._next_speed_up(0.75) == 0.85
+        assert controls._next_speed_up(0.85) == 1.0
+        # At/above 1.0 there's nothing to step to (won't go 1.25+).
+        assert controls._next_speed_up(1.0) is None
+
+    def test_enable_drops_to_start_speed_with_loop(self, controls, loaded):
+        self._make_loop(controls)
+        controls._trainer_start_speed = 0.75
+        with patch.object(loaded, "set_speed") as ss:
+            # Route through the combo the way the UI does.
+            with patch.object(controls, "_set_speed_preset") as sp:
+                controls._on_trainer_toggled(True)
+                sp.assert_called_once_with(0.75)
+
+    def test_enable_without_loop_does_not_change_speed(self, controls, loaded):
+        # No A-B region set.
+        with patch.object(controls, "_set_speed_preset") as sp:
+            controls._on_trainer_toggled(True)
+            sp.assert_not_called()
+
+    def test_wrap_advances_one_preset(self, controls, loaded):
+        self._make_loop(controls)
+        controls._trainer_enabled = True
+        loaded._playback_speed = 0.75
+        with patch.object(controls, "_set_speed_preset") as sp:
+            controls._on_loop_wrapped()
+            sp.assert_called_once_with(0.85)
+
+    def test_wrap_at_target_does_not_advance(self, controls, loaded):
+        self._make_loop(controls)
+        controls._trainer_enabled = True
+        loaded._playback_speed = 1.0
+        with patch.object(controls, "_set_speed_preset") as sp:
+            controls._on_loop_wrapped()
+            sp.assert_not_called()
+
+    def test_wrap_ignored_when_trainer_off(self, controls, loaded):
+        self._make_loop(controls)
+        controls._trainer_enabled = False
+        loaded._playback_speed = 0.75
+        with patch.object(controls, "_set_speed_preset") as sp:
+            controls._on_loop_wrapped()
+            sp.assert_not_called()
+
+    def test_full_ramp_sequence(self, controls, loaded):
+        """Successive wraps climb 0.75 -> 0.85 -> 1.0 then hold."""
+        self._make_loop(controls)
+        controls._trainer_start_speed = 0.75
+        controls._on_trainer_toggled(True)
+        # Simulate the render landing at each step by setting the speed.
+        seq = []
+        for _ in range(4):
+            loaded._playback_speed = (
+                controls._speed_combo.currentData() or loaded._playback_speed
+            )
+            # Emulate: whatever _set_speed_preset would target, apply it.
+            nxt = controls._next_speed_up(loaded._playback_speed)
+            controls._on_loop_wrapped()
+            if nxt is not None:
+                loaded._playback_speed = nxt
+            seq.append(loaded._playback_speed)
+        # Climbs to 1.0 and holds.
+        assert seq[-1] == 1.0
+        assert seq == sorted(seq)  # monotonic non-decreasing
+
+
+# -----------------------------------------------------------------------
+# UI: reset on song load + session round-trip
+# -----------------------------------------------------------------------
+
+class TestTrainerLifecycle:
+    def test_song_load_resets_trainer(self, controls):
+        controls._trainer_check.setChecked(True)
+        controls._trainer_enabled = True
+        controls.set_stem_names([])  # simulates loading a new (empty) song
+        assert controls._trainer_enabled is False
+        assert not controls._trainer_check.isChecked()
+
+    def test_restore_trainer_state_round_trip(self, controls):
+        controls.restore_trainer_state(True, 0.5)
+        assert controls.trainer_enabled is True
+        assert controls.trainer_start_speed == 0.5
+        assert controls._trainer_check.isChecked()
+
+    def test_restore_ignores_unknown_start_speed(self, controls):
+        # A start speed not in the combo is left at the default.
+        controls.restore_trainer_state(True, 0.999)
+        assert controls.trainer_start_speed in [
+            p for p in SPEED_PRESETS if p < 1.0
+        ]

--- a/tests/test_pitch_shift_ui.py
+++ b/tests/test_pitch_shift_ui.py
@@ -49,7 +49,16 @@ def player():
 def controls(qapp, player):
     ctrl = PlayerControls(player)
     yield ctrl
+    # Deterministic teardown: drain workers, then delete the widget now
+    # (while the QApplication is still alive) instead of leaving dozens of
+    # PlayerControls to be freed by Python's GC at interpreter exit in an
+    # order Qt can't survive (heap corruption). The player<->controls
+    # signal connections form a reference cycle, so this must happen
+    # before the player fixture tears down.
     ctrl._cleanup_peak_thread()
+    ctrl.setParent(None)
+    ctrl.deleteLater()
+    qapp.processEvents()
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -25,7 +25,9 @@ def qapp():
 
 @pytest.fixture
 def player():
-    return MultiTrackPlayer()
+    p = MultiTrackPlayer()
+    yield p
+    p.shutdown(wait_ms=5000)
 
 
 @pytest.fixture
@@ -37,7 +39,14 @@ def library(tmp_path):
 def controls(qapp, player):
     ctrl = PlayerControls(player)
     yield ctrl
+    # Delete the widget while the QApplication is alive rather than
+    # leaving it for GC at interpreter exit (heap corruption); the
+    # player<->controls signal connections form a reference cycle, so
+    # tear the widget down before the player fixture.
     ctrl._cleanup_peak_thread()
+    ctrl.setParent(None)
+    ctrl.deleteLater()
+    qapp.processEvents()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Adds a **Loop Trainer**: with an A-B loop active, playback speed steps up one preset each time the loop repeats — from a chosen start speed (0.5x / 0.75x / 0.85x) up to 1.0x, then holds. Learn a passage slow and work it up to tempo hands-free. A classic practice-tool feature that builds on the loop + speed engine hardened in v2.4.1.

### How it works
- **Player:** a realtime-safe loop-wrap counter is incremented in the audio callback (a plain int write); `_emit_position` (GUI-thread position timer) diffs it and emits a new `loop_wrapped` signal. All trainer logic runs on the GUI thread — never the audio callback.
- **UI:** a "Loop Trainer" checkbox + start-speed combo + status readout sit in a new bar under the loop/speed row. On each wrap the trainer advances the speed combo one preset toward 1.0x via the normal debounced, pre-rendered speed path, so it reuses the render serialization (no piled-up librosa workers).
- Enabling with a valid A-B region drops to the start speed; trainer resets on song load; start-speed and enabled state persist in the session.

### Test plan
- [x] 846 pass / 1 skip on Python 3.14 / PySide6 6.10.2
- [x] 838 pass on CI-parity venv (Python 3.12 / PySide6 6.11.1 / offscreen)
- [x] 13 new tests: wrap counter/signal, ramp progression + 1.0x cap, wrap-ignored-when-off, reset-on-load, session round-trip
- [x] Smoke test with a real separated song: 0.75x -> 0.85x -> 1.0x -> holds across simulated loop wraps

Also hardened the PlayerControls test fixtures to tear widgets down deterministically (deleteLater while the QApplication is alive), reducing GC-at-exit teardown fragility.