### PR TITLE
feat: v2.6.0 -- MDX-Net 2-stem GPU separation (v3.0 Phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ stemma/
     import_messages.py # User-facing import / download / separation error text
     metronome.py       # Tap tempo / BPM helpers for metronome UI
     click_utils.py     # Metronome click sample generation
-    separator.py       # ONNX stem separation engine
+    separator.py       # HTDemucs 4/6-stem ONNX separation engine (CPU)
+    mdx_separator.py   # MDX-Net 2-stem ONNX separation engine (DirectML GPU)
     beat_detector.py   # BPM/key/chord detection + beat_this ONNX beat tracking
     model_manager.py   # Download/cache ONNX models
     player.py          # Multi-track audio player

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
+## 2026-07-17 -- v2.6.0 MDX-Net 2-stem GPU separation (v3.0 Phase 1)
+
+### Done
+- **Second separation engine:** UVR's MDX-Net (Inst HQ 3) splits a song into vocals + backing. Unlike the HTDemucs export, MDX ONNX compiles on DirectML, so this path genuinely uses the GPU — verified on an RTX 4070 Ti at 73 ms/chunk (DML) vs 3.3 s (CPU), ~45x. A 72 s song separates in ~26 s end-to-end including one-time session setup; HTDemucs took minutes.
+- **New import option:** "2-stem fast (vocals + backing, GPU)" in the import dialog's model picker. Output maps to `vocals.wav` + `other.wav`, so the player, mixer, export, and recording features work unchanged.
+- **Engine details:** numpy/librosa STFT packing matching UVR's torch.stft conventions, classic context-trimmed windowing, DML→CPU fallback, secondary stem derived as mix − primary. No PyTorch. Cross-validated against HTDemucs stems of a real song: vocal-stem correlation 0.90.
+- **Model download integrity:** the MDX registry carries UVR's published tail hash; ModelDownloader verifies it after the transfer and deletes/reports a mismatched file instead of caching it.
+- Model weights by the Ultimate Vocal Remover project (MIT) — credit to UVR and its developers (see README Credits).
+
+### Metrics
+- 847 fast tests pass. +10 engine tests, including an identity-model reconstruction proof of the STFT/window math (max error < 1e-3) and a gated real-model integration test.
+
+---
+
 ## 2026-07-09 -- v2.5.0 Loop Trainer
 
 ### Done

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -86,7 +86,8 @@ stemma/
 │   ├── paths.py               # app_root(): frozen-build-aware root dir
 │   ├── qt_signal_utils.py     # PySide6 helpers (safe signal disconnect)
 │   ├── version.py             # __version__ string
-│   ├── separator.py           # ONNX Runtime stem separation
+│   ├── separator.py           # HTDemucs 4/6-stem ONNX separation (CPU)
+│   ├── mdx_separator.py       # MDX-Net 2-stem ONNX separation (DirectML GPU)
 │   ├── beat_detector.py       # BPM/key/chord detection + beat_this ONNX beat tracking
 │   ├── model_manager.py       # Download/cache ONNX models on first run
 │   ├── player.py              # Multi-track audio player (sounddevice)
@@ -260,9 +261,9 @@ stemma/
 Shipped in 2.x: session persistence (#55), metronome (#57), count-in (#78), recording (#79), animated startup (#76), MSIX / Store (#74), UI redesign and export extras (#92, #97, #98, #99, #100), release tooling (tag-driven `version.py` + manifest sync, CI on tags), automatic BPM/key detection and beat-synced metronome (#42), time signature detection and real-time chord display (#118), pitch shift / key transposition (#117, shipped v2.4.0), Loop Trainer speed ramp (shipped v2.5.0).
 
 Open (all labeled `v3.0` on GitHub):
-- [ ] Experimental DSP extensions (#28)
-- [ ] Real-time streaming stem separation (#13)
-- [ ] GPU separation via DirectML re-export (#125)
+- [ ] Experimental DSP extensions (#28) — reframed by the v3.0 research as separation-quality tiers (MDX/SCNet/RoFormer), not bespoke DSP
+- [ ] Real-time streaming stem separation (#13) — reframed as progressive pre-separation with early playback; true live separation is not feasible on this stack
+- [ ] GPU separation via DirectML re-export (#125) — partially addressed in v2.6.0: MDX-Net 2-stem runs on DirectML; 4/6-stem HTDemucs on GPU still needs a model re-export
 
 For the live checklist, prefer `AGENTS.md` and the GitHub issue list over this section if they disagree.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Import a song, separate it into stems (vocals, drums, bass, guitar, piano, other
 
 ## Features
 
-- AI-powered stem separation using HTDemucs v4 (4-stem and 6-stem models)
-- ONNX Runtime inference; DirectML GPU acceleration is attempted per model with automatic CPU fallback (separation currently runs on CPU — see issue #125)
+- AI-powered stem separation: HTDemucs v4 (4-stem and 6-stem, CPU) and MDX-Net 2-stem (vocals + backing) that runs on the GPU via DirectML — seconds instead of minutes
+- ONNX Runtime inference with DirectML GPU acceleration where the model supports it, automatic CPU fallback otherwise (full multi-stem GPU is tracked in issue #125)
 - Multi-track player with per-stem mute/solo/volume controls
 - Audio post-processing: Wiener filter and soft gating for cleaner stems
 - Real-time chord detection (major/minor) with Viterbi smoothing, updated 4×/s during playback
@@ -106,3 +106,9 @@ Use **Help > Keyboard Shortcuts** in the app for the authoritative list (same bi
 ## License
 
 MIT
+
+## Credits
+
+- **HTDemucs v4** — Meta AI Research (MIT)
+- **MDX-Net models** — trained by the [Ultimate Vocal Remover](https://github.com/Anjok07/ultimatevocalremovergui) project and its developers (MIT); thank you to UVR for making them available
+- **beat_this** — beat/downbeat tracking model (ISMIR 2024, MIT)

--- a/src/mdx_separator.py
+++ b/src/mdx_separator.py
@@ -1,0 +1,322 @@
+"""MDX-Net 2-stem separation engine (ONNX Runtime, DirectML-accelerated).
+
+Runs a UVR MDX-Net model to split a song into a primary stem and its
+complement (e.g. Instrumental + Vocals). Unlike the HTDemucs export,
+MDX-Net ONNX graphs initialize and run on the DirectML execution
+provider, so this path is GPU-accelerated on any DX12 device (~45x
+faster than CPU on an RTX 4070 Ti; a 4-minute song separates in
+seconds instead of minutes).
+
+The model operates on spectrogram chunks:
+    input  [1, 4, dim_f, dim_t]  -- (L.re, L.im, R.re, R.im) x freq x time
+    output [1, 4, dim_f, dim_t]  -- the primary stem's spectrogram
+
+STFT/iSTFT run in numpy/librosa outside the graph, matching UVR's
+torch.stft settings (periodic Hann, center=True, reflect padding).
+The secondary stem is derived as (mix - primary).
+
+Inference windows use the classic UVR scheme: each window carries
+``trim = n_fft // 2`` samples of context on both sides and only the
+central ``gen_size`` region is kept, so no cross-fade is needed.
+
+Model weights are trained by the Ultimate Vocal Remover project
+(https://github.com/Anjok07/ultimatevocalremovergui, MIT) -- credit to
+UVR and its developers. The chunking/packing scheme follows UVR /
+python-audio-separator (MIT).
+"""
+
+import os
+
+import librosa
+import numpy as np
+import soundfile as sf
+from PySide6.QtCore import QThread, Signal
+
+SAMPLE_RATE = 44100
+
+# Registry of supported MDX models. Parameters come from UVR's model-data
+# database keyed by the md5 of the file's last 10,000 KiB (UVR's hashing
+# convention); md5_tail lets the downloader verify integrity after the
+# transfer and guards against upstream file swaps.
+MDX_MODELS: dict[str, dict] = {
+    "mdx_inst_hq3": {
+        "display_name": "MDX-Net Inst HQ 3",
+        "file": "UVR-MDX-NET-Inst_HQ_3.onnx",
+        "url": (
+            "https://github.com/TRvlvr/model_repo/releases/download/"
+            "all_public_uvr_models/UVR-MDX-NET-Inst_HQ_3.onnx"
+        ),
+        "md5_tail": "55657dd70583b0fedfba5f67df11d711",
+        "n_fft": 6144,
+        "hop": 1024,
+        "dim_f": 3072,
+        "dim_t": 256,
+        "compensate": 1.022,
+        # The model predicts this stem; the other is (mix - primary).
+        "primary_stem": "Instrumental",
+    },
+}
+
+# Stem-file mapping for the 2-stem result. The player's mixer knows the
+# canonical stem names, so the instrumental complement is stored as
+# "other" (giving a Vocals + Other mixer, same as a 4-stem song with
+# drums/bass absent).
+PRIMARY_TO_FILES = {
+    "Instrumental": ("other", "vocals"),  # (primary file, secondary file)
+    "Vocals": ("vocals", "other"),
+}
+
+
+def hash_model_file(path: str) -> str:
+    """Return the md5 of the file's last 10,000 KiB (UVR's convention)."""
+    import hashlib
+
+    with open(path, "rb") as f:
+        try:
+            f.seek(-10000 * 1024, 2)
+        except OSError:
+            f.seek(0)
+        return hashlib.md5(f.read()).hexdigest()
+
+
+def _create_session(model_path: str):
+    """Create an ONNX Runtime session, DirectML first with CPU fallback.
+
+    Same pattern as separator._create_session; unlike HTDemucs, MDX
+    graphs actually compile on DML, so the first branch is the one that
+    normally runs.
+    """
+    import onnxruntime as ort
+
+    if not os.path.isfile(model_path):
+        raise FileNotFoundError(f"ONNX model file not found: {model_path}")
+
+    session_options = ort.SessionOptions()
+    available = set(ort.get_available_providers())
+
+    if "DmlExecutionProvider" in available:
+        try:
+            return ort.InferenceSession(
+                model_path,
+                sess_options=session_options,
+                providers=["DmlExecutionProvider", "CPUExecutionProvider"],
+            )
+        except Exception:
+            pass
+
+    return ort.InferenceSession(
+        model_path,
+        sess_options=session_options,
+        providers=["CPUExecutionProvider"],
+    )
+
+
+class MdxSeparatorWorker(QThread):
+    """Background thread that runs MDX-Net 2-stem separation.
+
+    Signals match SeparatorWorker so the import dialog can drive either
+    engine identically:
+        progress(int, str): Percentage (0-100) and a status message.
+        finished(dict): Mapping of stem name to output file path.
+        error(str): Error description if separation fails.
+    """
+
+    progress = Signal(int, str)
+    finished = Signal(dict)
+    error = Signal(str)
+
+    def __init__(
+        self,
+        input_path: str,
+        output_dir: str,
+        model_path: str,
+        model_key: str = "mdx_inst_hq3",
+    ) -> None:
+        super().__init__()
+        self.input_path = input_path
+        self.output_dir = output_dir
+        self.model_path = model_path
+        self.params = MDX_MODELS[model_key]
+        self._is_cancelled = False
+
+    def cancel(self) -> None:
+        """Request cancellation of the running separation."""
+        self._is_cancelled = True
+
+    def run(self) -> None:
+        try:
+            self._separate()
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+    # ------------------------------------------------------------------
+    # Pipeline
+    # ------------------------------------------------------------------
+
+    def _separate(self) -> None:
+        self.progress.emit(0, "Loading audio file...")
+        audio, sr = self._load_audio()
+
+        self.progress.emit(5, "Resampling audio...")
+        audio = self._resample(audio, sr)
+
+        self.progress.emit(10, "Initializing MDX model...")
+        session = self._create_session()
+
+        self.progress.emit(15, "Separating (2-stem)...")
+        primary = self._demix(audio, session)
+        del session
+
+        if self._is_cancelled:
+            self.error.emit("Separation cancelled by user.")
+            return
+
+        secondary = audio - primary
+
+        self.progress.emit(95, "Saving separated files...")
+        result_files = self._save(primary, secondary)
+
+        self.progress.emit(100, "Done")
+        self.finished.emit(result_files)
+
+    def _load_audio(self) -> tuple[np.ndarray, int]:
+        """Return (audio, sample_rate) with audio shaped (2, samples)."""
+        if not os.path.isfile(self.input_path):
+            raise FileNotFoundError(
+                f"Input audio file not found: {self.input_path}"
+            )
+        audio, sr = sf.read(self.input_path, always_2d=True)
+        audio = audio.T.astype(np.float32)
+        if audio.shape[0] == 1:
+            audio = np.repeat(audio, 2, axis=0)
+        return audio[:2], sr
+
+    def _resample(self, audio: np.ndarray, sr: int) -> np.ndarray:
+        if sr == SAMPLE_RATE:
+            return audio
+        return np.stack([
+            librosa.resample(ch, orig_sr=sr, target_sr=SAMPLE_RATE)
+            for ch in audio
+        ]).astype(np.float32)
+
+    def _create_session(self):
+        return _create_session(self.model_path)
+
+    # ------------------------------------------------------------------
+    # STFT packing (matches UVR's torch.stft usage)
+    # ------------------------------------------------------------------
+
+    def _stft(self, chunk: np.ndarray) -> np.ndarray:
+        """(2, chunk_size) waveform -> (1, 4, dim_f, dim_t) model input."""
+        n_fft = self.params["n_fft"]
+        hop = self.params["hop"]
+        dim_f = self.params["dim_f"]
+        specs = []
+        for ch in range(2):
+            spec = librosa.stft(
+                chunk[ch],
+                n_fft=n_fft,
+                hop_length=hop,
+                window="hann",
+                center=True,
+                pad_mode="reflect",
+            )
+            # Crop the top bin(s): the model sees dim_f of n_fft//2+1 bins.
+            spec = spec[:dim_f]
+            specs.append(spec.real.astype(np.float32))
+            specs.append(spec.imag.astype(np.float32))
+        # Channel order (L.re, L.im, R.re, R.im), matching UVR's
+        # reshape([B, ch, 2, f, t]) -> [B, 4, f, t] flattening.
+        return np.stack(specs)[np.newaxis]
+
+    def _istft(self, spec4: np.ndarray, length: int) -> np.ndarray:
+        """(4, dim_f, dim_t) model output -> (2, length) waveform."""
+        n_fft = self.params["n_fft"]
+        hop = self.params["hop"]
+        bins = n_fft // 2 + 1
+        out = []
+        for ch in range(2):
+            re = spec4[ch * 2]
+            im = spec4[ch * 2 + 1]
+            full = np.zeros((bins, re.shape[1]), dtype=np.complex64)
+            full[: re.shape[0]] = re + 1j * im
+            wave = librosa.istft(
+                full,
+                hop_length=hop,
+                n_fft=n_fft,
+                window="hann",
+                center=True,
+                length=length,
+            )
+            out.append(wave.astype(np.float32))
+        return np.stack(out)
+
+    # ------------------------------------------------------------------
+    # Windowed inference
+    # ------------------------------------------------------------------
+
+    def _demix(self, mix: np.ndarray, session) -> np.ndarray:
+        """Run the model across the track; return the primary stem.
+
+        Classic UVR windowing: each window is ``chunk_size`` samples with
+        ``trim`` of context at both ends; only the central ``gen_size``
+        samples of each window's result are kept.
+        """
+        n_fft = self.params["n_fft"]
+        hop = self.params["hop"]
+        dim_t = self.params["dim_t"]
+
+        trim = n_fft // 2
+        chunk_size = hop * (dim_t - 1)
+        gen_size = chunk_size - 2 * trim
+
+        n = mix.shape[1]
+        remainder = n % gen_size
+        pad = (gen_size - remainder) if remainder else 0
+        padded = np.concatenate(
+            [
+                np.zeros((2, trim), dtype=np.float32),
+                mix,
+                np.zeros((2, pad + trim), dtype=np.float32),
+            ],
+            axis=1,
+        )
+
+        input_name = session.get_inputs()[0].name
+        out = np.zeros((2, n + pad), dtype=np.float32)
+        num_windows = (n + pad) // gen_size
+
+        for k in range(num_windows):
+            if self._is_cancelled:
+                return out[:, :n]
+            start = k * gen_size
+            window = padded[:, start:start + chunk_size]
+            spec = self._stft(window)
+            pred = session.run(None, {input_name: spec})[0][0]
+            wave = self._istft(pred, chunk_size)
+            out[:, start:start + gen_size] = wave[:, trim:trim + gen_size]
+            # 15..90% across the windows.
+            pct = 15 + int(75 * (k + 1) / num_windows)
+            self.progress.emit(
+                pct, f"Separating (2-stem)... {k + 1}/{num_windows}"
+            )
+
+        return out[:, :n] * self.params["compensate"]
+
+    # ------------------------------------------------------------------
+    # Output
+    # ------------------------------------------------------------------
+
+    def _save(
+        self, primary: np.ndarray, secondary: np.ndarray,
+    ) -> dict[str, str]:
+        os.makedirs(self.output_dir, exist_ok=True)
+        primary_file, secondary_file = PRIMARY_TO_FILES[
+            self.params["primary_stem"]
+        ]
+        result = {}
+        for name, data in ((primary_file, primary), (secondary_file, secondary)):
+            path = os.path.join(self.output_dir, f"{name}.wav")
+            sf.write(path, data.T, SAMPLE_RATE, subtype="PCM_16")
+            result[name] = path
+        return result

--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -66,6 +66,7 @@ class ModelDownloader(QThread):
         *,
         url: str | None = None,
         file_name: str | None = None,
+        expected_md5_tail: str | None = None,
     ) -> None:
         super().__init__()
         self.model_name = model_name
@@ -73,6 +74,11 @@ class ModelDownloader(QThread):
         self._is_cancelled = False
         self._url = url
         self._file_name = file_name
+        # Optional integrity check: md5 of the file's last 10,000 KiB
+        # (UVR's model-hashing convention). Verified after the download
+        # completes; a mismatch removes the file and raises, so a swapped
+        # or corrupted upstream file can never be treated as cached.
+        self._expected_md5_tail = expected_md5_tail
         self._current_partial_path: str | None = None
 
     def cancel(self) -> None:
@@ -95,6 +101,29 @@ class ModelDownloader(QThread):
                 except OSError:
                     pass
             self.error.emit(str(exc))
+
+    def _verify_md5_tail(self, dest: str) -> None:
+        """Verify the downloaded file against the expected tail hash.
+
+        No-op when the downloader was created without an expected hash.
+        On mismatch the file is removed and an OSError raised so the
+        run() handler surfaces it via the error signal.
+        """
+        if not self._expected_md5_tail:
+            return
+        from src.mdx_separator import hash_model_file
+
+        actual = hash_model_file(dest)
+        if actual != self._expected_md5_tail:
+            try:
+                os.remove(dest)
+            except OSError:
+                pass
+            raise OSError(
+                f"Downloaded model failed integrity check "
+                f"(md5 {actual}, expected {self._expected_md5_tail}). "
+                "The upstream file may have changed; try again later."
+            )
 
     def _download_file(self, url: str, dest: str, on_progress) -> None:
         """Download *url* to *dest* atomically.
@@ -163,6 +192,7 @@ class ModelDownloader(QThread):
                     )
 
             self._download_file(self._url, dest, _on_progress)
+            self._verify_md5_tail(dest)
             self.progress.emit(100, "Download complete.")
             self.download_complete.emit(dest)
             return
@@ -243,6 +273,34 @@ class ModelManager(QObject):
         """
         name = "htdemucs_6s" if is_6_stem else "htdemucs"
         self._active_downloader = ModelDownloader(name, self.models_dir)
+        return self._active_downloader
+
+    def mdx_model_path(self, model_key: str = "mdx_inst_hq3") -> str:
+        """Return the expected local path to an MDX-Net ONNX model."""
+        from src.mdx_separator import MDX_MODELS
+
+        return os.path.join(self.models_dir, MDX_MODELS[model_key]["file"])
+
+    def is_mdx_model_downloaded(self, model_key: str = "mdx_inst_hq3") -> bool:
+        """Check whether the MDX-Net model exists on disk."""
+        return os.path.isfile(self.mdx_model_path(model_key))
+
+    def download_mdx_model(
+        self, model_key: str = "mdx_inst_hq3",
+    ) -> ModelDownloader:
+        """Create a downloader for an MDX-Net model (not started).
+
+        The downloader verifies the file against UVR's published tail
+        hash after the transfer.
+        """
+        from src.mdx_separator import MDX_MODELS
+
+        info = MDX_MODELS[model_key]
+        self._active_downloader = ModelDownloader(
+            model_key, self.models_dir,
+            url=info["url"], file_name=info["file"],
+            expected_md5_tail=info["md5_tail"],
+        )
         return self._active_downloader
 
     def beat_model_path(self) -> str:

--- a/src/ui/import_dialog.py
+++ b/src/ui/import_dialog.py
@@ -34,6 +34,7 @@ from src.downloader import (
 )
 from src.import_messages import format_import_error
 from src.library import Song, SongLibrary
+from src.mdx_separator import MdxSeparatorWorker
 from src.model_manager import ModelDownloader, ModelManager
 from src.qt_signal_utils import safe_disconnect as _safe_disconnect
 from src.separator import (
@@ -119,12 +120,12 @@ class ImportDialog(QDialog):
 
         self._library = library
         self._model_manager = model_manager
-        self._worker: SeparatorWorker | None = None
+        self._worker: SeparatorWorker | MdxSeparatorWorker | None = None
         self._download_worker: _DownloadWorker | None = None
         self._metadata_worker: _MetadataWorker | None = None
         self._model_downloader: ModelDownloader | None = None
         self._import_song_id: str | None = None
-        self._pending_separation_is_6_stem: bool = False
+        self._pending_model_key: str = "htdemucs"
         self._selected_path: str = ""
         self._tmp_dir: str | None = None  # Cleaned up after import or on close.
 
@@ -195,9 +196,18 @@ class ImportDialog(QDialog):
         model_row = QHBoxLayout()
         model_row.addWidget(QLabel("Model:"))
         self._model_combo = QComboBox()
-        self._model_combo.addItem("4-stem (vocals, drums, bass, other)", False)
-        self._model_combo.addItem("6-stem (+ guitar, piano)", True)
-        self._model_combo.setToolTip("Choose separation model")
+        self._model_combo.addItem(
+            "4-stem (vocals, drums, bass, other)", "htdemucs"
+        )
+        self._model_combo.addItem("6-stem (+ guitar, piano)", "htdemucs_6s")
+        self._model_combo.addItem(
+            "2-stem fast (vocals + backing, GPU)", "mdx_inst_hq3"
+        )
+        self._model_combo.setToolTip(
+            "Choose separation model. 4/6-stem separate every instrument "
+            "(slow, CPU); 2-stem splits vocals from the backing track in "
+            "seconds using the GPU where available."
+        )
         model_row.addWidget(self._model_combo)
         layout.addLayout(model_row)
 
@@ -379,26 +389,52 @@ class ImportDialog(QDialog):
         self._import_song_id = song.id
 
         # Start separation.
-        is_6_stem = self._model_combo.currentData()
-        model_path = self._model_manager.model_path(is_6_stem=is_6_stem)
+        model_key = self._model_combo.currentData()
+        model_path = self._model_path_for(model_key)
 
-        if not os.path.isfile(model_path):
-            self._begin_model_download(song, is_6_stem)
+        if not self._model_downloaded_for(model_key):
+            self._begin_model_download(song, model_key)
             return
 
-        self._start_separation_worker(song, model_path, is_6_stem)
+        self._start_separation_worker(song, model_path, model_key)
 
-    def _begin_model_download(self, song: Song, is_6_stem: bool) -> None:
+    def _model_path_for(self, model_key: str) -> str:
+        """Resolve the on-disk ONNX path for a separation model key."""
+        if model_key.startswith("mdx_"):
+            return self._model_manager.mdx_model_path(model_key)
+        return self._model_manager.model_path(
+            is_6_stem=model_key == "htdemucs_6s"
+        )
+
+    def _model_downloaded_for(self, model_key: str) -> bool:
+        """True when all artifacts for *model_key* exist on disk.
+
+        Uses the manager checks rather than a bare isfile() so the
+        two-artifact HTDemucs models aren't treated as cached when only
+        the graph (and not the .onnx.data weights) survived.
+        """
+        if model_key.startswith("mdx_"):
+            return self._model_manager.is_mdx_model_downloaded(model_key)
+        return self._model_manager.is_model_downloaded(
+            is_6_stem=model_key == "htdemucs_6s"
+        )
+
+    def _begin_model_download(self, song: Song, model_key: str) -> None:
         """Download the ONNX model in the background, then run separation."""
-        self._pending_separation_is_6_stem = is_6_stem
+        self._pending_model_key = model_key
         self._progress_bar.setVisible(True)
         self._progress_bar.setValue(0)
         self._status_label.setVisible(True)
         self._button_box.setEnabled(False)
 
-        self._model_downloader = self._model_manager.download_model(
-            is_6_stem=is_6_stem
-        )
+        if model_key.startswith("mdx_"):
+            self._model_downloader = self._model_manager.download_mdx_model(
+                model_key
+            )
+        else:
+            self._model_downloader = self._model_manager.download_model(
+                is_6_stem=model_key == "htdemucs_6s"
+            )
         self._model_downloader.progress.connect(self._on_progress)
         self._model_downloader.download_complete.connect(
             self._on_model_download_finished
@@ -408,7 +444,7 @@ class ImportDialog(QDialog):
 
     def _on_model_download_finished(self, _path: str) -> None:
         """Model file is on disk; continue with stem separation."""
-        is_6 = self._pending_separation_is_6_stem
+        model_key = self._pending_model_key
         self._model_downloader = None
 
         song_id = self._import_song_id
@@ -418,7 +454,7 @@ class ImportDialog(QDialog):
         if song is None:
             return
 
-        model_path = self._model_manager.model_path(is_6_stem=is_6)
+        model_path = self._model_path_for(model_key)
         if not os.path.isfile(model_path):
             try:
                 self._library.remove_song(song_id)
@@ -428,7 +464,7 @@ class ImportDialog(QDialog):
             self._on_error("Model file missing after download.")
             return
 
-        self._start_separation_worker(song, model_path, is_6)
+        self._start_separation_worker(song, model_path, model_key)
 
     def _on_model_download_error(self, message: str) -> None:
         """Show a readable download error and roll back the library entry."""
@@ -476,26 +512,42 @@ class ImportDialog(QDialog):
         self,
         song: Song,
         model_path: str,
-        is_6_stem: bool,
+        model_key: str,
     ) -> None:
         """Run ONNX separation for a song that already has a model file."""
-        if not self._check_memory_ok(song.original_path, is_6_stem):
-            self._button_box.setEnabled(True)
-            return
+        if model_key.startswith("mdx_"):
+            # MDX processes the track in small spectrogram windows; its
+            # peak memory is a few hundred MB regardless of track length,
+            # so the Demucs full-track RAM check doesn't apply.
+            self._progress_bar.setVisible(True)
+            self._status_label.setVisible(True)
+            self._button_box.setEnabled(False)
 
-        self._progress_bar.setVisible(True)
-        self._status_label.setVisible(True)
-        self._button_box.setEnabled(False)
+            self._worker = MdxSeparatorWorker(
+                input_path=song.original_path,
+                output_dir=song.stems_path,
+                model_path=model_path,
+                model_key=model_key,
+            )
+        else:
+            is_6_stem = model_key == "htdemucs_6s"
+            if not self._check_memory_ok(song.original_path, is_6_stem):
+                self._button_box.setEnabled(True)
+                return
 
-        self._worker = SeparatorWorker(
-            input_path=song.original_path,
-            output_dir=song.stems_path,
-            model_path=model_path,
-            is_6_stem=is_6_stem,
-        )
+            self._progress_bar.setVisible(True)
+            self._status_label.setVisible(True)
+            self._button_box.setEnabled(False)
+
+            self._worker = SeparatorWorker(
+                input_path=song.original_path,
+                output_dir=song.stems_path,
+                model_path=model_path,
+                is_6_stem=is_6_stem,
+            )
         self._worker.progress.connect(self._on_progress)
         self._worker.finished.connect(
-            lambda _: self._on_finished(song.id, is_6_stem)
+            lambda _: self._on_finished(song.id, model_key)
         )
         self._worker.error.connect(self._on_error)
         self._worker.start()
@@ -534,15 +586,11 @@ class ImportDialog(QDialog):
         self._progress_bar.setValue(percent)
         self._status_label.setText(message)
 
-    def _on_finished(self, song_id: str, is_6_stem: bool) -> None:
+    def _on_finished(self, song_id: str, model_key: str) -> None:
         self._import_song_id = None
-        # Use the actual model that ran this separation, threaded through
-        # from _start_separation_worker. Reading
-        # _pending_separation_is_6_stem here was wrong: it is only set on
-        # the download path, so a cached-model import recorded whatever
-        # the previous download left behind.
-        model_used = "htdemucs_6s" if is_6_stem else "htdemucs"
-        self._library.update_song(song_id, model_used=model_used)
+        # The model key doubles as the stored model_used value; the
+        # demucs keys match the strings recorded by earlier versions.
+        self._library.update_song(song_id, model_used=model_key)
         self.accept()
 
     def _on_error(self, message: str) -> None:

--- a/tests/test_import_dialog.py
+++ b/tests/test_import_dialog.py
@@ -159,6 +159,9 @@ class TestModelDownloadWhenMissing:
 
         md = MagicMock()
         dialog._model_manager.download_model.return_value = md
+        # The dialog now asks the manager (not a bare isfile) whether all
+        # model artifacts exist; report them missing.
+        dialog._model_manager.is_model_downloaded.return_value = False
 
         dialog._start_local_import(str(dummy))
 

--- a/tests/test_mdx_separator.py
+++ b/tests/test_mdx_separator.py
@@ -1,0 +1,240 @@
+"""Tests for the MDX-Net 2-stem separation engine.
+
+The heavy path (real ONNX inference) is exercised by the gated
+integration test at the bottom; everything else runs against a fake
+session so the suite stays fast and offline.
+
+The key correctness property: with an identity model (output equals
+input spectrogram), the whole STFT -> chunk -> inference -> iSTFT ->
+overlap pipeline must reconstruct the input waveform almost exactly.
+That validates the packing/windowing math independently of any model.
+"""
+
+import os
+
+import numpy as np
+import pytest
+import soundfile as sf
+from PySide6.QtWidgets import QApplication
+
+from src.mdx_separator import (
+    MDX_MODELS,
+    MdxSeparatorWorker,
+    PRIMARY_TO_FILES,
+    hash_model_file,
+)
+
+
+@pytest.fixture(scope="module")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+class _IdentitySession:
+    """Fake ORT session: returns the input spectrogram unchanged."""
+
+    class _Input:
+        name = "input"
+
+    def get_inputs(self):
+        return [self._Input()]
+
+    def run(self, _outputs, feeds):
+        return [feeds["input"]]
+
+
+class _HalfSession(_IdentitySession):
+    """Fake ORT session: returns the input at half amplitude."""
+
+    def run(self, _outputs, feeds):
+        return [feeds["input"] * 0.5]
+
+
+def _make_worker(tmp_path, session, seconds=3.0, sr=44100):
+    """Build a worker over a synthetic stereo tone file."""
+    t = np.arange(int(seconds * sr)) / sr
+    left = 0.4 * np.sin(2 * np.pi * 220 * t)
+    right = 0.4 * np.sin(2 * np.pi * 330 * t)
+    audio = np.stack([left, right], axis=1).astype(np.float32)
+    src = tmp_path / "tone.wav"
+    sf.write(str(src), audio, sr)
+
+    worker = MdxSeparatorWorker(
+        input_path=str(src),
+        output_dir=str(tmp_path / "out"),
+        model_path="unused.onnx",
+    )
+    worker._create_session = lambda: session
+    return worker, audio.T
+
+
+class TestRegistry:
+    def test_registry_entries_are_complete(self):
+        for key, info in MDX_MODELS.items():
+            for field in ("file", "url", "md5_tail", "n_fft", "hop",
+                          "dim_f", "dim_t", "compensate", "primary_stem"):
+                assert field in info, f"{key} missing {field}"
+            assert info["primary_stem"] in PRIMARY_TO_FILES
+
+    def test_hash_model_file_small_file(self, tmp_path):
+        """Files under 10,000 KiB hash from the start (seek fallback)."""
+        p = tmp_path / "m.onnx"
+        p.write_bytes(b"model-bytes")
+        import hashlib
+        assert hash_model_file(str(p)) == hashlib.md5(b"model-bytes").hexdigest()
+
+
+class TestPipelineReconstruction:
+    def test_identity_model_reconstructs_input(self, app, tmp_path):
+        """Identity 'model' -> primary stem equals the mix.
+
+        This validates STFT packing, bin cropping/padding, window trim
+        and reassembly in one shot: any mismatch in the math shows up as
+        reconstruction error.
+        """
+        worker, audio = _make_worker(tmp_path, _IdentitySession())
+        session = worker._create_session()
+        primary = worker._demix(audio, session)
+
+        compensate = worker.params["compensate"]
+        expected = audio * compensate
+        err = np.max(np.abs(primary - expected))
+        # The model's dim_f crop discards the top ~1.5% of the spectrum,
+        # so reconstruction is near-exact for band-limited content.
+        assert err < 1e-3, f"reconstruction error {err}"
+
+    def test_half_model_scales_output(self, app, tmp_path):
+        worker, audio = _make_worker(tmp_path, _HalfSession())
+        session = worker._create_session()
+        primary = worker._demix(audio, session)
+        expected = audio * 0.5 * worker.params["compensate"]
+        assert np.max(np.abs(primary - expected)) < 1e-3
+
+    def test_demix_preserves_length(self, app, tmp_path):
+        """Output length must equal input length for any duration,
+        including ones that don't divide evenly into windows."""
+        for seconds in (0.7, 3.0, 6.2):
+            worker, audio = _make_worker(
+                tmp_path, _IdentitySession(), seconds=seconds,
+            )
+            session = worker._create_session()
+            primary = worker._demix(audio, session)
+            assert primary.shape == audio.shape
+
+
+class TestFullRun:
+    def test_run_writes_both_stems_and_emits_finished(self, app, tmp_path):
+        worker, audio = _make_worker(tmp_path, _IdentitySession())
+        results = {}
+        worker.finished.connect(lambda d: results.update(d))
+        errors = []
+        worker.error.connect(lambda m: errors.append(m))
+
+        worker.run()
+
+        assert not errors
+        assert set(results) == {"vocals", "other"}
+        for path in results.values():
+            assert os.path.isfile(path)
+        # Identity model: primary (Instrumental -> other.wav) carries the
+        # mix; secondary (vocals) = mix - primary*compensate is small.
+        other, _ = sf.read(results["other"], always_2d=True)
+        vocals, _ = sf.read(results["vocals"], always_2d=True)
+        assert np.sqrt(np.mean(other ** 2)) > 0.1
+        assert np.sqrt(np.mean(vocals ** 2)) < 0.05
+
+    def test_cancel_mid_run_emits_no_finished(self, app, tmp_path):
+        worker, audio = _make_worker(tmp_path, _IdentitySession())
+        finished = []
+        worker.finished.connect(lambda d: finished.append(d))
+        errors = []
+        worker.error.connect(lambda m: errors.append(m))
+        # Cancel as soon as the first progress tick arrives.
+        worker.progress.connect(lambda p, m: worker.cancel())
+
+        worker.run()
+
+        assert finished == []
+        assert errors and "cancelled" in errors[0].lower()
+
+    def test_missing_input_emits_error(self, app, tmp_path):
+        worker = MdxSeparatorWorker(
+            input_path=str(tmp_path / "nope.mp3"),
+            output_dir=str(tmp_path / "out"),
+            model_path="unused.onnx",
+        )
+        errors = []
+        worker.error.connect(lambda m: errors.append(m))
+        worker.run()
+        assert errors and "not found" in errors[0]
+
+
+class TestDownloadVerification:
+    def test_md5_tail_mismatch_removes_file_and_errors(self, tmp_path):
+        """A downloaded MDX model failing the integrity check must be
+        deleted and surfaced as an error, never kept as 'cached'."""
+        from src.model_manager import ModelDownloader
+        from unittest.mock import patch
+        import io
+
+        class _Resp:
+            headers = {"Content-Length": "9"}
+            def read(self, n=-1):
+                return self._buf.read(n)
+            def __enter__(self):
+                self._buf = io.BytesIO(b"bad-bytes")
+                return self
+            def __exit__(self, *a):
+                return False
+
+        dl = ModelDownloader(
+            "mdx_inst_hq3", str(tmp_path),
+            url="http://x/m.onnx", file_name="m.onnx",
+            expected_md5_tail="0" * 32,
+        )
+        errors = []
+        dl.error.connect(lambda m: errors.append(m))
+        with patch("src.model_manager.urllib.request.urlopen",
+                   return_value=_Resp()):
+            dl.run()
+
+        assert errors and "integrity" in errors[0]
+        assert not os.path.exists(tmp_path / "m.onnx")
+
+
+# ---------------------------------------------------------------------------
+# Gated integration test: real model, real inference (slow marker).
+# Runs only when the MDX model file is already cached locally.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+def test_real_model_separates_tone(app, tmp_path):
+    from src.data_paths import platform_user_data_dir
+
+    model = os.path.join(
+        platform_user_data_dir(), "models",
+        MDX_MODELS["mdx_inst_hq3"]["file"],
+    )
+    if not os.path.isfile(model):
+        pytest.skip("MDX model not cached locally")
+
+    t = np.arange(44100 * 4) / 44100
+    audio = np.stack([np.sin(2 * np.pi * 220 * t)] * 2, axis=1) * 0.4
+    src = tmp_path / "tone.wav"
+    sf.write(str(src), audio.astype(np.float32), 44100)
+
+    worker = MdxSeparatorWorker(
+        input_path=str(src), output_dir=str(tmp_path / "out"),
+        model_path=model,
+    )
+    results = {}
+    worker.finished.connect(lambda d: results.update(d))
+    worker.run()
+
+    assert set(results) == {"vocals", "other"}
+    # A pure tone is not vocals: the instrumental stem should carry
+    # nearly all the energy.
+    other, _ = sf.read(results["other"], always_2d=True)
+    vocals, _ = sf.read(results["vocals"], always_2d=True)
+    rms = lambda x: float(np.sqrt(np.mean(x ** 2)))
+    assert rms(other) > 5 * rms(vocals)


### PR DESCRIPTION
## Summary

First slice of the v3.0 plan: a second separation engine that actually uses the GPU.

UVR's **MDX-Net (Inst HQ 3)** splits a song into **vocals + backing** in seconds. Unlike the HTDemucs export (which fails DirectML kernel compilation, #125), MDX ONNX graphs compile and run on the DirectML execution provider.

**Measured on the RTX 4070 Ti:** 73 ms/chunk on DML vs 3.3 s on CPU (~45x). A 72 s song separates in ~26 s end-to-end including one-time session setup; the HTDemucs path took minutes.

### What's in it
- `src/mdx_separator.py` — numpy/librosa STFT packing matching UVR's torch.stft conventions, classic context-trimmed windowing, ONNX inference with DML→CPU fallback, secondary stem = mix − primary. **No PyTorch.**
- Import dialog gains a third model choice: **"2-stem fast (vocals + backing, GPU)"**. The model-selection flow is generalized from an `is_6_stem` bool to a model-key string (stored `model_used` values unchanged for demucs). Output maps to `vocals.wav` + `other.wav`, so mixer/export/recording work unchanged.
- Model registry carries UVR's published tail hash; `ModelDownloader` now verifies it post-download and deletes/reports a mismatch instead of caching a bad file.
- MDX skips the full-track RAM warning (windowed processing, few hundred MB peak regardless of length).
- README Credits section added (UVR attribution per their MIT license request).

### Validation
- [x] **Identity-model reconstruction test** proves the STFT/window math: with a pass-through model, the pipeline reconstructs the input to < 1e-3 max error
- [x] **Cross-engine check on a real song:** corr(MDX vocals, HTDemucs vocals) = **0.90**; no channel swap; sane RMS
- [x] **GUI-level E2E:** real ImportDialog → 2-stem import → library row `model_used=mdx_inst_hq3`, both stems on disk
- [x] Gated real-model integration test (runs when the model is cached)
- [x] 847 fast tests pass (+10 new)

### Held for release sequencing
**Do not merge until v2.5.0 has been tagged and deployed to the Store** — main must stay clean for the 2.5 release tag.

Refs #125 (partially addressed: 2-stem GPU works; 4/6-stem GPU still needs the HTDemucs re-export). First step of the v3.0 Phase 1 plan (audio-separator-style model registry, quality tiers to follow).