### PR TITLE
feat: background separation queue -- import without waiting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ stemma/
     click_utils.py     # Metronome click sample generation
     separator.py       # HTDemucs 4/6-stem ONNX separation engine (CPU)
     mdx_separator.py   # MDX-Net 2-stem ONNX separation engine (DirectML GPU)
+    separation_queue.py # Background separation job queue (serial)
     beat_detector.py   # BPM/key/chord detection + beat_this ONNX beat tracking
     model_manager.py   # Download/cache ONNX models
     player.py          # Multi-track audio player

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable development sessions are documented here in reverse chronological or
 
 ---
 
-## 2026-07-17 -- v2.6.0 MDX-Net 2-stem GPU separation (v3.0 Phase 1)
+## 2026-07-17 -- v2.6.0 MDX-Net 2-stem GPU separation + background imports (v3.0 Phase 1)
 
 ### Done
+- **Background separation queue:** importing no longer blocks the app. After picking the file/model (and any first-time model download), the import dialog closes immediately and separation runs in a background queue. The library row shows live "Queued... / Separating... N%" progress, stays unselectable until its stems exist, and offers a right-click "Cancel separation". Failures roll the row back with a message; songs interrupted by an app crash are pruned on the next launch. Multiple imports queue serially.
 - **Second separation engine:** UVR's MDX-Net (Inst HQ 3) splits a song into vocals + backing. Unlike the HTDemucs export, MDX ONNX compiles on DirectML, so this path genuinely uses the GPU — verified on an RTX 4070 Ti at 73 ms/chunk (DML) vs 3.3 s (CPU), ~45x. A 72 s song separates in ~26 s end-to-end including one-time session setup; HTDemucs took minutes.
 - **New import option:** "2-stem fast (vocals + backing, GPU)" in the import dialog's model picker. Output maps to `vocals.wav` + `other.wav`, so the player, mixer, export, and recording features work unchanged.
 - **Engine details:** numpy/librosa STFT packing matching UVR's torch.stft conventions, classic context-trimmed windowing, DML→CPU fallback, secondary stem derived as mix − primary. No PyTorch. Cross-validated against HTDemucs stems of a real song: vocal-stem correlation 0.90.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -88,6 +88,7 @@ stemma/
 │   ├── version.py             # __version__ string
 │   ├── separator.py           # HTDemucs 4/6-stem ONNX separation (CPU)
 │   ├── mdx_separator.py       # MDX-Net 2-stem ONNX separation (DirectML GPU)
+│   ├── separation_queue.py    # Background separation job queue (serial)
 │   ├── beat_detector.py       # BPM/key/chord detection + beat_this ONNX beat tracking
 │   ├── model_manager.py       # Download/cache ONNX models on first run
 │   ├── player.py              # Multi-track audio player (sounddevice)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Import a song, separate it into stems (vocals, drums, bass, guitar, piano, other
 - Automatic tempo and key detection; beat-synced metronome mode
 - High-accuracy beat/downbeat tracking via beat_this ONNX model (auto-downloaded)
 - Import from YouTube URL (bundled ffmpeg when available; otherwise ffmpeg on PATH)
+- Imports run in the background: the dialog closes as soon as separation starts, the library row shows live progress, and the app stays fully usable (multiple imports queue up)
 - Clear errors and progress when ONNX models download on first use; large-file warning before heavy imports
 - Export individual stems or custom mixes as WAV or MP3
 - Waveform visualization with click-to-seek, playback cursor, and loop markers

--- a/src/separation_queue.py
+++ b/src/separation_queue.py
@@ -1,0 +1,192 @@
+"""Background separation queue.
+
+Runs stem-separation jobs one at a time on background threads so the
+import dialog can close immediately and the app stays usable while a
+song separates. The library panel subscribes to the queue's signals to
+show per-song progress; the main window finalizes or rolls back the
+library row when a job ends.
+
+Jobs run strictly serially: separation saturates either the CPU
+(HTDemucs) or the GPU (MDX), so overlapping jobs would only slow each
+other down and multiply peak memory.
+"""
+
+from collections import deque
+from dataclasses import dataclass
+
+from PySide6.QtCore import QObject, Signal
+
+from src.mdx_separator import MdxSeparatorWorker
+from src.qt_signal_utils import safe_disconnect as _safe_disconnect
+from src.separator import SeparatorWorker
+
+
+@dataclass
+class SeparationJob:
+    """One queued separation request."""
+
+    song_id: str
+    input_path: str
+    output_dir: str
+    model_path: str
+    model_key: str  # "htdemucs" | "htdemucs_6s" | "mdx_*"
+
+
+class SeparationQueue(QObject):
+    """Serial queue of separation jobs with per-song progress signals.
+
+    Signals:
+        job_queued(str): song_id -- accepted into the queue (fires for
+            every job, before job_started).
+        job_started(str): song_id -- a job's worker began running.
+        job_progress(str, int, str): song_id, percent, status message.
+        job_finished(str, str): song_id, model_key -- stems are on disk.
+        job_failed(str, str): song_id, error message. Emitted for real
+            failures and for cancellations (message contains
+            "cancelled"), so the owner can roll the row back either way.
+    """
+
+    job_queued = Signal(str)
+    job_started = Signal(str)
+    job_progress = Signal(str, int, str)
+    job_finished = Signal(str, str)
+    job_failed = Signal(str, str)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._pending: deque[SeparationJob] = deque()
+        self._active_job: SeparationJob | None = None
+        self._active_worker = None  # SeparatorWorker | MdxSeparatorWorker
+
+    # ------------------------------------------------------------------
+    # State
+    # ------------------------------------------------------------------
+
+    @property
+    def active_song_id(self) -> str | None:
+        """The song currently separating, or None when idle."""
+        return self._active_job.song_id if self._active_job else None
+
+    def is_song_pending(self, song_id: str) -> bool:
+        """True when *song_id* is separating now or waiting in the queue."""
+        if self._active_job and self._active_job.song_id == song_id:
+            return True
+        return any(j.song_id == song_id for j in self._pending)
+
+    @property
+    def pending_count(self) -> int:
+        """Number of jobs not yet finished (active + queued)."""
+        return len(self._pending) + (1 if self._active_job else 0)
+
+    # ------------------------------------------------------------------
+    # Operations
+    # ------------------------------------------------------------------
+
+    def enqueue(self, job: SeparationJob) -> None:
+        """Add a job; it starts immediately when the queue is idle."""
+        self._pending.append(job)
+        self.job_queued.emit(job.song_id)
+        if self._active_job is None:
+            self._start_next()
+
+    def cancel_song(self, song_id: str) -> None:
+        """Cancel *song_id*'s job, whether active or still queued.
+
+        A queued job is dropped synchronously (job_failed fires with a
+        cancellation message). Cancelling the active job asks the worker
+        to stop; its error path then reports through job_failed.
+        """
+        for job in list(self._pending):
+            if job.song_id == song_id:
+                self._pending.remove(job)
+                self.job_failed.emit(song_id, "Separation cancelled.")
+                return
+        if self._active_job and self._active_job.song_id == song_id:
+            if self._active_worker is not None:
+                self._active_worker.cancel()
+
+    def shutdown(self, wait_ms: int = 5000) -> None:
+        """Cancel the active job and drop queued ones (app close).
+
+        Interrupted songs are left without stems on disk; the startup
+        prune removes their library rows on the next launch.
+        """
+        self._pending.clear()
+        worker = self._active_worker
+        if worker is not None:
+            worker.cancel()
+            self._detach_active()
+            if worker.isRunning():
+                worker.wait(wait_ms)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _make_worker(self, job: SeparationJob):
+        if job.model_key.startswith("mdx_"):
+            return MdxSeparatorWorker(
+                input_path=job.input_path,
+                output_dir=job.output_dir,
+                model_path=job.model_path,
+                model_key=job.model_key,
+            )
+        return SeparatorWorker(
+            input_path=job.input_path,
+            output_dir=job.output_dir,
+            model_path=job.model_path,
+            is_6_stem=job.model_key == "htdemucs_6s",
+        )
+
+    def _start_next(self) -> None:
+        if not self._pending:
+            return
+        job = self._pending.popleft()
+        worker = self._make_worker(job)
+        self._active_job = job
+        self._active_worker = worker
+
+        sid = job.song_id
+        worker.progress.connect(
+            lambda pct, msg, s=sid: self.job_progress.emit(s, pct, msg)
+        )
+        # Both engines emit their custom `finished(dict)` on success and
+        # `error(str)` on failure/cancellation, exactly once.
+        worker.finished.connect(lambda _files: self._on_worker_done(None))
+        worker.error.connect(lambda msg: self._on_worker_done(msg))
+
+        self.job_started.emit(sid)
+        worker.start()
+
+    def _detach_active(self) -> None:
+        """Disconnect and release the active worker/job references."""
+        worker = self._active_worker
+        if worker is not None:
+            _safe_disconnect(worker.progress)
+            _safe_disconnect(worker.finished)
+            _safe_disconnect(worker.error)
+        self._active_job = None
+        self._active_worker = None
+
+    def _on_worker_done(self, error_message: str | None) -> None:
+        """Worker completed (successfully or not); report and advance."""
+        job = self._active_job
+        worker = self._active_worker
+        if job is None:
+            return
+        self._detach_active()
+
+        if worker is not None:
+            # run() has returned (the completion signal is its last act);
+            # wait for the OS thread to fully stop before deleteLater so
+            # Qt never reaps a live QThread.
+            if worker.isRunning():
+                worker.wait(5000)
+            worker.deleteLater()
+
+        if error_message is None:
+            self.job_finished.emit(job.song_id, job.model_key)
+        else:
+            self.job_failed.emit(job.song_id, error_message)
+
+        self._start_next()

--- a/src/ui/import_dialog.py
+++ b/src/ui/import_dialog.py
@@ -113,6 +113,7 @@ class ImportDialog(QDialog):
         model_manager: ModelManager,
         parent=None,
         file_path: str = "",
+        separation_queue=None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Import Song")
@@ -120,6 +121,13 @@ class ImportDialog(QDialog):
 
         self._library = library
         self._model_manager = model_manager
+        # When a SeparationQueue is provided (the main window always
+        # passes one), separation is handed off to it and the dialog
+        # closes immediately after acquisition + model download; the
+        # library row then shows live progress. Without a queue the
+        # dialog falls back to running the worker inline (blocking),
+        # which standalone/test usage relies on.
+        self._separation_queue = separation_queue
         self._worker: SeparatorWorker | MdxSeparatorWorker | None = None
         self._download_worker: _DownloadWorker | None = None
         self._metadata_worker: _MetadataWorker | None = None
@@ -514,15 +522,43 @@ class ImportDialog(QDialog):
         model_path: str,
         model_key: str,
     ) -> None:
-        """Run ONNX separation for a song that already has a model file."""
-        if model_key.startswith("mdx_"):
-            # MDX processes the track in small spectrogram windows; its
-            # peak memory is a few hundred MB regardless of track length,
-            # so the Demucs full-track RAM check doesn't apply.
-            self._progress_bar.setVisible(True)
-            self._status_label.setVisible(True)
-            self._button_box.setEnabled(False)
+        """Start separation: hand off to the queue, or run inline.
 
+        The RAM confirmation for the full-track Demucs engines happens
+        here in both cases -- it is a user prompt, so it must run while
+        the dialog is still up. MDX processes the track in small
+        spectrogram windows (a few hundred MB peak regardless of track
+        length), so the check doesn't apply to it.
+        """
+        if not model_key.startswith("mdx_"):
+            is_6_stem = model_key == "htdemucs_6s"
+            if not self._check_memory_ok(song.original_path, is_6_stem):
+                self._button_box.setEnabled(True)
+                return
+
+        if self._separation_queue is not None:
+            # Background path: enqueue and close. The song row is
+            # finalized (model_used) or rolled back by the main window
+            # when the queue reports the job's end; the dialog's own
+            # reject-time rollback must no longer touch it.
+            from src.separation_queue import SeparationJob
+
+            self._separation_queue.enqueue(SeparationJob(
+                song_id=song.id,
+                input_path=song.original_path,
+                output_dir=song.stems_path,
+                model_path=model_path,
+                model_key=model_key,
+            ))
+            self._import_song_id = None
+            self.accept()
+            return
+
+        self._progress_bar.setVisible(True)
+        self._status_label.setVisible(True)
+        self._button_box.setEnabled(False)
+
+        if model_key.startswith("mdx_"):
             self._worker = MdxSeparatorWorker(
                 input_path=song.original_path,
                 output_dir=song.stems_path,
@@ -530,20 +566,11 @@ class ImportDialog(QDialog):
                 model_key=model_key,
             )
         else:
-            is_6_stem = model_key == "htdemucs_6s"
-            if not self._check_memory_ok(song.original_path, is_6_stem):
-                self._button_box.setEnabled(True)
-                return
-
-            self._progress_bar.setVisible(True)
-            self._status_label.setVisible(True)
-            self._button_box.setEnabled(False)
-
             self._worker = SeparatorWorker(
                 input_path=song.original_path,
                 output_dir=song.stems_path,
                 model_path=model_path,
-                is_6_stem=is_6_stem,
+                is_6_stem=model_key == "htdemucs_6s",
             )
         self._worker.progress.connect(self._on_progress)
         self._worker.finished.connect(

--- a/src/ui/library_panel.py
+++ b/src/ui/library_panel.py
@@ -42,6 +42,9 @@ from src.ui.styles import DARK_COLORS, ON_ACCENT
 # Custom data roles for two-line display.
 _ARTIST_ROLE = Qt.ItemDataRole.UserRole + 1
 _TITLE_ROLE = Qt.ItemDataRole.UserRole + 2
+# Progress text while the song is still separating in the background
+# (e.g. "Separating... 42%"); unset/empty for ready songs.
+_PROGRESS_ROLE = Qt.ItemDataRole.UserRole + 3
 
 _CTRL_ICON = 18  # Icon size for library control buttons.
 _CTRL_BTN = 28   # Button size for library control buttons.
@@ -286,6 +289,17 @@ class _SongDelegate(QStyledItemDelegate):
             title,
         )
 
+        # Background-separation progress, right-aligned in accent color
+        # (e.g. "Separating... 42%").
+        progress = index.data(_PROGRESS_ROLE)
+        if progress:
+            painter.setPen(QColor(self._accent_color))
+            painter.drawText(
+                title_rect,
+                Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter,
+                progress,
+            )
+
         # Separator line at the bottom of each item.
         painter.setPen(QPen(self._separator_color, 1))
         y = option.rect.bottom()
@@ -363,6 +377,7 @@ class LibraryPanel(QWidget):
 
     song_selected = Signal(str)
     song_removed = Signal(str)  # emitted with the removed song's id
+    cancel_separation_requested = Signal(str)  # song_id still separating
     repeat_mode_changed = Signal(str)
     shuffle_toggled = Signal(bool)
     previous_requested = Signal()
@@ -374,6 +389,10 @@ class LibraryPanel(QWidget):
         self._repeat_mode: str = REPEAT_OFF
         self._shuffle_enabled: bool = False
         self._ctrl_accent: str = DARK_COLORS["accent"]
+        # song_id -> progress text for songs still separating in the
+        # background. Rows in this state are unselectable (their stems
+        # are half-written) and offer only "Cancel separation".
+        self._separating: dict[str, str] = {}
 
         self._setup_ui()
         self.refresh()
@@ -589,8 +608,53 @@ class LibraryPanel(QWidget):
             item.setData(Qt.ItemDataRole.UserRole, song.id)
             item.setData(_ARTIST_ROLE, song.artist)
             item.setData(_TITLE_ROLE, song.title)
+            self._apply_separating_state(item, song.id)
             self._list.addItem(item)
         self._apply_filter(self._search_edit.text())
+
+    # ------------------------------------------------------------------
+    # Background-separation state
+    # ------------------------------------------------------------------
+
+    def set_song_separating(self, song_id: str, text: str) -> None:
+        """Mark *song_id* as separating and show *text* on its row."""
+        self._separating[song_id] = text
+        item = self._item_for_song(song_id)
+        if item is not None:
+            self._apply_separating_state(item, song_id)
+
+    def clear_song_separating(self, song_id: str) -> None:
+        """Return *song_id*'s row to the normal, selectable state."""
+        self._separating.pop(song_id, None)
+        item = self._item_for_song(song_id)
+        if item is not None:
+            self._apply_separating_state(item, song_id)
+
+    def is_song_separating(self, song_id: str) -> bool:
+        """True while *song_id* is separating in the background."""
+        return song_id in self._separating
+
+    def _item_for_song(self, song_id: str) -> QListWidgetItem | None:
+        for i in range(self._list.count()):
+            item = self._list.item(i)
+            if item.data(Qt.ItemDataRole.UserRole) == song_id:
+                return item
+        return None
+
+    def _apply_separating_state(self, item: QListWidgetItem, song_id: str) -> None:
+        """Sync an item's progress role and selectability with the state.
+
+        Separating rows are made unselectable at the Qt level: their
+        stems are half-written, so loading (or removing) them must be
+        impossible until the job ends.
+        """
+        text = self._separating.get(song_id)
+        item.setData(_PROGRESS_ROLE, text or None)
+        flags = item.flags()
+        if text:
+            item.setFlags(flags & ~Qt.ItemFlag.ItemIsSelectable)
+        else:
+            item.setFlags(flags | Qt.ItemFlag.ItemIsSelectable)
 
     def song_count(self) -> int:
         """Return the number of songs in the library."""
@@ -626,7 +690,9 @@ class LibraryPanel(QWidget):
     def _on_item_changed(self, current: QListWidgetItem | None, _previous) -> None:
         if current is not None:
             song_id = current.data(Qt.ItemDataRole.UserRole)
-            if song_id:
+            # Separating rows are unselectable at the flag level; this
+            # guard covers programmatic setCurrentItem paths as well.
+            if song_id and not self.is_song_separating(song_id):
                 self.song_selected.emit(song_id)
                 self._remove_btn.setEnabled(True)
         else:
@@ -636,6 +702,16 @@ class LibraryPanel(QWidget):
         """Show a right-click context menu on the song list."""
         item = self._list.itemAt(pos)
         if item is None:
+            return
+        song_id = item.data(Qt.ItemDataRole.UserRole)
+        if song_id and self.is_song_separating(song_id):
+            # The only sensible action on a half-separated song is to
+            # abort the job (the main window rolls the row back).
+            menu = QMenu(self)
+            menu.addAction("Cancel separation").triggered.connect(
+                lambda: self.cancel_separation_requested.emit(song_id)
+            )
+            menu.exec(self._list.mapToGlobal(pos))
             return
         # Select the right-clicked item so _on_edit_song targets it,
         # not whatever was previously selected.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -51,6 +51,7 @@ from src.app_settings import (
 from src.data_paths import consume_data_dir_reset_notice
 from src.exporter import ExportWorker, StemExporter
 from src.library import SongLibrary
+from src.separation_queue import SeparationQueue
 from src.model_manager import ModelManager
 from src.player import (
     PITCH_MAX_SEMITONES,
@@ -127,11 +128,18 @@ class MainWindow(QMainWindow):
         self._shuffle_queue: list[str] = []
         self._volume_toast: QLabel | None = None
         self._volume_toast_timer: QTimer | None = None
+        self._separation_queue = SeparationQueue(self)
 
         self._settings = QSettings("stemma", "stemma")
         self._theme = self._settings.value("theme", "dark")
         if self._theme not in ("dark", "light"):
             self._theme = "dark"
+
+        # Remove library rows whose separation never finished (the app
+        # was closed or crashed mid-job): their dirs hold no stems, so
+        # the rows would be unplayable ghosts. Mirrors the import
+        # dialog's failure rollback, across process restarts.
+        self._prune_incomplete_songs()
 
         self._setup_ui()
         self._setup_menu()
@@ -962,6 +970,10 @@ class MainWindow(QMainWindow):
         if self._export_worker is not None and self._export_worker.isRunning():
             self._export_worker.wait(5000)
 
+        # Abort any background separation; interrupted songs are pruned
+        # from the library on the next launch (no stems on disk).
+        self._separation_queue.shutdown(5000)
+
         self._player.stop()
         # Cancel and drain stretch/peak workers *before* Qt tears down,
         # otherwise Python's atexit blocks in ThreadPoolExecutor.join()
@@ -980,6 +992,26 @@ class MainWindow(QMainWindow):
         """Wire up signals between panels."""
         self._library_panel.song_selected.connect(self._on_song_selected)
         self._library_panel.song_removed.connect(self._on_song_removed)
+        self._library_panel.cancel_separation_requested.connect(
+            self._separation_queue.cancel_song
+        )
+        self._separation_queue.job_queued.connect(
+            lambda sid: self._library_panel.set_song_separating(
+                sid, "Queued..."
+            )
+        )
+        self._separation_queue.job_started.connect(
+            lambda sid: self._library_panel.set_song_separating(
+                sid, "Separating..."
+            )
+        )
+        self._separation_queue.job_progress.connect(
+            self._on_separation_progress
+        )
+        self._separation_queue.job_finished.connect(
+            self._on_separation_finished
+        )
+        self._separation_queue.job_failed.connect(self._on_separation_failed)
         self._library_panel.previous_requested.connect(
             lambda: self._advance_song(-1)
         )
@@ -1360,9 +1392,67 @@ class MainWindow(QMainWindow):
             model_manager=self._model_manager,
             parent=self,
             file_path=file_path,
+            separation_queue=self._separation_queue,
         )
         if dialog.exec():
+            # The new row appears immediately; while its job runs it
+            # shows queue-driven progress and stays unselectable.
             self._library_panel.refresh()
+
+    # ------------------------------------------------------------------
+    # Background separation queue
+    # ------------------------------------------------------------------
+
+    def _prune_incomplete_songs(self) -> None:
+        """Remove library rows whose song dir contains no stems at all.
+
+        A row without stems can only come from a separation that never
+        finished (app closed or crashed mid-job); keeping it would show
+        an unplayable ghost entry.
+        """
+        for song in list(self._library.songs):
+            has_stems = any(
+                os.path.isfile(os.path.join(song.stems_path, f"{name}.wav"))
+                for name in ALL_STEM_NAMES
+            )
+            if not has_stems:
+                try:
+                    self._library.remove_song(song.id)
+                except KeyError:
+                    pass
+
+    def _on_separation_progress(
+        self, song_id: str, percent: int, _message: str,
+    ) -> None:
+        self._library_panel.set_song_separating(
+            song_id, f"Separating... {percent}%"
+        )
+
+    def _on_separation_finished(self, song_id: str, model_key: str) -> None:
+        """Job done: record the model and make the row selectable."""
+        try:
+            self._library.update_song(song_id, model_used=model_key)
+        except KeyError:
+            pass  # Row removed while the job was finishing.
+        self._library_panel.clear_song_separating(song_id)
+        self._library_panel.refresh()
+
+    def _on_separation_failed(self, song_id: str, message: str) -> None:
+        """Job failed or was cancelled: roll the library row back."""
+        self._library_panel.clear_song_separating(song_id)
+        if self._library.get_song(song_id) is not None:
+            try:
+                self._library.remove_song(song_id)
+            except KeyError:
+                pass
+        self._library_panel.refresh()
+        # User-initiated cancellations need no dialog; real failures do.
+        if "cancelled" not in message.lower():
+            QMessageBox.warning(
+                self,
+                "Import failed",
+                f"Stem separation did not complete:\n{message}",
+            )
 
     # ------------------------------------------------------------------
     # Drag-and-drop import

--- a/tests/test_separation_queue.py
+++ b/tests/test_separation_queue.py
@@ -1,0 +1,371 @@
+"""Tests for the background separation queue and its UI integration.
+
+Workers are replaced with synchronous fakes: `start()` runs the fake
+inline and emits like the real engines (progress, then finished(dict)
+or error(str) exactly once), so queue behavior is tested without audio
+or models.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtWidgets import QApplication
+
+from src.separation_queue import SeparationJob, SeparationQueue
+
+
+@pytest.fixture(scope="module")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+class _FakeWorker(QObject):
+    """Stands in for SeparatorWorker / MdxSeparatorWorker.
+
+    By default completes successfully the moment start() is called.
+    Set ``outcome`` to "error" for failure, or "hold" to stay 'running'
+    until finish()/fail() is called manually (simulates a long job).
+    """
+
+    progress = Signal(int, str)
+    finished = Signal(dict)
+    error = Signal(str)
+
+    def __init__(self, job, outcome="success"):
+        super().__init__()
+        self.job = job
+        self.outcome = outcome
+        self.cancelled = False
+        self._running = False
+
+    def start(self):
+        self._running = True
+        self.progress.emit(50, "half way")
+        if self.outcome == "success":
+            self.finish()
+        elif self.outcome == "error":
+            self.fail("boom")
+        # "hold": stay running until told otherwise.
+
+    def finish(self):
+        self._running = False
+        self.finished.emit({"vocals": "v.wav"})
+
+    def fail(self, msg):
+        self._running = False
+        self.error.emit(msg)
+
+    def cancel(self):
+        self.cancelled = True
+        # Real engines notice the flag between windows and emit error.
+        if self._running:
+            self.fail("Separation cancelled by user.")
+
+    def isRunning(self):
+        return self._running
+
+    def wait(self, _ms=0):
+        return True
+
+    def deleteLater(self):  # noqa: D401 (QObject API)
+        pass
+
+
+def _job(song_id, model_key="mdx_inst_hq3"):
+    return SeparationJob(
+        song_id=song_id, input_path="in.mp3", output_dir="out",
+        model_path="m.onnx", model_key=model_key,
+    )
+
+
+@pytest.fixture
+def queue_and_log(app):
+    """A queue whose workers are fakes, plus a signal log."""
+    q = SeparationQueue()
+    log = []
+    q.job_queued.connect(lambda s: log.append(("queued", s)))
+    q.job_started.connect(lambda s: log.append(("started", s)))
+    q.job_progress.connect(lambda s, p, m: log.append(("progress", s, p)))
+    q.job_finished.connect(lambda s, k: log.append(("finished", s, k)))
+    q.job_failed.connect(lambda s, m: log.append(("failed", s, m)))
+
+    made = []
+
+    def fake_make(job, outcome_by_song=None):
+        w = _FakeWorker(job, (outcome_by_song or {}).get(job.song_id, "success"))
+        made.append(w)
+        return w
+
+    q._outcomes = {}
+    q._make_worker = lambda job: fake_make(job, q._outcomes)
+    q._made_workers = made
+    return q, log
+
+
+class TestQueueSequencing:
+    def test_single_job_full_lifecycle(self, queue_and_log):
+        q, log = queue_and_log
+        q.enqueue(_job("a"))
+        assert log == [
+            ("queued", "a"), ("started", "a"), ("progress", "a", 50),
+            ("finished", "a", "mdx_inst_hq3"),
+        ]
+        assert q.pending_count == 0
+        assert not q.is_song_pending("a")
+
+    def test_two_jobs_run_serially_in_order(self, queue_and_log):
+        q, log = queue_and_log
+        q._outcomes = {"a": "hold"}
+        q.enqueue(_job("a"))
+        q.enqueue(_job("b"))
+        # b waits while a runs.
+        assert q.is_song_pending("b")
+        assert q.active_song_id == "a"
+        assert not any(e[0] == "started" and e[1] == "b" for e in log)
+
+        q._made_workers[0].finish()
+
+        assert ("finished", "a", "mdx_inst_hq3") in log
+        assert ("started", "b") in log
+        assert ("finished", "b", "mdx_inst_hq3") in log
+        assert q.pending_count == 0
+
+    def test_failed_job_does_not_block_next(self, queue_and_log):
+        q, log = queue_and_log
+        q._outcomes = {"a": "error"}
+        q.enqueue(_job("a"))
+        q.enqueue(_job("b"))
+        assert ("failed", "a", "boom") in log
+        assert ("finished", "b", "mdx_inst_hq3") in log
+
+    def test_model_key_passed_through(self, queue_and_log):
+        q, log = queue_and_log
+        q.enqueue(_job("a", model_key="htdemucs_6s"))
+        assert ("finished", "a", "htdemucs_6s") in log
+
+
+class TestQueueCancel:
+    def test_cancel_queued_job_drops_it(self, queue_and_log):
+        q, log = queue_and_log
+        q._outcomes = {"a": "hold"}
+        q.enqueue(_job("a"))
+        q.enqueue(_job("b"))
+
+        q.cancel_song("b")
+
+        assert any(
+            e[0] == "failed" and e[1] == "b" and "cancelled" in e[2].lower()
+            for e in log
+        )
+        assert not q.is_song_pending("b")
+        # a is untouched.
+        assert q.active_song_id == "a"
+
+    def test_cancel_active_job_cancels_worker(self, queue_and_log):
+        q, log = queue_and_log
+        q._outcomes = {"a": "hold"}
+        q.enqueue(_job("a"))
+
+        q.cancel_song("a")
+
+        worker = q._made_workers[0]
+        assert worker.cancelled
+        assert any(
+            e[0] == "failed" and e[1] == "a" and "cancelled" in e[2].lower()
+            for e in log
+        )
+        assert q.active_song_id is None
+
+    def test_cancel_unknown_song_is_noop(self, queue_and_log):
+        q, log = queue_and_log
+        q.cancel_song("ghost")
+        assert log == []
+
+
+class TestQueueShutdown:
+    def test_shutdown_cancels_active_and_drops_queued(self, queue_and_log):
+        q, log = queue_and_log
+        q._outcomes = {"a": "hold"}
+        q.enqueue(_job("a"))
+        q.enqueue(_job("b"))
+
+        q.shutdown(wait_ms=10)
+
+        worker = q._made_workers[0]
+        assert worker.cancelled
+        assert q.pending_count == 0
+        # Shutdown is silent: detached before the cancel lands, queued
+        # jobs dropped without signals (the app is closing).
+        assert not any(e[0] == "finished" for e in log)
+
+
+class TestWorkerSelection:
+    def test_mdx_key_builds_mdx_worker(self, app):
+        q = SeparationQueue()
+        with patch("src.separation_queue.MdxSeparatorWorker") as mdx_cls, \
+             patch("src.separation_queue.SeparatorWorker") as demucs_cls:
+            q._make_worker(_job("a", model_key="mdx_inst_hq3"))
+            mdx_cls.assert_called_once()
+            demucs_cls.assert_not_called()
+
+    def test_demucs_keys_build_demucs_worker(self, app):
+        q = SeparationQueue()
+        with patch("src.separation_queue.MdxSeparatorWorker") as mdx_cls, \
+             patch("src.separation_queue.SeparatorWorker") as demucs_cls:
+            q._make_worker(_job("a", model_key="htdemucs_6s"))
+            demucs_cls.assert_called_once()
+            assert demucs_cls.call_args.kwargs["is_6_stem"] is True
+            mdx_cls.assert_not_called()
+
+
+class TestDialogHandoff:
+    """With a queue, the dialog enqueues and closes instead of running
+    the worker inline."""
+
+    def test_dialog_enqueues_and_accepts(self, app, tmp_path):
+        from src.ui.import_dialog import ImportDialog
+
+        library = MagicMock()
+        mm = MagicMock()
+        queue = MagicMock()
+        dlg = ImportDialog(library, mm, separation_queue=queue)
+
+        song = MagicMock()
+        song.id = "s1"
+        song.original_path = str(tmp_path / "in.mp3")
+        song.stems_path = str(tmp_path / "stems")
+
+        with patch.object(dlg, "accept") as accept:
+            dlg._start_separation_worker(song, "model.onnx", "mdx_inst_hq3")
+
+        queue.enqueue.assert_called_once()
+        job = queue.enqueue.call_args.args[0]
+        assert job.song_id == "s1"
+        assert job.model_key == "mdx_inst_hq3"
+        accept.assert_called_once()
+        # The dialog must not treat the song as its own rollback target
+        # anymore -- the queue owns the outcome now.
+        assert dlg._import_song_id is None
+        assert dlg._worker is None
+
+    def test_dialog_without_queue_runs_inline(self, app, tmp_path):
+        from src.ui.import_dialog import ImportDialog
+
+        library = MagicMock()
+        mm = MagicMock()
+        dlg = ImportDialog(library, mm)
+
+        song = MagicMock()
+        song.id = "s1"
+        song.original_path = str(tmp_path / "in.mp3")
+        song.stems_path = str(tmp_path / "stems")
+
+        with patch(
+            "src.ui.import_dialog.MdxSeparatorWorker"
+        ) as worker_cls:
+            dlg._start_separation_worker(song, "model.onnx", "mdx_inst_hq3")
+        worker_cls.assert_called_once()
+        worker_cls.return_value.start.assert_called_once()
+
+
+class TestLibraryPanelSeparatingState:
+    def _panel(self, app):
+        from src.ui.library_panel import LibraryPanel
+
+        library = MagicMock()
+        song = MagicMock()
+        song.id = "s1"
+        song.artist = "a"
+        song.title = "t"
+        library.songs = [song]
+        return LibraryPanel(library)
+
+    def test_separating_row_is_unselectable(self, app):
+        from PySide6.QtCore import Qt
+
+        panel = self._panel(app)
+        panel.set_song_separating("s1", "Separating... 10%")
+        item = panel._item_for_song("s1")
+        assert not (item.flags() & Qt.ItemFlag.ItemIsSelectable)
+        assert panel.is_song_separating("s1")
+
+        panel.clear_song_separating("s1")
+        item = panel._item_for_song("s1")
+        assert item.flags() & Qt.ItemFlag.ItemIsSelectable
+        assert not panel.is_song_separating("s1")
+
+    def test_state_survives_refresh(self, app):
+        from PySide6.QtCore import Qt
+
+        panel = self._panel(app)
+        panel.set_song_separating("s1", "Separating... 10%")
+        panel.refresh()
+        item = panel._item_for_song("s1")
+        assert not (item.flags() & Qt.ItemFlag.ItemIsSelectable)
+
+    def test_select_song_refuses_separating_row(self, app):
+        panel = self._panel(app)
+        panel.set_song_separating("s1", "Separating...")
+        selected = []
+        panel.song_selected.connect(lambda s: selected.append(s))
+        panel.select_song("s1")
+        assert selected == []
+
+
+class TestMainWindowGlue:
+    """Stub-based checks of the queue handlers (no full window)."""
+
+    def test_finished_records_model_and_clears_state(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        MainWindow._on_separation_finished(stub, "s1", "mdx_inst_hq3")
+        stub._library.update_song.assert_called_once_with(
+            "s1", model_used="mdx_inst_hq3"
+        )
+        stub._library_panel.clear_song_separating.assert_called_once_with("s1")
+        stub._library_panel.refresh.assert_called_once()
+
+    def test_failed_rolls_back_row(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        stub._library.get_song.return_value = MagicMock()
+        with patch("src.ui.main_window.QMessageBox") as mb:
+            MainWindow._on_separation_failed(stub, "s1", "boom")
+        stub._library.remove_song.assert_called_once_with("s1")
+        mb.warning.assert_called_once()
+
+    def test_cancelled_failure_shows_no_dialog(self, app):
+        from src.ui.main_window import MainWindow
+
+        stub = MagicMock()
+        stub._library.get_song.return_value = MagicMock()
+        with patch("src.ui.main_window.QMessageBox") as mb:
+            MainWindow._on_separation_failed(
+                stub, "s1", "Separation cancelled by user."
+            )
+        stub._library.remove_song.assert_called_once_with("s1")
+        mb.warning.assert_not_called()
+
+    def test_prune_removes_stemless_songs(self, app, tmp_path):
+        from src.ui.main_window import MainWindow
+
+        good = MagicMock()
+        good.id = "good"
+        good.stems_path = str(tmp_path / "good")
+        os.makedirs(good.stems_path)
+        open(os.path.join(good.stems_path, "vocals.wav"), "wb").close()
+
+        ghost = MagicMock()
+        ghost.id = "ghost"
+        ghost.stems_path = str(tmp_path / "ghost")
+        os.makedirs(ghost.stems_path)
+
+        stub = MagicMock()
+        stub._library.songs = [good, ghost]
+        MainWindow._prune_incomplete_songs(stub)
+
+        stub._library.remove_song.assert_called_once_with("ghost")


### PR DESCRIPTION
## Summary

Stacked on #128 (merge that first; GitHub will retarget this to main automatically). Second slice of v3.0 Phase 1 — the practical core of the reframed #13.

**Importing no longer blocks the app.** After picking the file and model (and any first-time model download), the import dialog closes immediately and separation runs in a background queue:

- The library row appears at once and shows live **"Queued... / Separating... N%"** progress in accent color.
- The row is **unselectable at the Qt flag level** until its stems exist (they're half-written on disk), and right-click offers **"Cancel separation"**.
- Failures roll the row back with a warning; user cancellations roll back silently.
- Multiple imports queue serially (separation saturates CPU or GPU; overlapping jobs would just slow each other down).
- App close drains the queue; songs interrupted by a crash are pruned at the next launch (stem-less ghost rows).

Combined with #128's GPU path, a 2-stem import now feels near-instant: dialog closes in ~10 ms and the song is ready seconds later.

### Design notes
- `SeparationQueue` is engine-agnostic (drives both `SeparatorWorker` and `MdxSeparatorWorker` through their identical signal contracts).
- The dialog keeps its inline (blocking) path when constructed without a queue — standalone/test usage unchanged.
- The Demucs RAM confirmation still happens in the dialog (it's a user prompt), before handoff.

### Test plan
- [x] 866 fast tests pass (+19: queue sequencing/cancel/failure/shutdown, worker selection, dialog handoff both modes, panel state + selection guards, MainWindow finish/rollback/prune)
- [x] GUI-level E2E with the real MDX model: dialog closed in 0.01 s, row locked with live progress, background job completed, row unlocked with stems on disk