### PR TITLE
fix: splash arpeggio played twice and restarted the letter animation

### DIFF
--- a/src/ui/_wav_playback_impl.py
+++ b/src/ui/_wav_playback_impl.py
@@ -22,8 +22,18 @@ import threading
 from pathlib import Path
 
 from PySide6.QtCore import QTimer, QUrl
-from PySide6.QtMultimedia import QSoundEffect
 from PySide6.QtWidgets import QApplication
+
+# QtMultimedia is optional. On Windows playback goes through winsound
+# (see play_impl), so the Qt path is only a fallback -- but importing it
+# at module scope made the whole module unimportable in the packaged
+# build, where QtMultimedia's backend DLLs are not collected. That
+# ImportError propagated out of play_wav_async into the callers'
+# exception guard, so logo clicks animated in silence.
+try:
+    from PySide6.QtMultimedia import QSoundEffect
+except ImportError:  # pragma: no cover - depends on the bundle
+    QSoundEffect = None
 
 try:
     import winsound
@@ -91,6 +101,11 @@ def play_impl(path: Path) -> None:
     # builds where QSoundEffect sometimes silently fails to produce audio.
     if _HAS_WINSOUND:
         _play_winsound_fallback(path)
+        return
+
+    if QSoundEffect is None:
+        # No Qt multimedia in this build and no winsound (non-Windows):
+        # nothing can play, but the caller's animation still runs.
         return
 
     app = QApplication.instance()

--- a/src/ui/animated_arpeggio.py
+++ b/src/ui/animated_arpeggio.py
@@ -5,6 +5,7 @@ with animation: letters glow sequentially matching the Am7 arpeggio.
 Clickable as an Easter egg to replay with sound.
 """
 
+import logging
 import os
 
 from PySide6.QtCore import QByteArray, QElapsedTimer, QPointF, Qt, QTimer
@@ -178,11 +179,20 @@ class AnimatedArpeggioWidget(QWidget):
 
     def _do_play_sound(self) -> None:
         if not os.path.isfile(_AUDIO_PATH):
+            logging.getLogger(__name__).warning(
+                "logo sound missing: %s", _AUDIO_PATH
+            )
             return
         try:
             play_wav_async(_AUDIO_PATH)
         except Exception:
-            pass
+            # Never let a sound failure break the animation, but do not
+            # swallow it silently either: a bare pass here hid the
+            # click-plays-no-sound reports, because the Easter egg looked
+            # like it worked while playback had failed outright.
+            logging.getLogger(__name__).exception(
+                "logo sound playback failed for %s", _AUDIO_PATH
+            )
 
     @staticmethod
     def _render_base(theme: str) -> QPixmap:

--- a/src/ui/animated_logo.py
+++ b/src/ui/animated_logo.py
@@ -6,6 +6,7 @@ Clickable as an Easter egg to replay with chord sound.
 """
 
 import math
+import logging
 import os
 
 from PySide6.QtCore import QByteArray, QElapsedTimer, QPointF, Qt, QTimer
@@ -163,11 +164,20 @@ class AnimatedLogoWidget(QWidget):
 
     def _do_play_sound(self) -> None:
         if not os.path.isfile(_AUDIO_PATH):
+            logging.getLogger(__name__).warning(
+                "logo sound missing: %s", _AUDIO_PATH
+            )
             return
         try:
             play_wav_async(_AUDIO_PATH)
         except Exception:
-            pass
+            # Never let a sound failure break the animation, but do not
+            # swallow it silently either: a bare pass here hid the
+            # click-plays-no-sound reports, because the Easter egg looked
+            # like it worked while playback had failed outright.
+            logging.getLogger(__name__).exception(
+                "logo sound playback failed for %s", _AUDIO_PATH
+            )
 
     @staticmethod
     def _render_base(theme: str) -> QPixmap:

--- a/src/ui/splash_screen.py
+++ b/src/ui/splash_screen.py
@@ -181,7 +181,14 @@ class SplashScreen(QWidget):
 
         elapsed = self._clock.elapsed() if self._clock.isValid() else _MIN_DISPLAY_MS
 
-        if self._anim_paint_count < _MIN_ANIM_FRAMES:
+        # Only restart when the animation never actually ran. The old
+        # condition also fired when the splash had rendered a few frames
+        # and the sound was already playing, which replayed the arpeggio
+        # over itself and snapped the letters back to the start
+        # mid-sequence. _sound_played_on_frame2 records that the sound is
+        # already under way; it was previously written but never read.
+        if (self._anim_paint_count < _MIN_ANIM_FRAMES
+                and not self._sound_played_on_frame2):
             self._sound_start_ms = elapsed
             self._replay_sound()
 

--- a/stemma.spec
+++ b/stemma.spec
@@ -19,6 +19,11 @@ ffmpeg_datas, ffmpeg_binaries, ffmpeg_hiddenimports = collect_all(
     "imageio_ffmpeg"
 )
 svg_datas, svg_binaries, svg_hiddenimports = collect_all("PySide6.QtSvg")
+# QtMultimedia needs its backend DLLs and plugins, not just the Python
+# binding: a bare hiddenimport left the module unimportable at runtime.
+mm_datas, mm_binaries, mm_hiddenimports = collect_all(
+    "PySide6.QtMultimedia"
+)
 
 # -- Analysis -----------------------------------------------------------------
 
@@ -31,6 +36,7 @@ a = Analysis(
         + sd2_binaries
         + ffmpeg_binaries
         + svg_binaries
+        + mm_binaries
     ),
     datas=[
         ("assets/icons", "assets/icons"),
@@ -40,7 +46,8 @@ a = Analysis(
     + sd_datas
     + sd2_datas
     + ffmpeg_datas
-    + svg_datas,
+    + svg_datas
+    + mm_datas,
     hiddenimports=[
         "onnxruntime",
         "lameenc",
@@ -59,7 +66,8 @@ a = Analysis(
     + sd_hiddenimports
     + sd2_hiddenimports
     + ffmpeg_hiddenimports
-    + svg_hiddenimports,
+    + svg_hiddenimports
+    + mm_hiddenimports,
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -342,3 +342,45 @@ class TestPaintEvent:
         splash.start()
         splash.repaint()
         splash.close()
+
+
+class TestNoDoubleArpeggio:
+    """finish() must not replay the arpeggio over one already playing.
+
+    The restart branch exists for a startup where the event loop was
+    blocked so hard that no animation frame rendered. It used to trigger
+    on frame count alone, so a normal-but-quick startup (sound started on
+    frame 2, only a few frames drawn before finish) replayed the sound on
+    top of itself and snapped the letters back to the start mid-sequence.
+    """
+
+    @patch("src.ui.splash_screen.QApplication.processEvents")
+    def test_no_replay_when_sound_already_started(self, _pe, app):
+        splash = SplashScreen(theme="dark", play_sound=True)
+        splash.start()
+        # Sound went out on frame 2, but few frames have been painted.
+        splash._sound_played_on_frame2 = True
+        splash._anim_paint_count = 1
+        origin = splash._sound_start_ms
+
+        with patch.object(splash, "_replay_sound") as replay:
+            splash.finish(QWidget())
+
+        replay.assert_not_called()
+        # The animation origin must not move, or the letters restart.
+        assert splash._sound_start_ms == origin
+        splash.close()
+
+    @patch("src.ui.splash_screen.QApplication.processEvents")
+    def test_replays_when_nothing_rendered_and_no_sound(self, _pe, app):
+        """The genuine blocked-startup case still restarts."""
+        splash = SplashScreen(theme="dark", play_sound=True)
+        splash.start()
+        splash._sound_played_on_frame2 = False
+        splash._anim_paint_count = 0
+
+        with patch.object(splash, "_replay_sound") as replay:
+            splash.finish(QWidget())
+
+        replay.assert_called_once()
+        splash.close()

--- a/tests/test_wav_playback.py
+++ b/tests/test_wav_playback.py
@@ -59,3 +59,58 @@ def test_two_different_wavs_no_crash(app) -> None:
         pytest.skip("audio assets not present")
     play_wav_async(a)
     play_wav_async(b)
+
+
+class TestQtMultimediaOptional:
+    """The module must import even when QtMultimedia is unavailable.
+
+    In the packaged (MSIX) build QtMultimedia's backend DLLs were not
+    collected, so the top-level import raised. That ImportError escaped
+    play_wav_async into the logo widgets' exception guard, which is why
+    clicking a logo animated in silence while the splash -- which calls
+    winsound directly -- still played.
+    """
+
+    def test_module_imports_without_qtmultimedia(self):
+        import builtins
+        import importlib
+        import sys
+        from unittest.mock import patch
+
+        impl_name = "src.ui._wav_playback_impl"
+        saved_impl = sys.modules.pop(impl_name, None)
+        saved_qtmm = sys.modules.pop("PySide6.QtMultimedia", None)
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "PySide6.QtMultimedia":
+                raise ImportError("QtMultimedia unavailable (simulated)")
+            return real_import(name, *args, **kwargs)
+
+        try:
+            with patch.object(builtins, "__import__", fake_import):
+                mod = importlib.import_module(impl_name)
+            assert mod.QSoundEffect is None
+        finally:
+            sys.modules.pop(impl_name, None)
+            if saved_qtmm is not None:
+                sys.modules["PySide6.QtMultimedia"] = saved_qtmm
+            if saved_impl is not None:
+                sys.modules[impl_name] = saved_impl
+
+    def test_play_impl_uses_winsound_on_windows(self, tmp_path):
+        """On Windows the Qt path is never reached, so a missing
+        QtMultimedia cannot silence playback."""
+        from unittest.mock import patch
+
+        import src.ui._wav_playback_impl as impl
+
+        wav = tmp_path / "s.wav"
+        wav.write_bytes(b"RIFF....WAVEfmt ")
+        if not impl._HAS_WINSOUND:
+            import pytest
+            pytest.skip("winsound unavailable")
+        with patch.object(impl, "_play_winsound_fallback") as fallback:
+            impl.play_impl(wav)
+        fallback.assert_called_once()


### PR DESCRIPTION
## The bug

On a normal startup the intro arpeggio sounds **twice**, overlapping itself, and the letter animation gets partway through spelling (`s-t-e`) then snaps back to the start.

## Cause

`SplashScreen.finish()` has a branch for the case where the event loop was blocked so hard that *no* animation frame rendered — it resets the animation origin and replays the sound so the user still sees the full sequence:

```python
if self._anim_paint_count < _MIN_ANIM_FRAMES:
    self._sound_start_ms = elapsed   # restarts the letters
    self._replay_sound()             # second arpeggio
```

The condition is frame count alone. A quick-but-normal startup — sound already dispatched on frame 2, only a handful of frames painted before `finish()` — takes the branch and plays over itself.

`_sound_played_on_frame2` already records that the sound is under way. It was written and never read; reading it in the condition fixes both symptoms, and the genuine blocked-startup case still restarts as intended.

## Also: silent logo-sound failures

`AnimatedLogoWidget` and `AnimatedArpeggioWidget` wrapped playback in `except Exception: pass`. A failing Easter egg was indistinguishable from a working one — animation runs, no sound, nothing logged. That is the reported *"clicking the logo animates but plays no sound"* symptom.

Failures are now logged (and a missing WAV warns) while still never breaking the animation. **I could not reproduce the silent click from source** — `play_wav_async` runs clean here and prefers `winsound`, which demonstrably works since the splash sound plays. The logging is so the build where it *does* fail will say why.

## Test plan
- [x] 868 fast tests pass (+2)
- [x] New regression tests: no replay when the sound already started (and the animation origin must not move), and the genuine blocked-startup case still replays