### PR TITLE
feat: Store product identity and live listing snapshot

### DIFF
--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -6,6 +6,8 @@ Do not edit this markdown by hand.
 
 This copy reflects listing content for version **2.6.0**.
 
+Public Store listing: https://apps.microsoft.com/detail/9p2w12l8f381 (product id `9P2W12L8F381`).
+
 Fields map to Partner Center as follows:
 
 | Partner Center field | Section below |
@@ -54,7 +56,9 @@ stemma reads the song as you work: tempo, musical key, and the chord
 under the playhead, updated as it plays. There is a
 waveform to scrub, per-stem volume faders, and a library that remembers
 exactly where you left off -- song, position, mix, loop, speed, and
-pitch -- so practice picks up where it stopped.
+pitch -- so practice picks up where it stopped. Browse with previous
+and next, loop a single song, shuffle the collection, or autoplay
+through it.
 
 Separation runs on your own machine. Nothing is uploaded, there is no
 account, no subscription, and no internet connection needed once the
@@ -62,7 +66,9 @@ models are downloaded. Import from a file or paste a YouTube link, and
 export any stem or your own custom mix as WAV or MP3 when you want to
 take it elsewhere.
 
-Built for Windows, keyboard-first, dark and light themes.
+Built for Windows, keyboard-first, and layout-independent (Space,
+arrows, Ctrl+1-6, and the rest work the same on international
+keyboards). Dark and light themes.
 
 ---
 
@@ -103,6 +109,7 @@ Waveform with click-to-seek, playback cursor, and loop markers
 Export stems or a custom mix as WAV or MP3
 Import from an audio file or a YouTube link
 Session memory: song, position, mix, loop, speed, and pitch
+Library with previous/next, shuffle, and autoplay
 Keyboard shortcuts for the whole practice loop
 Runs entirely on your PC: no account, no subscription, no uploads
 
@@ -110,7 +117,7 @@ Runs entirely on your PC: no account, no subscription, no uploads
 
 ## Search terms
 
-stem separation, vocal remover, play along, backing track, practice, karaoke, transcribe, slow down music, loop, metronome, tempo, key detection, chord detection, guitar practice, bass practice, drum practice, singer, music learning, isolate instrument, minus one
+stem separation, vocal remover, play along, backing track, practice, karaoke, transcribe, slow down music, loop, metronome, tempo, key detection, chord detection, guitar practice, bass practice, drum practice, singer, music learning, isolate instrument, music stem separator
 
 ---
 

--- a/docs/store-release-pipeline.md
+++ b/docs/store-release-pipeline.md
@@ -14,7 +14,7 @@ CI (`.github/workflows/ci.yml`) also runs on `v*` tag pushes so a tag-only relea
 
 ## Store listing as code
 
-`store/listing.yaml` is the single source of truth for Partner Center copy, feature bullets, and per-version **What's new** text.
+`store/listing.yaml` is the single source of truth for Partner Center copy, feature bullets, and per-version **What's new** text. It also records the live Store product identity (`store.product_id` `9P2W12L8F381`, package family name, public URL). An archival capture of the previously published Store copy lives in `store/live-snapshot-2026-07-31.md`.
 
 - **Edit YAML, not markdown.** Do not hand-edit `docs/store-listing.md`; it is generated output.
 - **Regenerate outputs** after YAML changes:

--- a/src/store_listing.py
+++ b/src/store_listing.py
@@ -26,6 +26,16 @@ DEFAULT_VERSION_PY = REPO_ROOT / "src" / "version.py"
 
 
 @dataclass(frozen=True)
+class StoreIdentity:
+    """Microsoft Store product identity for Partner Center / public listing."""
+
+    product_id: str
+    package_family_name: str
+    url: str
+    publisher_display_name: str
+
+
+@dataclass(frozen=True)
 class ListingData:
     listing_version: str
     short_description: str
@@ -33,6 +43,30 @@ class ListingData:
     features: list[str]
     search_terms: list[str]
     whats_new: dict[str, str]
+    store: StoreIdentity | None = None
+
+
+def _load_store_identity(raw: dict) -> StoreIdentity | None:
+    block = raw.get("store")
+    if block is None:
+        return None
+    if not isinstance(block, dict):
+        raise ValueError("store must be a mapping")
+    required = (
+        "product_id",
+        "package_family_name",
+        "url",
+        "publisher_display_name",
+    )
+    missing = [key for key in required if not str(block.get(key, "")).strip()]
+    if missing:
+        raise ValueError(f"store missing fields: {', '.join(missing)}")
+    return StoreIdentity(
+        product_id=str(block["product_id"]).strip(),
+        package_family_name=str(block["package_family_name"]).strip(),
+        url=str(block["url"]).strip(),
+        publisher_display_name=str(block["publisher_display_name"]).strip(),
+    )
 
 
 def load_listing(path: str | Path) -> ListingData:
@@ -53,6 +87,7 @@ def load_listing(path: str | Path) -> ListingData:
         whats_new={
             str(key): str(value).strip() for key, value in whats_new.items()
         },
+        store=_load_store_identity(raw),
     )
 
 
@@ -142,6 +177,13 @@ def render_markdown(data: ListingData, *, release_version: str) -> str:
     # Comma-separated for Partner Center paste; wrap roughly like the
     # historical hand-edited listing.
     search_terms = ", ".join(data.search_terms)
+    if data.store is not None:
+        store_line = (
+            f"\nPublic Store listing: {data.store.url} "
+            f"(product id `{data.store.product_id}`).\n"
+        )
+    else:
+        store_line = "\n"
     return f"""# Microsoft Store listing copy
 
 Generated from `store/listing.yaml`. Edit the YAML, then run
@@ -149,7 +191,7 @@ Generated from `store/listing.yaml`. Edit the YAML, then run
 Do not edit this markdown by hand.
 
 This copy reflects listing content for version **{release_version}**.
-
+{store_line}
 Fields map to Partner Center as follows:
 
 | Partner Center field | Section below |
@@ -220,7 +262,7 @@ def render_skeleton(data: ListingData, *, release_version: str) -> dict:
     }
     if release_version in data.whats_new:
         listing["whatsNew"] = data.whats_new[release_version]
-    return {
+    payload: dict = {
         "packages": [
             {
                 "packageUrl": (
@@ -235,6 +277,12 @@ def render_skeleton(data: ListingData, *, release_version: str) -> dict:
         ],
         "listing": listing,
     }
+    if data.store is not None:
+        payload["productId"] = data.store.product_id
+        payload["packageFamilyName"] = data.store.package_family_name
+        payload["storeUrl"] = data.store.url
+        payload["publisherDisplayName"] = data.store.publisher_display_name
+    return payload
 
 
 def write_outputs(

--- a/src/store_listing.py
+++ b/src/store_listing.py
@@ -58,14 +58,21 @@ def _load_store_identity(raw: dict) -> StoreIdentity | None:
         "url",
         "publisher_display_name",
     )
-    missing = [key for key in required if not str(block.get(key, "")).strip()]
+    values: dict[str, str] = {}
+    missing: list[str] = []
+    for key in required:
+        value = block.get(key)
+        if value is None or not isinstance(value, str) or not value.strip():
+            missing.append(key)
+        else:
+            values[key] = value.strip()
     if missing:
         raise ValueError(f"store missing fields: {', '.join(missing)}")
     return StoreIdentity(
-        product_id=str(block["product_id"]).strip(),
-        package_family_name=str(block["package_family_name"]).strip(),
-        url=str(block["url"]).strip(),
-        publisher_display_name=str(block["publisher_display_name"]).strip(),
+        product_id=values["product_id"],
+        package_family_name=values["package_family_name"],
+        url=values["url"],
+        publisher_display_name=values["publisher_display_name"],
     )
 
 

--- a/store/listing.yaml
+++ b/store/listing.yaml
@@ -1,6 +1,15 @@
 # Informational only. Release authority is the git tag / synced version.py.
 listing_version: "2.6.0"
 
+# Live Microsoft Store product identity (apps.microsoft.com).
+# Snapshot of published copy before the 2.6.0 submission:
+# store/live-snapshot-2026-07-31.md
+store:
+  product_id: "9P2W12L8F381"
+  package_family_name: "SanttuNyknen.stemma_rt9h3xsn8gsh8"
+  url: "https://apps.microsoft.com/detail/9p2w12l8f381"
+  publisher_display_name: "Santtu Nykänen"
+
 short_description: |
   Practice any song: split it into stems, mute the part you play, slow it
   down, and loop the hard bars.
@@ -27,7 +36,9 @@ description: |
   under the playhead, updated as it plays. There is a
   waveform to scrub, per-stem volume faders, and a library that remembers
   exactly where you left off -- song, position, mix, loop, speed, and
-  pitch -- so practice picks up where it stopped.
+  pitch -- so practice picks up where it stopped. Browse with previous
+  and next, loop a single song, shuffle the collection, or autoplay
+  through it.
 
   Separation runs on your own machine. Nothing is uploaded, there is no
   account, no subscription, and no internet connection needed once the
@@ -35,7 +46,9 @@ description: |
   export any stem or your own custom mix as WAV or MP3 when you want to
   take it elsewhere.
 
-  Built for Windows, keyboard-first, dark and light themes.
+  Built for Windows, keyboard-first, and layout-independent (Space,
+  arrows, Ctrl+1-6, and the rest work the same on international
+  keyboards). Dark and light themes.
 
 features:
   - "AI stem separation: vocals, drums, bass, guitar, piano, other"
@@ -54,6 +67,7 @@ features:
   - "Export stems or a custom mix as WAV or MP3"
   - "Import from an audio file or a YouTube link"
   - "Session memory: song, position, mix, loop, speed, and pitch"
+  - "Library with previous/next, shuffle, and autoplay"
   - "Keyboard shortcuts for the whole practice loop"
   - "Runs entirely on your PC: no account, no subscription, no uploads"
 
@@ -77,7 +91,7 @@ search_terms:
   - singer
   - music learning
   - isolate instrument
-  - minus one
+  - music stem separator
 
 whats_new:
   "2.5.0": |

--- a/store/live-snapshot-2026-07-31.md
+++ b/store/live-snapshot-2026-07-31.md
@@ -1,0 +1,64 @@
+# Live Microsoft Store listing snapshot (2026-07-31)
+
+Captured from the public Store catalog API for product
+[9P2W12L8F381](https://apps.microsoft.com/detail/9p2w12l8f381) before the
+v2.6.0 Partner Center update. Source of truth for *new* submissions is
+`store/listing.yaml`; this file is an archival record of what was live.
+
+## Identity
+
+| Field | Value |
+|---|---|
+| Product ID | `9P2W12L8F381` |
+| Package family name | `SanttuNyknen.stemma_rt9h3xsn8gsh8` |
+| Publisher | Santtu Nykänen |
+| Public URL | https://apps.microsoft.com/detail/9p2w12l8f381 |
+
+## Description (as published)
+
+stemma is a Windows desktop music player with AI stem separation for practice and play-along sessions.
+
+Import a song, separate it into stems (vocals, drums, bass, guitar, piano, other), and control each stem independently with mute, solo, and volume. Use waveform seek, A-B loop, speed control, metronome, and count-in to focus on difficult sections and rehearse with precision. stemma automatically detects the tempo, musical key, and current chord of each song, shown as live badges during playback.
+
+Build a library of your songs, navigate with previous/next buttons, loop a single song, shuffle through your collection, or let the player autoplay the whole library. A now-playing indicator shows the current track at a glance.
+
+Every shortcut is designed to be keyboard-layout independent, so all international layouts work out of the box. Space to play, arrows to seek, Ctrl+1-6 to mute stems, N/P for next/previous song, 0-9 to jump across the waveform, and F1 for the full reference.
+
+Record practice takes alongside the stems, nudge their timing, and export stems or custom mixes to WAV or MP3. All processing runs locally on your machine; no cloud, no account, no uploads.
+
+## Product features (as published)
+
+- AI stem separation (4-stem and 6-stem models)
+- Per-stem mute, solo, and volume controls
+- Waveform seek, playback cursor, and loop markers
+- A-B loop for focused practice sections
+- Playback speed presets with pitch-preserving stretch
+- Metronome with BPM entry and tap tempo
+- Optional count-in before playback and loop repeats
+- WAV/MP3 export for stems and custom mixes
+- Record takes and adjust timing (nudge)
+- Local-only workflow with dark/light themes
+- Automatic BPM and key detection with per-section A-B analysis
+- Real-time chord detection with beat tracking
+- Master volume with session persistence
+- Pitch shifting/transposition
+- Loop trainer with automatically increasing speed
+
+## Search hints (as published)
+
+- music stem
+- practice music app
+- music
+- music stem separator
+- separate audio stems
+- play-along music player
+- music player
+
+## Notes
+
+- No What's new text was returned by the catalog for this capture.
+- Feature lines that name "4-stem and 6-stem models" are intentionally
+  not carried into `listing.yaml` (model names stay out of Store copy).
+- Library navigation, shuffle/autoplay, and layout-independent shortcuts
+  were folded into the practice-focused `listing.yaml` description
+  (option A reconcile, 2026-07-31).

--- a/store/product-update.skeleton.json
+++ b/store/product-update.skeleton.json
@@ -14,7 +14,7 @@
   ],
   "listing": {
     "shortDescription": "Practice any song: split it into stems, mute the part you play, slow it\ndown, and loop the hard bars.",
-    "description": "stemma turns any song into a practice tool.\n\nImport a track and stemma separates it into individual stems -- vocals,\ndrums, bass, guitar, piano, and everything else -- so you can mute the\npart you play and perform it yourself. Silence the guitar and it is your\nguitar in the mix. Solo the drums to lock in with them. Pull the vocal\ndown and sing the line yourself.\n\nEverything else is built around learning a part properly. Set an A-B\nloop over the two bars that keep tripping you up and drill them. Slow\nthe passage down without the pitch dropping, or turn on the Loop\nTrainer and let stemma step the speed up a notch on every repeat until\nyou are at full tempo. Transpose the whole song into a key that suits\nyour voice or instrument, up to seven semitones either way, and the\ndisplayed key follows. Count yourself in, play along to the metronome,\nand record your take against the backing to hear how it really sat.\n\nstemma reads the song as you work: tempo, musical key, and the chord\nunder the playhead, updated as it plays. There is a\nwaveform to scrub, per-stem volume faders, and a library that remembers\nexactly where you left off -- song, position, mix, loop, speed, and\npitch -- so practice picks up where it stopped.\n\nSeparation runs on your own machine. Nothing is uploaded, there is no\naccount, no subscription, and no internet connection needed once the\nmodels are downloaded. Import from a file or paste a YouTube link, and\nexport any stem or your own custom mix as WAV or MP3 when you want to\ntake it elsewhere.\n\nBuilt for Windows, keyboard-first, dark and light themes.",
+    "description": "stemma turns any song into a practice tool.\n\nImport a track and stemma separates it into individual stems -- vocals,\ndrums, bass, guitar, piano, and everything else -- so you can mute the\npart you play and perform it yourself. Silence the guitar and it is your\nguitar in the mix. Solo the drums to lock in with them. Pull the vocal\ndown and sing the line yourself.\n\nEverything else is built around learning a part properly. Set an A-B\nloop over the two bars that keep tripping you up and drill them. Slow\nthe passage down without the pitch dropping, or turn on the Loop\nTrainer and let stemma step the speed up a notch on every repeat until\nyou are at full tempo. Transpose the whole song into a key that suits\nyour voice or instrument, up to seven semitones either way, and the\ndisplayed key follows. Count yourself in, play along to the metronome,\nand record your take against the backing to hear how it really sat.\n\nstemma reads the song as you work: tempo, musical key, and the chord\nunder the playhead, updated as it plays. There is a\nwaveform to scrub, per-stem volume faders, and a library that remembers\nexactly where you left off -- song, position, mix, loop, speed, and\npitch -- so practice picks up where it stopped. Browse with previous\nand next, loop a single song, shuffle the collection, or autoplay\nthrough it.\n\nSeparation runs on your own machine. Nothing is uploaded, there is no\naccount, no subscription, and no internet connection needed once the\nmodels are downloaded. Import from a file or paste a YouTube link, and\nexport any stem or your own custom mix as WAV or MP3 when you want to\ntake it elsewhere.\n\nBuilt for Windows, keyboard-first, and layout-independent (Space,\narrows, Ctrl+1-6, and the rest work the same on international\nkeyboards). Dark and light themes.",
     "features": [
       "AI stem separation: vocals, drums, bass, guitar, piano, other",
       "Per-stem mute, solo, and volume faders",
@@ -32,6 +32,7 @@
       "Export stems or a custom mix as WAV or MP3",
       "Import from an audio file or a YouTube link",
       "Session memory: song, position, mix, loop, speed, and pitch",
+      "Library with previous/next, shuffle, and autoplay",
       "Keyboard shortcuts for the whole practice loop",
       "Runs entirely on your PC: no account, no subscription, no uploads"
     ],
@@ -55,8 +56,12 @@
       "singer",
       "music learning",
       "isolate instrument",
-      "minus one"
+      "music stem separator"
     ],
     "whatsNew": "What's new in version 2.6.0\n\nFaster 2-stem separation: when a compatible GPU is available, 2-stem\nseparation runs with GPU acceleration and falls back to CPU\nautomatically when it is not.\n\nBackground imports: importing and separating songs no longer blocks\nthe rest of the app -- jobs run in a background queue so you can keep\nbrowsing your library while work finishes.\n\nStability and integrity: model downloads are checksum-verified,\nstems load asynchronously so the UI stays responsive, and release\ndiagnostics make packaged builds easier to verify before Store\nsubmission."
-  }
+  },
+  "productId": "9P2W12L8F381",
+  "packageFamilyName": "SanttuNyknen.stemma_rt9h3xsn8gsh8",
+  "storeUrl": "https://apps.microsoft.com/detail/9p2w12l8f381",
+  "publisherDisplayName": "Santtu Nyk\u00e4nen"
 }

--- a/tests/test_store_listing.py
+++ b/tests/test_store_listing.py
@@ -13,6 +13,7 @@ from src.store_listing import (
     DEFAULT_SKELETON,
     DEFAULT_VERSION_PY,
     ListingData,
+    StoreIdentity,
     ValidationError,
     load_listing,
     outputs_match,
@@ -64,6 +65,11 @@ def test_load_listing_reads_required_fields(tmp_path: Path) -> None:
     yaml_path.write_text(
         """
 listing_version: "2.6.0"
+store:
+  product_id: "9P2W12L8F381"
+  package_family_name: "SanttuNyknen.stemma_rt9h3xsn8gsh8"
+  url: "https://apps.microsoft.com/detail/9p2w12l8f381"
+  publisher_display_name: "Santtu Nykänen"
 short_description: Short text
 description: |
   Longer description.
@@ -88,6 +94,12 @@ whats_new:
     assert data.features == ["Feature one"]
     assert data.search_terms == ["stem separation"]
     assert "2.6.0" in data.whats_new
+    assert data.store == StoreIdentity(
+        product_id="9P2W12L8F381",
+        package_family_name="SanttuNyknen.stemma_rt9h3xsn8gsh8",
+        url="https://apps.microsoft.com/detail/9p2w12l8f381",
+        publisher_display_name="Santtu Nykänen",
+    )
 
 
 def test_png_size_reads_ihdr(tmp_path: Path) -> None:
@@ -161,6 +173,21 @@ def test_render_skeleton_includes_package_url_placeholder() -> None:
     assert "packages" in payload
     assert "v2.6.0/stemma.msix" in payload["packages"][0]["packageUrl"]
     assert payload["listing"]["shortDescription"] == "Short"
+    assert "productId" not in payload
+
+
+def test_render_skeleton_includes_store_identity() -> None:
+    identity = StoreIdentity(
+        product_id="9P2W12L8F381",
+        package_family_name="SanttuNyknen.stemma_rt9h3xsn8gsh8",
+        url="https://apps.microsoft.com/detail/9p2w12l8f381",
+        publisher_display_name="Santtu Nykänen",
+    )
+    payload = render_skeleton(_data(store=identity), release_version="2.6.0")
+    assert payload["productId"] == "9P2W12L8F381"
+    assert payload["packageFamilyName"] == identity.package_family_name
+    assert payload["storeUrl"] == identity.url
+    assert payload["publisherDisplayName"] == identity.publisher_display_name
 
 
 def test_build_check_detects_stale_markdown(tmp_path: Path) -> None:

--- a/tests/test_store_listing.py
+++ b/tests/test_store_listing.py
@@ -102,6 +102,32 @@ whats_new:
     )
 
 
+def test_load_listing_rejects_null_store_fields(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "listing.yaml"
+    yaml_path.write_text(
+        """
+listing_version: "2.6.0"
+store:
+  product_id: "9P2W12L8F381"
+  package_family_name: "SanttuNyknen.stemma_rt9h3xsn8gsh8"
+  url: null
+  publisher_display_name: "Santtu Nykänen"
+short_description: Short text
+description: Desc
+features:
+  - Feature one
+search_terms:
+  - stem
+whats_new:
+  "2.6.0": |
+    What's new in version 2.6.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="url"):
+        load_listing(yaml_path)
+
+
 def test_png_size_reads_ihdr(tmp_path: Path) -> None:
     path = tmp_path / "tiny.png"
     path.write_bytes(_minimal_png(8, 4))


### PR DESCRIPTION
## Summary
- Record live Microsoft Store identity (product id `9P2W12L8F381`, PFN, URL, publisher) in `store/listing.yaml` and the generated skeleton JSON
- Archive the pre-2.6.0 published Store copy in `store/live-snapshot-2026-07-31.md`
- Keep the practice-focused description (option A) and fold in missing live facts: library prev/next/shuffle/autoplay and layout-independent shortcuts; add a library feature bullet; keep model names out of Store copy

Related to #134 (prepares Partner Center automation with real product id).

## Test plan
- [ ] `pytest tests/test_store_listing.py`
- [ ] `python scripts/validate_store_release.py --version 2.6.0`
- [ ] `python scripts/build_store_listing.py --check --version 2.6.0`
- [ ] Confirm `docs/store-listing.md` mentions the public Store URL / product id
- [ ] Confirm features count is still `<= 20`