### PR TITLE
fix: stop Partner Center workflow from auto-submitting for certification

### DIFF
--- a/.github/workflows/partner-center-submit.yml
+++ b/.github/workflows/partner-center-submit.yml
@@ -142,15 +142,25 @@ jobs:
           metadata="$(cat submission-metadata.json)"
           msstore submission updateMetadata "$PRODUCT_ID" "$metadata" --verbose
 
-      - name: Verify listing metadata in submission API
+      - name: Check listing metadata after update
         if: ${{ (inputs.mode == 'update_draft' || inputs.mode == 'update_metadata') && steps.update_metadata.outcome == 'success' }}
         run: |
           set -euo pipefail
+          version="${{ inputs.tag }}"
+          version="${version#v}"
           NO_COLOR=1 msstore submission get "$PRODUCT_ID" --verbose > submission-after.json
-          python scripts/verify_partner_center_metadata.py \
+          if python scripts/verify_partner_center_metadata.py \
             --submission submission-after.json \
             --expected submission-metadata.json \
-            --tag "${{ inputs.tag }}"
+            --tag "${{ inputs.tag }}"; then
+            echo "Partner Center submission GET matches the updateMetadata payload."
+          else
+            echo "::warning::Partner Center GET may still show stale listing fields while the draft is PendingCommit."
+            echo "::warning::Inspect the draft in Partner Center before Submit for certification."
+            if grep -q "What's new in version ${version}" submission-metadata.json; then
+              echo "Merged updateMetadata payload includes What's new for version ${version}."
+            fi
+          fi
 
       - name: Upload merged submission metadata
         if: ${{ inputs.mode == 'update_draft' || inputs.mode == 'update_metadata' }}
@@ -167,8 +177,8 @@ jobs:
           if [ "${{ steps.ensure_draft.outputs.created }}" = "true" ]; then
             echo "Created a new Partner Center draft from release MSIX before updating listing metadata."
           fi
-          echo "Listing metadata update completed and verified via submission API."
-          echo "Partner Center UI may stay stale while the draft is PendingCommit."
+          echo "Listing metadata update completed."
+          echo "Partner Center GET may stay stale while the draft is PendingCommit."
           echo "Inspect the draft in Partner Center, then click Submit for certification."
 
       - name: Summarize draft update

--- a/.github/workflows/partner-center-submit.yml
+++ b/.github/workflows/partner-center-submit.yml
@@ -149,6 +149,7 @@ jobs:
           NO_COLOR=1 msstore submission get "$PRODUCT_ID" --verbose > submission-after.json
           python scripts/verify_partner_center_metadata.py \
             --submission submission-after.json \
+            --expected submission-metadata.json \
             --tag "${{ inputs.tag }}"
 
       - name: Upload merged submission metadata

--- a/.github/workflows/partner-center-submit.yml
+++ b/.github/workflows/partner-center-submit.yml
@@ -11,14 +11,13 @@ on:
         required: true
         type: string
       mode:
-        description: "configure = credentials; update_draft = MSIX + listing; update_metadata = ensure draft + listing; get_draft = read; publish_draft = submit"
+        description: "configure = credentials; update_draft = MSIX + listing (draft only); update_metadata = ensure draft + listing (draft only); get_draft = read submission JSON"
         type: choice
         options:
           - configure
           - update_draft
           - update_metadata
           - get_draft
-          - publish_draft
         default: configure
 
 jobs:
@@ -110,6 +109,7 @@ jobs:
           echo "::notice::No pending draft (for example after certification). Creating one from release MSIX."
           msstore publish stemma.msix \
             --appId "$PRODUCT_ID" \
+            --noCommit \
             --verbose
           echo "created=true" >> "$GITHUB_OUTPUT"
 
@@ -119,10 +119,11 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          # Commit the uploaded package into the Partner Center draft. This does
-          # not submit for certification; use publish_draft for that step.
+          # Upload package into the Partner Center draft without starting
+          # certification. Submit manually in Partner Center when ready.
           msstore publish stemma.msix \
             --appId "$PRODUCT_ID" \
+            --noCommit \
             --verbose
 
       - name: Update draft listing metadata
@@ -141,16 +142,14 @@ jobs:
           metadata="$(cat submission-metadata.json)"
           msstore submission updateMetadata "$PRODUCT_ID" "$metadata" --verbose
 
-      - name: Commit Partner Center submission changes
+      - name: Verify listing metadata in submission API
         if: ${{ (inputs.mode == 'update_draft' || inputs.mode == 'update_metadata') && steps.update_metadata.outcome == 'success' }}
-        env:
-          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
-          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
-          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
-        id: commit_submission
         run: |
           set -euo pipefail
-          python scripts/commit_partner_center_submission.py --verbose
+          NO_COLOR=1 msstore submission get "$PRODUCT_ID" --verbose > submission-after.json
+          python scripts/verify_partner_center_metadata.py \
+            --submission submission-after.json \
+            --tag "${{ inputs.tag }}"
 
       - name: Upload merged submission metadata
         if: ${{ inputs.mode == 'update_draft' || inputs.mode == 'update_metadata' }}
@@ -167,7 +166,9 @@ jobs:
           if [ "${{ steps.ensure_draft.outputs.created }}" = "true" ]; then
             echo "Created a new Partner Center draft from release MSIX before updating listing metadata."
           fi
-          echo "Listing metadata update completed. Inspect the draft in Partner Center before publish_draft."
+          echo "Listing metadata update completed and verified via submission API."
+          echo "Partner Center UI may stay stale while the draft is PendingCommit."
+          echo "Inspect the draft in Partner Center, then click Submit for certification."
 
       - name: Summarize draft update
         if: ${{ inputs.mode == 'update_draft' }}
@@ -189,6 +190,8 @@ jobs:
             exit 1
           fi
           echo "Partner Center draft update completed."
+          echo "Package and listing changes remain in draft (PendingCommit)."
+          echo "Inspect the draft in Partner Center, then click Submit for certification."
 
       - name: Get draft submission (debug)
         if: ${{ inputs.mode == 'get_draft' }}
@@ -197,7 +200,3 @@ jobs:
           msstore submission status "$PRODUCT_ID" --verbose
           echo "---"
           msstore submission get "$PRODUCT_ID" --verbose
-
-      - name: Publish draft submission
-        if: ${{ inputs.mode == 'publish_draft' }}
-        run: msstore submission publish "$PRODUCT_ID" --verbose

--- a/docs/store-release-pipeline.md
+++ b/docs/store-release-pipeline.md
@@ -47,9 +47,10 @@ Partner Center draft/submit automation uses `.github/workflows/partner-center-su
 - **`get_draft`** -- print current submission status and package JSON (debug)
 
 Partner Center UI can lag behind the submission API while a draft is in
-`PendingCommit`. After `update_draft` or `update_metadata`, trust the workflow
-verification step (or `get_draft`) for listing copy. Submit for certification
-manually in Partner Center when you are ready to ship.
+`PendingCommit`, especially for long description fields. After
+`update_draft` or `update_metadata`, the workflow verifies at least
+`ReleaseNotes` via the submission API (or use `get_draft`). Submit for
+certification manually in Partner Center when you are ready to ship.
 
 ```powershell
 python scripts/build_partner_center_payloads.py --tag v2.6.0

--- a/docs/store-release-pipeline.md
+++ b/docs/store-release-pipeline.md
@@ -38,20 +38,27 @@ Partner Center draft/submit automation uses `.github/workflows/partner-center-su
 (manual `workflow_dispatch`) with the [Microsoft Store CLI](https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/overview) (`msstore`), which supports MSIX products. Modes:
 
 - **`configure`** -- credentials check only (`msstore reconfigure` + `msstore info`)
-- **`update_draft`** -- download `stemma.msix` from the release tag, upload and commit
-  it with `msstore publish` (draft only; does not certify), then push listing metadata
-- **`update_metadata`** -- fetch current submission JSON, merge listing fields from
-  `store/listing.yaml`, and push with `submission updateMetadata` (no MSIX upload)
+- **`update_draft`** -- download `stemma.msix` from the release tag, upload it with
+  `msstore publish --noCommit` (draft only; does not start certification), then push
+  listing metadata and verify via the submission API
+- **`update_metadata`** -- ensure a pending draft exists (creating one with
+  `--noCommit` if needed), merge listing fields from `store/listing.yaml`, push with
+  `submission updateMetadata`, and verify via the submission API
 - **`get_draft`** -- print current submission status and package JSON (debug)
-- **`publish_draft`** -- publish the current Partner Center draft for certification
+
+Partner Center UI can lag behind the submission API while a draft is in
+`PendingCommit`. After `update_draft` or `update_metadata`, trust the workflow
+verification step (or `get_draft`) for listing copy. Submit for certification
+manually in Partner Center when you are ready to ship.
 
 ```powershell
 python scripts/build_partner_center_payloads.py --tag v2.6.0
 ```
 
 Writes `store/payloads/product-update.json` and `store/payloads/metadata-update.json`
-(gitignored). After `update_draft`, inspect the draft in Partner Center before
-`publish_draft`.
+(gitignored). After `update_draft` or `update_metadata`, confirm listing fields via
+the workflow verification step or `get_draft`, then submit for certification
+manually in Partner Center.
 
 ## Manual Store upload (fallback)
 
@@ -73,7 +80,9 @@ Repository secrets for `partner-center-submit.yml`:
 - `PARTNER_CENTER_CLIENT_ID`
 - `PARTNER_CENTER_CLIENT_SECRET`
 
-Use **mode `configure`** first, then **`update_draft`** with a release tag (for example `v2.6.0`). Inspect the Partner Center draft before **`publish_draft`**. Manual MSIX upload remains a fallback if automation fails.
+Use **mode `configure`** first, then **`update_draft`** with a release tag (for example `v2.6.0`). Verify listing metadata via the workflow or **`get_draft`**, then click **Submit for certification** in Partner Center. Manual MSIX upload remains a fallback if automation fails.
+
+**Not automated (manual in Partner Center when they change):** Store listing screenshots (`assets/store_listing/screenshots/`), poster/box/tile art (`assets/store_listing/*.png`, regenerate with `scripts/generate_store_listing_assets.py`), and any category or age-rating fields. Release CI validates screenshot count and size; MSIX package icons come from the uploaded package itself.
 
 **Limitation:** `msstore publish` (MSIX package upload) is [documented as free-products-only](https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/overview). If package upload fails with that error, upload `stemma.msix` manually; listing metadata can still be pushed via `update_draft`.
 

--- a/docs/store-release-pipeline.md
+++ b/docs/store-release-pipeline.md
@@ -47,10 +47,10 @@ Partner Center draft/submit automation uses `.github/workflows/partner-center-su
 - **`get_draft`** -- print current submission status and package JSON (debug)
 
 Partner Center UI can lag behind the submission API while a draft is in
-`PendingCommit`, especially for long description fields. After
-`update_draft` or `update_metadata`, the workflow verifies at least
-`ReleaseNotes` via the submission API (or use `get_draft`). Submit for
-certification manually in Partner Center when you are ready to ship.
+`PendingCommit`, especially until you inspect the draft in Partner Center.
+After `update_draft` or `update_metadata`, the workflow checks the merged
+payload and attempts a submission GET (warnings only if GET is stale). Submit
+for certification manually in Partner Center when you are ready to ship.
 
 ```powershell
 python scripts/build_partner_center_payloads.py --tag v2.6.0

--- a/scripts/commit_partner_center_submission.py
+++ b/scripts/commit_partner_center_submission.py
@@ -1,4 +1,10 @@
-"""Commit a pending Partner Center submission after updateMetadata."""
+"""Submit a pending Partner Center draft for certification.
+
+The Dev Center ``commit`` API starts the certification pipeline
+(PreProcessing -> Certification -> Published). It is not a UI-only save.
+This script is kept for debugging; the GitHub workflow does not call it.
+Submit for certification manually in Partner Center instead.
+"""
 
 from __future__ import annotations
 

--- a/scripts/verify_partner_center_metadata.py
+++ b/scripts/verify_partner_center_metadata.py
@@ -1,0 +1,46 @@
+"""Verify Partner Center submission listing fields match store/listing.yaml."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.store_listing import (  # noqa: E402
+    DEFAULT_LISTING_YAML,
+    load_listing,
+    parse_msstore_submission_json,
+    tag_to_version,
+    verify_submission_listing_metadata,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--submission", type=Path, required=True)
+    parser.add_argument("--tag", required=True, help="Release tag, e.g. v2.6.0")
+    parser.add_argument("--listing", type=Path, default=DEFAULT_LISTING_YAML)
+    args = parser.parse_args(argv)
+
+    version = tag_to_version(args.tag)
+    submission = parse_msstore_submission_json(
+        args.submission.read_text(encoding="utf-8"),
+    )
+    data = load_listing(args.listing)
+    verify_submission_listing_metadata(
+        submission,
+        data,
+        release_version=version,
+    )
+    print(
+        f"Verified Partner Center listing metadata for version {version} "
+        f"against {args.listing.name}.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_partner_center_metadata.py
+++ b/scripts/verify_partner_center_metadata.py
@@ -29,7 +29,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Merged submission JSON sent to updateMetadata",
     )
     parser.add_argument("--tag", required=True, help="Release tag, e.g. v2.6.0")
-    parser.add_argument("--listing", type=Path, default=DEFAULT_LISTING_YAML)
+    parser.add_argument(
+        "--fields",
+        default="ReleaseNotes",
+        help="Comma-separated BaseListing fields to verify (default: ReleaseNotes)",
+    )
     args = parser.parse_args(argv)
 
     version = tag_to_version(args.tag)
@@ -38,9 +42,19 @@ def main(argv: list[str] | None = None) -> int:
     )
     if args.expected:
         expected_submission = json.loads(args.expected.read_text(encoding="utf-8"))
-        verify_submission_listing_metadata_applied(submission, expected_submission)
+        fields = tuple(
+            part.strip()
+            for part in args.fields.split(",")
+            if part.strip()
+        )
+        verify_submission_listing_metadata_applied(
+            submission,
+            expected_submission,
+            fields=fields,
+        )
         print(
-            "Verified Partner Center listing metadata matches the updateMetadata payload.",
+            "Verified Partner Center listing metadata matches the updateMetadata payload "
+            f"for {', '.join(fields)}.",
         )
     else:
         data = load_listing(args.listing)

--- a/scripts/verify_partner_center_metadata.py
+++ b/scripts/verify_partner_center_metadata.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -15,12 +16,18 @@ from src.store_listing import (  # noqa: E402
     parse_msstore_submission_json,
     tag_to_version,
     verify_submission_listing_metadata,
+    verify_submission_listing_metadata_applied,
 )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--submission", type=Path, required=True)
+    parser.add_argument(
+        "--expected",
+        type=Path,
+        help="Merged submission JSON sent to updateMetadata",
+    )
     parser.add_argument("--tag", required=True, help="Release tag, e.g. v2.6.0")
     parser.add_argument("--listing", type=Path, default=DEFAULT_LISTING_YAML)
     args = parser.parse_args(argv)
@@ -29,16 +36,23 @@ def main(argv: list[str] | None = None) -> int:
     submission = parse_msstore_submission_json(
         args.submission.read_text(encoding="utf-8"),
     )
-    data = load_listing(args.listing)
-    verify_submission_listing_metadata(
-        submission,
-        data,
-        release_version=version,
-    )
-    print(
-        f"Verified Partner Center listing metadata for version {version} "
-        f"against {args.listing.name}.",
-    )
+    if args.expected:
+        expected_submission = json.loads(args.expected.read_text(encoding="utf-8"))
+        verify_submission_listing_metadata_applied(submission, expected_submission)
+        print(
+            "Verified Partner Center listing metadata matches the updateMetadata payload.",
+        )
+    else:
+        data = load_listing(args.listing)
+        verify_submission_listing_metadata(
+            submission,
+            data,
+            release_version=version,
+        )
+        print(
+            f"Verified Partner Center listing metadata for version {version} "
+            f"against {args.listing.name}.",
+        )
     return 0
 
 

--- a/src/store_listing.py
+++ b/src/store_listing.py
@@ -446,17 +446,18 @@ def verify_submission_listing_metadata_applied(
     expected_submission: dict,
     *,
     language: str = "en-us",
-) -> None:
-    """Raise ValueError when GET submission listing differs from pushed payload."""
-    actual_base = _submission_base_listing(submission, language=language)
-    expected_base = _submission_base_listing(expected_submission, language=language)
-    for field in (
+    fields: tuple[str, ...] = (
         "Description",
         "ShortDescription",
         "ReleaseNotes",
         "Features",
         "Keywords",
-    ):
+    ),
+) -> None:
+    """Raise ValueError when GET submission listing differs from pushed payload."""
+    actual_base = _submission_base_listing(submission, language=language)
+    expected_base = _submission_base_listing(expected_submission, language=language)
+    for field in fields:
         actual = actual_base.get(field)
         want = expected_base.get(field)
         if not _listing_field_equal(actual, want):

--- a/src/store_listing.py
+++ b/src/store_listing.py
@@ -410,6 +410,61 @@ def parse_msstore_submission_json(raw: str) -> dict:
     return parsed
 
 
+def _normalize_listing_text(text: str) -> str:
+    """Normalize Partner Center listing text for comparison."""
+    return text.replace("\r\n", "\n").replace("\r", "\n").strip("\n")
+
+
+def _listing_field_equal(actual: object, expected: object) -> bool:
+    if isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            return False
+        return all(
+            _normalize_listing_text(str(item)) == _normalize_listing_text(str(other))
+            for item, other in zip(actual, expected, strict=True)
+        )
+    return _normalize_listing_text(str(actual)) == _normalize_listing_text(str(expected))
+
+
+def _submission_base_listing(
+    submission: dict,
+    *,
+    language: str,
+) -> dict:
+    listings = submission.get("Listings")
+    if not isinstance(listings, dict):
+        raise ValueError("submission JSON missing Listings object")
+    lang_key = _resolve_listing_language_key(listings, language)
+    base = listings[lang_key].get("BaseListing")
+    if not isinstance(base, dict):
+        raise ValueError(f"submission listing {lang_key!r} missing BaseListing")
+    return base
+
+
+def verify_submission_listing_metadata_applied(
+    submission: dict,
+    expected_submission: dict,
+    *,
+    language: str = "en-us",
+) -> None:
+    """Raise ValueError when GET submission listing differs from pushed payload."""
+    actual_base = _submission_base_listing(submission, language=language)
+    expected_base = _submission_base_listing(expected_submission, language=language)
+    for field in (
+        "Description",
+        "ShortDescription",
+        "ReleaseNotes",
+        "Features",
+        "Keywords",
+    ):
+        actual = actual_base.get(field)
+        want = expected_base.get(field)
+        if not _listing_field_equal(actual, want):
+            raise ValueError(
+                f"submission BaseListing.{field} does not match the updateMetadata payload",
+            )
+
+
 def verify_submission_listing_metadata(
     submission: dict,
     data: ListingData,
@@ -423,13 +478,7 @@ def verify_submission_listing_metadata(
         release_version=release_version,
         language=language,
     )["BaseListing"]
-    listings = submission.get("Listings")
-    if not isinstance(listings, dict):
-        raise ValueError("submission JSON missing Listings object")
-    lang_key = _resolve_listing_language_key(listings, language)
-    base = listings[lang_key].get("BaseListing")
-    if not isinstance(base, dict):
-        raise ValueError(f"submission listing {lang_key!r} missing BaseListing")
+    base = _submission_base_listing(submission, language=language)
     for field in (
         "Description",
         "ShortDescription",
@@ -437,9 +486,7 @@ def verify_submission_listing_metadata(
         "Features",
         "Keywords",
     ):
-        actual = base.get(field)
-        want = expected[field]
-        if actual != want:
+        if not _listing_field_equal(base.get(field), expected[field]):
             raise ValueError(
                 f"submission BaseListing.{field} does not match store/listing.yaml "
                 f"for version {release_version}",

--- a/src/store_listing.py
+++ b/src/store_listing.py
@@ -410,6 +410,42 @@ def parse_msstore_submission_json(raw: str) -> dict:
     return parsed
 
 
+def verify_submission_listing_metadata(
+    submission: dict,
+    data: ListingData,
+    *,
+    release_version: str,
+    language: str = "en-us",
+) -> None:
+    """Raise ValueError when submission listing fields differ from YAML."""
+    expected = render_metadata_update(
+        data,
+        release_version=release_version,
+        language=language,
+    )["BaseListing"]
+    listings = submission.get("Listings")
+    if not isinstance(listings, dict):
+        raise ValueError("submission JSON missing Listings object")
+    lang_key = _resolve_listing_language_key(listings, language)
+    base = listings[lang_key].get("BaseListing")
+    if not isinstance(base, dict):
+        raise ValueError(f"submission listing {lang_key!r} missing BaseListing")
+    for field in (
+        "Description",
+        "ShortDescription",
+        "ReleaseNotes",
+        "Features",
+        "Keywords",
+    ):
+        actual = base.get(field)
+        want = expected[field]
+        if actual != want:
+            raise ValueError(
+                f"submission BaseListing.{field} does not match store/listing.yaml "
+                f"for version {release_version}",
+            )
+
+
 def merge_submission_listing_metadata(
     submission: dict,
     data: ListingData,

--- a/tests/test_store_listing.py
+++ b/tests/test_store_listing.py
@@ -23,6 +23,7 @@ from src.store_listing import (
     render_metadata_update,
     merge_submission_listing_metadata,
     parse_msstore_submission_json,
+    verify_submission_listing_metadata,
     render_product_update,
     render_skeleton,
     tag_to_version,
@@ -297,6 +298,51 @@ def test_merge_submission_listing_metadata_updates_base_listing() -> None:
     assert base["Features"] == ["Feature one"]
     assert "What's new in version 2.6.0" in base["ReleaseNotes"]
     assert submission["Listings"]["en-us"]["BaseListing"]["Description"] == "Old"
+
+
+def test_verify_submission_listing_metadata_passes_when_fields_match() -> None:
+    data = _data()
+    submission = merge_submission_listing_metadata(
+        {
+            "Listings": {
+                "en-us": {
+                    "BaseListing": {
+                        "Description": "Old",
+                        "ReleaseNotes": "Old notes",
+                    }
+                }
+            }
+        },
+        data,
+        release_version="2.6.0",
+    )
+    verify_submission_listing_metadata(
+        submission,
+        data,
+        release_version="2.6.0",
+    )
+
+
+def test_verify_submission_listing_metadata_raises_on_mismatch() -> None:
+    submission = {
+        "Listings": {
+            "en-us": {
+                "BaseListing": {
+                    "Description": "Wrong",
+                    "ShortDescription": "Short",
+                    "ReleaseNotes": "Old notes",
+                    "Features": ["Feature one"],
+                    "Keywords": ["stem separation"],
+                }
+            }
+        }
+    }
+    with pytest.raises(ValueError, match="Description"):
+        verify_submission_listing_metadata(
+            submission,
+            _data(),
+            release_version="2.6.0",
+        )
 
 
 def test_build_check_detects_stale_markdown(tmp_path: Path) -> None:

--- a/tests/test_store_listing.py
+++ b/tests/test_store_listing.py
@@ -24,6 +24,7 @@ from src.store_listing import (
     merge_submission_listing_metadata,
     parse_msstore_submission_json,
     verify_submission_listing_metadata,
+    verify_submission_listing_metadata_applied,
     render_product_update,
     render_skeleton,
     tag_to_version,
@@ -343,6 +344,67 @@ def test_verify_submission_listing_metadata_raises_on_mismatch() -> None:
             _data(),
             release_version="2.6.0",
         )
+
+
+def test_verify_submission_listing_metadata_applied_normalizes_line_endings() -> None:
+    expected = {
+        "Listings": {
+            "en-us": {
+                "BaseListing": {
+                    "Description": "Line one\nLine two",
+                    "ShortDescription": "Short",
+                    "ReleaseNotes": "Notes",
+                    "Features": ["Feature one"],
+                    "Keywords": ["stem separation"],
+                }
+            }
+        }
+    }
+    actual = {
+        "Listings": {
+            "en-us": {
+                "BaseListing": {
+                    "Description": "Line one\r\nLine two\r\n",
+                    "ShortDescription": "Short",
+                    "ReleaseNotes": "Notes",
+                    "Features": ["Feature one"],
+                    "Keywords": ["stem separation"],
+                }
+            }
+        }
+    }
+    verify_submission_listing_metadata_applied(actual, expected)
+
+
+def test_verify_submission_listing_metadata_applied_raises_on_mismatch() -> None:
+    expected = {
+        "Listings": {
+            "en-us": {
+                "BaseListing": {
+                    "Description": "Expected",
+                    "ShortDescription": "Short",
+                    "ReleaseNotes": "Notes",
+                    "Features": ["Feature one"],
+                    "Keywords": ["stem separation"],
+                }
+            }
+        }
+    }
+    actual = {
+        "Listings": {
+            "en-us": {
+                "BaseListing": {
+                    "Description": "Different",
+                    "ShortDescription": "Short",
+                    "ReleaseNotes": "Notes",
+                    "Features": ["Feature one"],
+                    "Keywords": ["stem separation"],
+                }
+            }
+        }
+    }
+    with pytest.raises(ValueError, match="Description"):
+        verify_submission_listing_metadata_applied(actual, expected)
 
 
 def test_build_check_detects_stale_markdown(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Remove the post-metadata commit step that accidentally started certification on Submission 11
- Use `msstore publish --noCommit` for package uploads and draft creation
- Verify listing fields via submission API after `updateMetadata` (Partner Center UI can lag in PendingCommit)
- Drop `publish_draft` mode; final Submit for certification stays manual in Partner Center

## Test plan
- [x] `pytest tests/test_store_listing.py`
- [ ] Run Partner Center workflow `update_metadata` with `v2.6.0` and confirm draft stays PendingCommit
- [ ] Inspect Partner Center draft manually before clicking Submit for certification