### PR TITLE
docs: record v2.6.0 release and point roadmap at v3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,13 +77,11 @@ rationale and subsystem boundaries.
 
 ## Current Status
 
-Verified against GitHub Releases on 2026-07-28:
+Verified against GitHub Releases on 2026-08-01:
 
-- Latest stable: **v2.5.0**
-- Current source and manifest target: **v2.6.0**, unreleased
-- v2.6 focus: DirectML-capable MDX two-stem separation, background imports,
-  correctness/lifecycle hardening, reproducible release validation, and
-  documentation/Project repair
+- Latest stable: **v2.6.0**
+- Current source on `main` targets **v3.0** (unreleased)
+- v3.0 focus: practice cockpit visual recomposition ([#131](https://github.com/cyanidesayonara/stemma/issues/131))
 
 Use `docs/ROADMAP.md` for future scope and `CHANGELOG.md` for shipped
 releases. Do not infer release status from code already present on a branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Release publication on GitHub is authoritative. Source code present on
 `main` or a feature branch is not considered shipped until a release is
 published.
 
+## [v2.6.0](https://github.com/cyanidesayonara/stemma/releases/tag/v2.6.0) - 2026-07-31
+
+- Added DirectML-capable MDX two-stem separation with automatic CPU fallback.
+- Moved imports and separation onto a background queue so the UI stays usable.
+- Hardened model download checksums, async stem loading, lifecycle safety, and
+  packaged release diagnostics.
+
 ## [v2.5.0](https://github.com/cyanidesayonara/stemma/releases/tag/v2.5.0) - 2026-07-26
 
 - Added Loop Trainer speed ramps for A-B loop practice.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -4,8 +4,8 @@ A Windows desktop music player with AI stem separation. Import a song, separate 
 
 **Personal-use tool. No cloud, no subscriptions, no command line needed.**
 
-Latest stable release: **v2.5.0**. The current source tree targets
-**v2.6.0**, which is not released. Release notes live in `CHANGELOG.md`;
+Latest stable release: **v2.6.0**. The current source tree targets
+**v3.0**, which is not released. Release notes live in `CHANGELOG.md`;
 future scope lives in `docs/ROADMAP.md`.
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,23 +1,18 @@
 # Roadmap
 
-Latest stable release: **v2.5.0**. The current source tree targets
-**v2.6.0**, which is not released.
+Latest stable release: **v2.6.0**.
 
 This document is intentionally short. GitHub issues hold acceptance criteria,
 discussion, and live status; `../CHANGELOG.md` records only shipped releases.
 Version groupings below describe the intended sequence, not a promise of
 scope or date.
 
-## v2.6 -- stability and release hardening
+## v2.6 -- stability and release hardening (shipped)
 
 - [#137: v2.6 stability and release hardening](https://github.com/cyanidesayonara/stemma/issues/137)
-  tracks the DirectML/runtime truth, correctness and lifecycle work,
-  generation-safe background loading, reproducible release validation, and
-  documentation/Project repair.
-
-Do not close the issue or describe v2.6 as shipped until the builder pull
-request is reviewed and merged, required validation passes, and the release
-is published.
+  — DirectML/runtime truth, correctness and lifecycle work, generation-safe
+  background loading, reproducible release validation, and Store listing
+  automation ([#134](https://github.com/cyanidesayonara/stemma/issues/134)).
 
 ## v3.0 -- practice cockpit
 
@@ -43,10 +38,10 @@ is published.
 - [#125: DirectML-compatible HTDemucs exports](https://github.com/cyanidesayonara/stemma/issues/125)
   investigates GPU inference for four/six-stem separation. Those paths are
   CPU-only today.
+- [#146: Store listing screenshots for v3.0](https://github.com/cyanidesayonara/stemma/issues/146)
+  plans refreshed Store visuals before the v3.0 submission.
 - [#28: experimental DSP extensions](https://github.com/cyanidesayonara/stemma/issues/28)
   evaluates separation and post-processing approaches without promising a
   quality tier.
 - [#13: real-time streaming separation](https://github.com/cyanidesayonara/stemma/issues/13)
   investigates progressive playback/separation constraints.
-- [#134: Store submission and listing automation](https://github.com/cyanidesayonara/stemma/issues/134)
-  keeps release metadata and Store assets reproducible across versions.

--- a/scripts/verify_partner_center_metadata.py
+++ b/scripts/verify_partner_center_metadata.py
@@ -30,6 +30,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--tag", required=True, help="Release tag, e.g. v2.6.0")
     parser.add_argument(
+        "--listing",
+        type=Path,
+        default=DEFAULT_LISTING_YAML,
+    )
+    parser.add_argument(
         "--fields",
         default="ReleaseNotes",
         help="Comma-separated BaseListing fields to verify (default: ReleaseNotes)",


### PR DESCRIPTION
## Summary
- Add v2.6.0 to CHANGELOG
- Mark v2.6 as shipped in ROADMAP and retarget active work at v3.0 (#131)
- Update AGENTS.md and PROJECT.md release status

## Test plan
- [ ] Docs read correctly; no code changes

## Follow-up after merge
- [ ] Close #134 (Store pipeline slice complete)