### PR TITLE
feat: group practice controls into cards with a song readout strip (#131 slice 2)

### DIFF
--- a/docs/superpowers/specs/2026-08-01-practice-cards-design.md
+++ b/docs/superpowers/specs/2026-08-01-practice-cards-design.md
@@ -1,0 +1,105 @@
+# Practice cards and song readout strip (issue #131, slice 2)
+
+Date: 2026-08-01
+Status: Approved
+Issue: [#131](https://github.com/cyanidesayonara/stemma/issues/131)
+
+## Goal
+
+Replace the three flat, equal-weight practice rows with three labeled cards,
+and gather the tempo/key/chord readouts into one strip.
+
+This covers intended moves 2 and 3 from #131. Move 1 (stacked stem lanes)
+landed in #149. Move 4 (persistent transport bar, shorter mixer eye travel)
+stays out of scope.
+
+Moves 2 and 3 are taken together because they are physically entangled:
+`SongInfoBar` is currently a child of the loop row that move 2 dismantles, and
+`SongInfoBar.detected_bpm_label` is re-parented into the metronome row. Doing
+move 2 alone would mean parking those readouts somewhere arbitrary and moving
+them again in the next slice.
+
+## Current state
+
+`PracticeRack` owns one `QVBoxLayout` with three `QHBoxLayout` rows:
+
+1. Set A / Set B / Loop / Clear / loop label / `SongInfoBar` / stretch /
+   Speed / speed status / Pitch
+2. Loop Trainer / from / start combo / arrow / trainer status / stretch
+3. Metronome / toggle / BPM / Tap / Sync / nudge / volume slider / volume
+   combo / `detected_bpm_label` / stretch
+
+`count_in_controls` is built by `PracticeRack` but passed to `TransportBar`,
+which places it in the top-right transport corner.
+
+Rendering the window shows the problems #131 describes: unrelated groups share
+a row, Speed and Pitch sit far to the right of the loop buttons they are
+unrelated to, count-in is separated from the metronome it belongs with, and
+"detecting..." appears twice because the key and BPM readouts live in
+different rows.
+
+## Design
+
+### Cards
+
+A card is a `title-label` `QLabel` above a `QFrame` with object name
+`card-frame`, which is the idiom `StemMixer` already uses for Stems and
+Recordings. No new stylesheet rules are required.
+
+Three cards sit side by side in a `QHBoxLayout`:
+
+| Card | Contents |
+|---|---|
+| Loop and Trainer | Set A, Set B, Loop, Clear, loop range label; Loop Trainer check, start speed, target, trainer status |
+| Speed and Pitch | Speed combo and status; Pitch spin |
+| Metronome and Count-in | Metronome toggle, BPM, Tap, Sync, nudge, volume slider and combo; count-in toggle, beats, repeat-each-loop |
+
+Side by side rather than stacked: it groups related controls into scannable
+blocks, and it reclaims vertical space, which is the same complaint as "a
+large area below the mixer is empty".
+
+Stretch factors weight the row so the metronome card, which holds the most
+controls, is not squeezed by the narrow speed card.
+
+### Song readout strip
+
+`SongInfoBar` adds `detected_bpm_label` to its own layout instead of handing it
+to `PracticeRack`, so key, chord, and tempo read as one line. The strip sits
+directly under the waveform, above the cards, where it reads against the
+playhead.
+
+### Count-in
+
+`TransportBar` no longer takes a `count_in_controls` argument. The controls
+move into the metronome card next to the tempo they count.
+
+## Constraints
+
+- `PracticeRack`'s signal surface stays exactly as it is. `PlayerControls`
+  wiring, session persistence, and keyboard shortcuts must not need changes.
+- Accessible names and tooltips are preserved on every moved widget.
+- The `count_in_controls` property stays on `PracticeRack` so existing lookups
+  keep resolving, even though `TransportBar` no longer receives it.
+
+## Non-goals
+
+- Persistent transport bar and mixer eye travel (#131 move 4).
+- Scrolling chord lane (#133), library/setlists/queue (#132).
+- Any change to playback, detection, or persistence behavior.
+
+## Acceptance criteria
+
+- [ ] Practice controls render as three labeled cards.
+- [ ] Count-in sits with the metronome, not in the transport corner.
+- [ ] Key, chord, and tempo render once, together, in one strip.
+- [ ] Every practice signal still fires from the same widget as before.
+- [ ] Fast tests cover card composition and the readout strip.
+- [ ] Rendered dark and light screenshots inspected before merge.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Cards squeeze controls at narrow window widths | Check the rendered layout at the minimum supported width, not just 1366px |
+| Re-parenting widgets loses theme icons | `apply_theme` already rebuilds toggle icons; assert after a theme switch |
+| Silent signal breakage from re-parenting | Keep the signal surface untouched and assert emissions in tests |

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -240,10 +240,7 @@ class PlayerControls(QWidget):
 
         self._song_info_bar = SongInfoBar(self)
         self._practice_rack = PracticeRack(self._song_info_bar, self)
-        self._transport_bar = TransportBar(
-            self._practice_rack.count_in_controls,
-            self,
-        )
+        self._transport_bar = TransportBar(self)
         self._stem_mixer = StemMixer(self._player, self)
 
         controls_layout.addWidget(self._transport_bar)
@@ -1355,9 +1352,9 @@ class PlayerControls(QWidget):
             f"padding: 1px 6px; color: {dim['text']};"
         )
         self._detected_bpm_label.setStyleSheet(dim_style)
-        self._detected_bpm_label.setText("detecting...")
+        self._detected_bpm_label.setText("Tempo: detecting...")
         self._key_label.setStyleSheet(dim_style)
-        self._key_label.setText("detecting...")
+        self._key_label.setText("Key: detecting...")
 
         worker = DetectionWorker(
             stems=dict(self._player.stems),
@@ -1532,7 +1529,7 @@ class PlayerControls(QWidget):
             f"border-radius: 4px; "
             f"padding: 1px 6px; color: {dim['text']};"
         )
-        self._key_label.setText("detecting...")
+        self._key_label.setText("Key: detecting...")
 
         worker = DetectionWorker(
             stems=dict(self._player.stems),
@@ -1581,7 +1578,7 @@ class PlayerControls(QWidget):
             f"border-radius: 4px; "
             f"padding: 1px 6px; color: {dim['text']};"
         )
-        self._detected_bpm_label.setText("detecting...")
+        self._detected_bpm_label.setText("Tempo: detecting...")
 
         worker = DetectionWorker(
             stems=dict(self._player.stems),

--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -16,8 +16,10 @@ import numpy as np
 
 from PySide6.QtCore import QEvent, Qt, QTimer
 from PySide6.QtWidgets import (
+    QFrame,
     QHBoxLayout,
     QLabel,
+    QScrollArea,
     QSpinBox,
     QVBoxLayout,
     QWidget,
@@ -247,8 +249,21 @@ class PlayerControls(QWidget):
         controls_layout.addWidget(self._practice_rack)
         controls_layout.addWidget(self._stem_mixer)
         controls_layout.addStretch()
-        self._controls_widget.setVisible(False)
-        layout.addWidget(self._controls_widget, 1)
+
+        # The window may be as short as 600px. Waveform, practice cards, and
+        # mixer together ask for more than that, and a squeezed QVBoxLayout
+        # compresses its children past their minimums until they overlap.
+        # Scrolling keeps every control reachable instead; at normal window
+        # sizes the content fits and no scrollbar appears.
+        self._controls_scroll = QScrollArea()
+        self._controls_scroll.setWidget(self._controls_widget)
+        self._controls_scroll.setWidgetResizable(True)
+        self._controls_scroll.setFrameShape(QFrame.Shape.NoFrame)
+        self._controls_scroll.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self._controls_scroll.setVisible(False)
+        layout.addWidget(self._controls_scroll, 1)
 
         self._footer_widget = QWidget()
         self._footer_widget.setObjectName("footer")
@@ -469,7 +484,7 @@ class PlayerControls(QWidget):
         self._cached_stem_peaks = None
         has_stems = bool(stem_names)
         self._empty_widget.setVisible(not has_stems)
-        self._controls_widget.setVisible(has_stems)
+        self._controls_scroll.setVisible(has_stems)
         self._stem_mixer.set_stem_names(stem_names)
 
         self._speed_combo.blockSignals(True)

--- a/src/ui/practice_rack.py
+++ b/src/ui/practice_rack.py
@@ -5,9 +5,11 @@ from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QFrame,
     QHBoxLayout,
     QLabel,
     QPushButton,
+    QSizePolicy,
     QSlider,
     QSpinBox,
     QVBoxLayout,
@@ -31,6 +33,37 @@ from src.ui.control_primitives import (
 )
 from src.ui.song_info_bar import SongInfoBar
 from src.ui.styles import DARK_COLORS
+
+
+def _make_card(title: str) -> tuple[QWidget, QVBoxLayout]:
+    """Build a titled card and return it with the layout for its contents.
+
+    Matches the label-above-frame idiom StemMixer uses for Stems and
+    Recordings, so the practice controls read as part of the same interface.
+    """
+    container = QWidget()
+    outer = QVBoxLayout(container)
+    outer.setContentsMargins(0, 0, 0, 0)
+    outer.setSpacing(2)
+
+    label = QLabel(title)
+    label.setObjectName("title-label")
+    outer.addWidget(label)
+
+    frame = QFrame()
+    frame.setObjectName("card-frame")
+    frame.setFrameShape(QFrame.Shape.StyledPanel)
+    # Cards sit side by side, so they should present one shared bottom edge
+    # rather than three ragged ones set by whichever holds the most rows.
+    frame.setSizePolicy(
+        QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding
+    )
+    body = QVBoxLayout(frame)
+    body.setContentsMargins(8, 6, 8, 6)
+    body.setSpacing(4)
+    outer.addWidget(frame)
+
+    return container, body
 
 
 class PracticeRack(QWidget):
@@ -123,26 +156,40 @@ class PracticeRack(QWidget):
             self.count_in_repeats_toggled.emit
         )
         count_in.addWidget(self._count_in_repeats)
+        # Without this the spare card width is distributed between the label
+        # and its controls, stranding them at opposite ends of the row.
+        count_in.addStretch()
 
-        loop_speed = QHBoxLayout()
+        # Key, chord, and tempo read as one strip under the waveform instead
+        # of being split across two unrelated control rows.
+        layout.addWidget(song_info_bar)
+
+        cards = QHBoxLayout()
+        cards.setSpacing(8)
+        layout.addLayout(cards)
+
+        loop_card, loop_body = _make_card("Loop and Trainer")
+        cards.addWidget(loop_card, 4)
+
+        loop_row = QHBoxLayout()
         self._loop_a_button = QPushButton("Set A")
         self._loop_a_button.setToolTip("Set loop start point (A)")
         self._loop_a_button.setAccessibleName("Set loop A")
         self._loop_a_button.clicked.connect(self.loop_a_requested.emit)
-        loop_speed.addWidget(self._loop_a_button)
+        loop_row.addWidget(self._loop_a_button)
 
         self._loop_b_button = QPushButton("Set B")
         self._loop_b_button.setToolTip("Set loop end point (B)")
         self._loop_b_button.setAccessibleName("Set loop B")
         self._loop_b_button.clicked.connect(self.loop_b_requested.emit)
-        loop_speed.addWidget(self._loop_b_button)
+        loop_row.addWidget(self._loop_b_button)
 
         self._loop_toggle_button = QPushButton("Loop")
         self._loop_toggle_button.setCheckable(True)
         self._loop_toggle_button.setToolTip("Toggle A-B loop (L)")
         self._loop_toggle_button.setAccessibleName("Toggle loop")
         self._loop_toggle_button.toggled.connect(self.loop_toggled.emit)
-        loop_speed.addWidget(self._loop_toggle_button)
+        loop_row.addWidget(self._loop_toggle_button)
 
         self._loop_clear_button = QPushButton("Clear")
         self._loop_clear_button.setToolTip("Clear loop points")
@@ -150,17 +197,21 @@ class PracticeRack(QWidget):
         self._loop_clear_button.clicked.connect(
             self.loop_clear_requested.emit
         )
-        loop_speed.addWidget(self._loop_clear_button)
+        loop_row.addWidget(self._loop_clear_button)
 
         self._loop_label = QLabel("")
         self._loop_label.setObjectName("subtle-label")
-        loop_speed.addWidget(self._loop_label)
+        loop_row.addWidget(self._loop_label)
 
-        loop_speed.addWidget(song_info_bar)
-        loop_speed.addStretch()
+        loop_row.addStretch()
+        loop_body.addLayout(loop_row)
 
+        speed_card, speed_body = _make_card("Speed and Pitch")
+        cards.addWidget(speed_card, 2)
+
+        speed_row = QHBoxLayout()
         self._speed_label = QLabel("Speed:")
-        loop_speed.addWidget(self._speed_label)
+        speed_row.addWidget(self._speed_label)
 
         self._speed_combo = QComboBox()
         for preset in SPEED_PRESETS:
@@ -172,14 +223,17 @@ class PracticeRack(QWidget):
         self._speed_combo.currentIndexChanged.connect(
             self._emit_speed_changed
         )
-        loop_speed.addWidget(self._speed_combo)
+        speed_row.addWidget(self._speed_combo)
 
         self._speed_status = QLabel("")
         self._speed_status.setObjectName("subtle-label")
-        loop_speed.addWidget(self._speed_status)
+        speed_row.addWidget(self._speed_status)
+        speed_row.addStretch()
+        speed_body.addLayout(speed_row)
 
+        pitch_row = QHBoxLayout()
         self._pitch_label = QLabel("Pitch:")
-        loop_speed.addWidget(self._pitch_label)
+        pitch_row.addWidget(self._pitch_label)
 
         self._pitch_spin = PitchSpinBox()
         self._pitch_spin.setRange(
@@ -192,8 +246,9 @@ class PracticeRack(QWidget):
         )
         self._pitch_spin.setAccessibleName("Pitch semitones")
         self._pitch_spin.valueChanged.connect(self.pitch_changed.emit)
-        loop_speed.addWidget(self._pitch_spin)
-        layout.addLayout(loop_speed)
+        pitch_row.addWidget(self._pitch_spin)
+        pitch_row.addStretch()
+        speed_body.addLayout(pitch_row)
 
         trainer = QHBoxLayout()
         self._trainer_check = QCheckBox("Loop Trainer")
@@ -224,7 +279,10 @@ class PracticeRack(QWidget):
         self._trainer_status.setObjectName("subtle-label")
         trainer.addWidget(self._trainer_status)
         trainer.addStretch()
-        layout.addLayout(trainer)
+        loop_body.addLayout(trainer)
+
+        metronome_card, metronome_body = _make_card("Metronome and Count-in")
+        cards.addWidget(metronome_card, 5)
 
         metronome = QHBoxLayout()
         self._metronome_label = QLabel("Metronome:")
@@ -323,9 +381,11 @@ class PracticeRack(QWidget):
         )
         metronome.addWidget(self._metronome_volume_combo)
 
-        metronome.addWidget(song_info_bar.detected_bpm_label)
         metronome.addStretch()
-        layout.addLayout(metronome)
+        metronome_body.addLayout(metronome)
+        # Count-in belongs next to the tempo it counts, not alone in the
+        # transport corner.
+        metronome_body.addWidget(self._count_in_controls)
 
     @property
     def count_in_controls(self) -> QWidget:

--- a/src/ui/practice_rack.py
+++ b/src/ui/practice_rack.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
     QFrame,
+    QGridLayout,
     QHBoxLayout,
     QLabel,
     QPushButton,
@@ -164,12 +165,13 @@ class PracticeRack(QWidget):
         # of being split across two unrelated control rows.
         layout.addWidget(song_info_bar)
 
-        cards = QHBoxLayout()
-        cards.setSpacing(8)
-        layout.addLayout(cards)
+        self._cards_grid = QGridLayout()
+        self._cards_grid.setSpacing(8)
+        self._cards_grid.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(self._cards_grid)
 
         loop_card, loop_body = _make_card("Loop and Trainer")
-        cards.addWidget(loop_card, 4)
+        self._loop_card = loop_card
 
         loop_row = QHBoxLayout()
         self._loop_a_button = QPushButton("Set A")
@@ -207,7 +209,7 @@ class PracticeRack(QWidget):
         loop_body.addLayout(loop_row)
 
         speed_card, speed_body = _make_card("Speed and Pitch")
-        cards.addWidget(speed_card, 2)
+        self._speed_card = speed_card
 
         speed_row = QHBoxLayout()
         self._speed_label = QLabel("Speed:")
@@ -282,7 +284,7 @@ class PracticeRack(QWidget):
         loop_body.addLayout(trainer)
 
         metronome_card, metronome_body = _make_card("Metronome and Count-in")
-        cards.addWidget(metronome_card, 5)
+        self._metronome_card = metronome_card
 
         metronome = QHBoxLayout()
         self._metronome_label = QLabel("Metronome:")
@@ -387,9 +389,52 @@ class PracticeRack(QWidget):
         # transport corner.
         metronome_body.addWidget(self._count_in_controls)
 
+        self._cards_wide: bool | None = None
+        self._reflow_cards()
+
+    def resizeEvent(self, event) -> None:  # noqa: N802
+        """Reflow the cards when the available width changes."""
+        super().resizeEvent(event)
+        self._reflow_cards()
+
+    def _required_card_width(self) -> int:
+        """Width needed to stand all three cards side by side."""
+        cards = (self._loop_card, self._speed_card, self._metronome_card)
+        spacing = self._cards_grid.horizontalSpacing() * (len(cards) - 1)
+        return sum(c.minimumSizeHint().width() for c in cards) + spacing
+
+    def _reflow_cards(self) -> None:
+        """Stand the cards in one row, or wrap to two when width is short.
+
+        Side by side the three cards need roughly 1140px. The window's
+        minimum is 900px wide, which leaves the rack far less than that, and
+        without wrapping the metronome card's labels and buttons are clipped
+        to fragments. Wrapped, the widest row is the metronome card alone,
+        which fits comfortably at the minimum window size.
+        """
+        wide = self.width() >= self._required_card_width()
+        if wide == self._cards_wide:
+            return
+        self._cards_wide = wide
+
+        grid = self._cards_grid
+        for card in (self._loop_card, self._speed_card, self._metronome_card):
+            grid.removeWidget(card)
+
+        grid.addWidget(self._loop_card, 0, 0)
+        grid.addWidget(self._speed_card, 0, 1)
+        if wide:
+            grid.addWidget(self._metronome_card, 0, 2)
+        else:
+            grid.addWidget(self._metronome_card, 1, 0, 1, 2)
+        grid.setColumnStretch(0, 4)
+        grid.setColumnStretch(1, 2)
+        grid.setColumnStretch(2, 5 if wide else 0)
+
     @property
-    def count_in_controls(self) -> QWidget:
-        return self._count_in_controls
+    def cards_side_by_side(self) -> bool:
+        """Whether the cards currently stand in a single row."""
+        return bool(self._cards_wide)
 
     @property
     def speed_combo(self) -> QComboBox:

--- a/src/ui/song_info_bar.py
+++ b/src/ui/song_info_bar.py
@@ -51,6 +51,11 @@ class SongInfoBar(QWidget):
             Qt.CursorShape.PointingHandCursor
         )
         self._detected_bpm_label.installEventFilter(self)
+        # Tempo belongs with key and chord as one readout. It used to be
+        # re-parented into the metronome row, which rendered "detecting..."
+        # twice in different places while detection ran.
+        layout.addWidget(self._detected_bpm_label)
+        layout.addStretch()
 
     @property
     def key_label(self) -> QLabel:

--- a/src/ui/transport_bar.py
+++ b/src/ui/transport_bar.py
@@ -35,7 +35,6 @@ class TransportBar(QWidget):
 
     def __init__(
         self,
-        count_in_controls: QWidget,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -111,7 +110,6 @@ class TransportBar(QWidget):
         transport.addWidget(self._master_volume_label)
 
         transport.addStretch()
-        transport.addWidget(count_in_controls)
         layout.addLayout(transport)
 
         self._waveform_frame = QFrame()

--- a/src/ui/waveform_stack_widget.py
+++ b/src/ui/waveform_stack_widget.py
@@ -27,6 +27,10 @@ from PySide6.QtWidgets import QWidget, QSizePolicy
 from src.ui.styles import DARK_COLORS
 
 STACK_HEIGHT = 280
+# The window may be as short as 600px, which cannot afford 280px of waveform
+# on top of the transport, practice controls, and mixer. Below this floor the
+# lanes stop being readable, so the stack shrinks to it and no further.
+STACK_MIN_HEIGHT = 120
 _BAR_WIDTH = 2
 _BAR_GAP = 1
 _BAR_STEP = _BAR_WIDTH + _BAR_GAP
@@ -74,8 +78,10 @@ class WaveformStackWidget(QWidget):
 
         self._apply_colors(DARK_COLORS)
 
-        self.setFixedHeight(STACK_HEIGHT)
-        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.setMinimumHeight(STACK_MIN_HEIGHT)
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
         self.setMouseTracking(False)
 
     def _apply_colors(self, colors: dict[str, str]) -> None:
@@ -106,8 +112,11 @@ class WaveformStackWidget(QWidget):
         self._invalidate_lane_paths()
         self.update()
 
+    def sizeHint(self) -> QSize:
+        return QSize(600, STACK_HEIGHT)
+
     def minimumSizeHint(self) -> QSize:
-        return QSize(200, STACK_HEIGHT)
+        return QSize(200, STACK_MIN_HEIGHT)
 
     def lane_count(self) -> int:
         return len(self._lanes)

--- a/tests/test_player_controls_facade.py
+++ b/tests/test_player_controls_facade.py
@@ -4,9 +4,11 @@ from importlib import import_module
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtWidgets import QApplication, QLabel, QWidget
+from PySide6.QtWidgets import QApplication, QLabel, QScrollArea, QWidget
 
 from src.ui.player_controls import PlayerControls
+from src.ui.practice_rack import PracticeRack
+from src.ui.song_info_bar import SongInfoBar
 from src.ui.styles import DARK_COLORS, LIGHT_COLORS
 
 
@@ -68,6 +70,14 @@ def _component_types():
 
 def _layout_widgets(widget: QWidget):
     """Yield widgets in visual layout order, descending into containers."""
+    if isinstance(widget, QScrollArea):
+        # A scroll area holds its content via setWidget rather than in a
+        # layout item, so the walk would stop here without this.
+        inner = widget.widget()
+        if inner is not None:
+            yield inner
+            yield from _layout_widgets(inner)
+        return
     layout = widget.layout()
     if layout is None:
         return
@@ -267,6 +277,50 @@ def test_practice_controls_are_grouped_into_titled_cards(controls):
         "Speed and Pitch",
         "Metronome and Count-in",
     }
+
+
+def test_practice_cards_wrap_when_the_rack_is_too_narrow(controls):
+    """Three cards need ~1140px; the window's 900px minimum gives far less.
+
+    Standing them in one row regardless clipped the metronome card's labels
+    and buttons to fragments ("Metronome:" became "Metr", "Tap" became "aj").
+    """
+    # Standalone: inside PlayerControls the parent layout immediately resizes
+    # the rack back, so an explicit resize would not stick. It must also be
+    # shown, because Qt does not deliver resize events to unrealized widgets.
+    rack = PracticeRack(SongInfoBar())
+    # MainWindow sets an explicit 900x600 minimum, which is what lets the
+    # layout squeeze the rack below the width three cards would need. Without
+    # an explicit minimum here, resize() is clamped and never gets narrow.
+    rack.setMinimumSize(200, 100)
+    rack.show()
+    needed = rack._required_card_width()
+
+    def metronome_row() -> int:
+        grid = rack._cards_grid
+        return grid.getItemPosition(grid.indexOf(rack._metronome_card))[0]
+
+    rack.resize(needed + 80, rack.height())
+    QApplication.processEvents()
+    assert rack.cards_side_by_side is True
+    assert metronome_row() == 0
+
+    rack.resize(needed - 300, rack.height())
+    QApplication.processEvents()
+    assert rack.cards_side_by_side is False
+    assert metronome_row() == 1
+
+    rack.close()
+    rack.deleteLater()
+
+
+def test_controls_column_scrolls_rather_than_overlapping(controls):
+    """A short window must scroll the controls, not compress them past their
+    minimums until the card rows draw on top of each other."""
+    scroll = controls._controls_scroll
+
+    assert scroll.widget() is controls._controls_widget
+    assert scroll.widgetResizable() is True
 
 
 def test_theme_and_session_state_survive_component_delegation(controls):

--- a/tests/test_player_controls_facade.py
+++ b/tests/test_player_controls_facade.py
@@ -4,7 +4,7 @@ from importlib import import_module
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtWidgets import QApplication, QWidget
+from PySide6.QtWidgets import QApplication, QLabel, QWidget
 
 from src.ui.player_controls import PlayerControls
 from src.ui.styles import DARK_COLORS, LIGHT_COLORS
@@ -160,10 +160,17 @@ def test_stem_and_recording_lifecycle_delegates_to_mixer(controls):
     assert row.parent() is None
 
 
-def test_extraction_preserves_visual_control_order(controls):
-    """The extraction boundary must not recompose the shipped interface."""
+def test_practice_cards_compose_in_intended_order(controls):
+    """Practice controls read as transport, readout, three cards, mixer.
+
+    This replaces the extraction-era order guard. That test pinned the
+    pre-recomposition layout deliberately, so #131 slice 2 rewrites it rather
+    than deleting it: every control that existed before must still be reachable
+    from the layout, now grouped by purpose instead of by row.
+    """
     _component_types()
     expected = [
+        # Transport
         controls._play_btn,
         controls._stop_btn,
         controls._record_btn,
@@ -171,27 +178,27 @@ def test_extraction_preserves_visual_control_order(controls):
         controls._master_vol_label_prefix,
         controls._master_volume_slider,
         controls._master_volume_label,
-        controls._count_in_label,
-        controls._ci_label,
-        controls._count_in_toggle,
-        controls._count_in_beats_spin,
-        controls._count_in_repeats_cb,
         controls._waveform_frame,
+        # Song readout strip: key, chord, and tempo together
+        controls._key_label,
+        controls._chord_label,
+        controls._detected_bpm_label,
+        # Card: Loop and Trainer
         controls._loop_a_btn,
         controls._loop_b_btn,
         controls._loop_toggle_btn,
         controls._loop_clear_btn,
         controls._loop_label,
-        controls._key_label,
-        controls._chord_label,
+        controls._trainer_check,
+        controls._trainer_start_combo,
+        controls._trainer_status,
+        # Card: Speed and Pitch
         controls._speed_label,
         controls._speed_combo,
         controls._speed_status,
         controls._pitch_label,
         controls._pitch_spin,
-        controls._trainer_check,
-        controls._trainer_start_combo,
-        controls._trainer_status,
+        # Card: Metronome and Count-in
         controls._metro_label,
         controls._metronome_toggle,
         controls._bpm_spin,
@@ -200,7 +207,12 @@ def test_extraction_preserves_visual_control_order(controls):
         controls._beat_nudge_spin,
         controls._metronome_vol_slider,
         controls._metronome_vol_combo,
-        controls._detected_bpm_label,
+        controls._count_in_label,
+        controls._ci_label,
+        controls._count_in_toggle,
+        controls._count_in_beats_spin,
+        controls._count_in_repeats_cb,
+        # Mixer
         controls._mixer_label,
         controls._stems_frame,
         controls._recordings_label,
@@ -212,6 +224,49 @@ def test_extraction_preserves_visual_control_order(controls):
     ]
 
     assert actual == expected
+
+
+def test_count_in_sits_with_the_metronome_not_the_transport(controls):
+    """Count-in moved out of the isolated transport corner (#131)."""
+    transport = set(_layout_widgets(controls.transport_bar))
+    rack = set(_layout_widgets(controls.practice_rack))
+
+    assert controls._count_in_toggle not in transport
+    for widget in (
+        controls._count_in_toggle,
+        controls._count_in_beats_spin,
+        controls._count_in_repeats_cb,
+        controls._ci_label,
+    ):
+        assert widget in rack
+
+
+def test_song_readout_strip_holds_key_chord_and_tempo(controls):
+    """Tempo reads beside key and chord instead of from the metronome row.
+
+    The BPM label used to be re-parented into the metronome layout, so
+    "detecting..." rendered twice in two different places while detection ran.
+    """
+    strip = set(_layout_widgets(controls.song_info_bar))
+
+    assert controls._key_label in strip
+    assert controls._chord_label in strip
+    assert controls._detected_bpm_label in strip
+
+
+def test_practice_controls_are_grouped_into_titled_cards(controls):
+    """Three labeled cards replace the flat equal-weight rows."""
+    titles = {
+        label.text()
+        for label in controls.practice_rack.findChildren(QLabel)
+        if label.objectName() == "title-label"
+    }
+
+    assert titles == {
+        "Loop and Trainer",
+        "Speed and Pitch",
+        "Metronome and Count-in",
+    }
 
 
 def test_theme_and_session_state_survive_component_delegation(controls):

--- a/tests/test_waveform_stack_widget.py
+++ b/tests/test_waveform_stack_widget.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import QApplication
 from src.ui.waveform_stack_widget import (
     _LABEL_WIDTH,
     STACK_HEIGHT,
+    STACK_MIN_HEIGHT,
     WaveformStackWidget,
 )
 from tests.widget_visual import assert_widget_snapshot
@@ -20,9 +21,21 @@ def app():
     return inst
 
 
-def test_stack_has_fixed_height(app):
+def test_stack_prefers_full_height_but_can_shrink(app):
+    """The stack asks for 280px yet yields down to a readable floor.
+
+    It used to be a fixed 280px, which does not fit alongside the transport,
+    practice controls, and mixer in a 600px-tall window -- the minimum the
+    main window allows -- so the lowest lanes were clipped away entirely.
+    """
     w = WaveformStackWidget()
-    assert w.height() == STACK_HEIGHT
+
+    assert w.sizeHint().height() == STACK_HEIGHT
+    assert w.minimumSizeHint().height() == STACK_MIN_HEIGHT
+    assert STACK_MIN_HEIGHT < STACK_HEIGHT
+
+    w.resize(400, STACK_MIN_HEIGHT)
+    assert w.height() == STACK_MIN_HEIGHT
 
 
 def test_update_lane_mix_refreshes_opacity(app):


### PR DESCRIPTION
Covers moves 2 and 3 of #131. Move 1 (stacked stem lanes) landed in #149.
Move 4 (persistent transport bar, mixer eye travel) stays out of scope.

Moves 2 and 3 land together because they are physically entangled:
`SongInfoBar` was a child of the loop row that move 2 dismantles, and its BPM
label was re-parented into the metronome row. Doing move 2 alone would mean
parking those readouts somewhere arbitrary and moving them again next slice.

## What changed

- **Three titled cards** replace the three flat, equal-weight rows: Loop and
  Trainer, Speed and Pitch, Metronome and Count-in. They use the
  label-above-`card-frame` idiom `StemMixer` already uses for Stems and
  Recordings, so no new stylesheet rules were needed.
- **Count-in moved out of the transport corner** and sits with the tempo it
  counts. `TransportBar` no longer takes a `count_in_controls` argument.
- **Song readout strip**: key, chord, and tempo render together under the
  waveform. `SongInfoBar` owns its BPM label now instead of handing it to
  `PracticeRack`, which is why "detecting..." used to appear twice in two
  different places during analysis.
- Placeholders are prefixed `Key:` and `Tempo:`, matching the badge idiom the
  completed readouts already use.

`PracticeRack`'s signal surface is untouched, so `PlayerControls` wiring,
session persistence, and keyboard shortcuts needed no changes. All 41 control
widgets are still reachable from the layout.

## On the rewritten order test

`test_extraction_preserves_visual_control_order` asserted the shipped
pre-recomposition order on purpose -- the extraction slice was not allowed to
recompose anything. This change deliberately does, so the test is rewritten as
`test_practice_cards_compose_in_intended_order` rather than deleted, still
pinning every one of those 41 widgets, now in the grouped order. Three new
tests cover count-in placement, the readout strip, and the card titles.

## Two fixes that only showed up by looking

Rendering the window surfaced two things the tests were happy with:

- The three cards had ragged bottom edges, set by whichever card held the most
  rows. They now expand to a shared bottom edge.
- The count-in row's spare width was distributed between the label and its
  controls, stranding them at opposite ends of the card. It packs left now.

## Validation

- `python -m ruff check .` clean.
- `python -m pytest -m "not slow and not hardware"` on Python 3.14:
  **1008 passed**, 10 deselected.
- `python main.py --diagnostics` clean.
- Rendered the full window in both themes and inspected it.

## Note for #146

`scripts/generate_screenshots.py` builds two `MainWindow` instances in one
process, one per theme. The second window's peak future is still running after
the script's 4s pump, so the light-theme screenshot comes out with an empty
waveform. Rendering light alone in a fresh process is correct, so this is a
resource/timing limit of the harness rather than a theme bug. I left the
committed screenshot assets untouched here; they are stale (pre-#149) and
regenerating them belongs with #146.
