### PR TITLE
feat: anchor the transport below the scrolling practice content (#131 move 4)

### DIFF
--- a/src/ui/player_controls.py
+++ b/src/ui/player_controls.py
@@ -44,6 +44,7 @@ from src.ui.styles import (
     STEM_COLORS_LIGHT,
 )
 from src.ui.transport_bar import TransportBar
+from src.ui.waveform_panel import WaveformPanel
 from src.waveform import compute_stem_peaks
 
 _PEAK_DEBOUNCE_MS = 80
@@ -199,6 +200,11 @@ class PlayerControls(QWidget):
         return self._transport_bar
 
     @property
+    def waveform_panel(self) -> WaveformPanel:
+        """Return the framed stem-lane waveform component."""
+        return self._waveform_panel
+
+    @property
     def stem_mixer(self) -> StemMixer:
         """Return the stem and recording mixer component."""
         return self._stem_mixer
@@ -243,9 +249,10 @@ class PlayerControls(QWidget):
         self._song_info_bar = SongInfoBar(self)
         self._practice_rack = PracticeRack(self._song_info_bar, self)
         self._transport_bar = TransportBar(self)
+        self._waveform_panel = WaveformPanel(self)
         self._stem_mixer = StemMixer(self._player, self)
 
-        controls_layout.addWidget(self._transport_bar)
+        controls_layout.addWidget(self._waveform_panel)
         controls_layout.addWidget(self._practice_rack)
         controls_layout.addWidget(self._stem_mixer)
         controls_layout.addStretch()
@@ -264,6 +271,13 @@ class PlayerControls(QWidget):
         )
         self._controls_scroll.setVisible(False)
         layout.addWidget(self._controls_scroll, 1)
+
+        # Anchored below the scroll area rather than inside it: play, stop,
+        # record, and the master volume stay put no matter how far the
+        # practice content is scrolled, and they sit closest to the mixer a
+        # player reaches for between takes.
+        self._transport_bar.setVisible(False)
+        layout.addWidget(self._transport_bar)
 
         self._footer_widget = QWidget()
         self._footer_widget.setObjectName("footer")
@@ -309,8 +323,8 @@ class PlayerControls(QWidget):
         self._master_vol_label_prefix = transport.master_volume_prefix
         self._master_volume_slider = transport.master_volume_slider
         self._master_volume_label = transport.master_volume_label
-        self._waveform_frame = transport.waveform_frame
-        self._waveform = transport.waveform
+        self._waveform_frame = self._waveform_panel.frame
+        self._waveform = self._waveform_panel.waveform
         self._play_icon = transport.play_icon
         self._pause_icon = transport.pause_icon
         self._stop_icon = transport.stop_icon
@@ -368,7 +382,7 @@ class PlayerControls(QWidget):
         transport.master_volume_changed.connect(
             self._on_master_volume_requested
         )
-        transport.seek_requested.connect(self._on_waveform_seek)
+        self._waveform_panel.seek_requested.connect(self._on_waveform_seek)
 
         practice = self._practice_rack
         practice.loop_a_requested.connect(self.set_loop_a)
@@ -432,6 +446,7 @@ class PlayerControls(QWidget):
         """Switch all theme-dependent visuals to *theme*."""
         self._theme = theme
         self._transport_bar.apply_theme(colors, self._player.is_playing)
+        self._waveform_panel.apply_theme(colors)
         self._play_icon = self._transport_bar.play_icon
         self._pause_icon = self._transport_bar.pause_icon
         self._stop_icon = self._transport_bar.stop_icon
@@ -485,6 +500,7 @@ class PlayerControls(QWidget):
         has_stems = bool(stem_names)
         self._empty_widget.setVisible(not has_stems)
         self._controls_scroll.setVisible(has_stems)
+        self._transport_bar.setVisible(has_stems)
         self._stem_mixer.set_stem_names(stem_names)
 
         self._speed_combo.blockSignals(True)

--- a/src/ui/styles.py
+++ b/src/ui/styles.py
@@ -408,6 +408,13 @@ QWidget#footer {{
     border-top: 1px solid {c["surface0"]};
 }}
 
+/* The transport is anchored below the scrolling practice content, so it
+   needs an edge to read as a fixed bar rather than as the last row that
+   happened to scroll into view. */
+QWidget#transport-bar {{
+    border-top: 1px solid {c["surface0"]};
+}}
+
 QLabel#copyright {{
     color: {c["surface1"]};
     font-size: 9pt;

--- a/src/ui/transport_bar.py
+++ b/src/ui/transport_bar.py
@@ -1,9 +1,13 @@
-"""Core playback transport and waveform presentation."""
+"""Core playback transport controls.
+
+The waveform lives in WaveformPanel rather than here: the transport stays
+anchored to the bottom of the window while the waveform scrolls with the rest
+of the practice content.
+"""
 
 from PySide6.QtCore import QSize, Qt, Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
-    QFrame,
     QHBoxLayout,
     QLabel,
     QPushButton,
@@ -21,25 +25,24 @@ from src.ui.control_primitives import (
     make_icon,
 )
 from src.ui.styles import RECORDING_COLOR
-from src.ui.waveform_stack_widget import WaveformStackWidget
 
 
 class TransportBar(QWidget):
-    """Playback, recording, master-volume, seek, and waveform controls."""
+    """Playback, recording, and master-volume controls."""
 
     play_pause_requested = Signal()
     stop_requested = Signal()
     record_toggled = Signal(bool)
     master_volume_changed = Signal(float)
-    seek_requested = Signal(float)
 
     def __init__(
         self,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
+        self.setObjectName("transport-bar")
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setContentsMargins(0, 6, 0, 0)
 
         transport = QHBoxLayout()
         icon_color = QColor("#cdd6f4")
@@ -112,17 +115,6 @@ class TransportBar(QWidget):
         transport.addStretch()
         layout.addLayout(transport)
 
-        self._waveform_frame = QFrame()
-        self._waveform_frame.setObjectName("card-frame")
-        self._waveform_frame.setFrameShape(QFrame.Shape.StyledPanel)
-        waveform_layout = QVBoxLayout(self._waveform_frame)
-        waveform_layout.setContentsMargins(4, 4, 4, 4)
-
-        self._waveform = WaveformStackWidget()
-        self._waveform.seek_requested.connect(self.seek_requested.emit)
-        waveform_layout.addWidget(self._waveform)
-        layout.addWidget(self._waveform_frame)
-
     @property
     def play_button(self) -> QPushButton:
         return self._play_button
@@ -150,14 +142,6 @@ class TransportBar(QWidget):
     @property
     def master_volume_label(self) -> QLabel:
         return self._master_volume_label
-
-    @property
-    def waveform_frame(self) -> QFrame:
-        return self._waveform_frame
-
-    @property
-    def waveform(self) -> WaveformStackWidget:
-        return self._waveform
 
     @property
     def play_icon(self):
@@ -199,7 +183,6 @@ class TransportBar(QWidget):
             self._pause_icon if playing else self._play_icon
         )
         self._stop_button.setIcon(self._stop_icon)
-        self._waveform.set_theme_colors(colors)
 
     def set_playing(self, playing: bool) -> None:
         """Reflect the current player state in the play button."""

--- a/src/ui/waveform_panel.py
+++ b/src/ui/waveform_panel.py
@@ -1,0 +1,45 @@
+"""Framed stacked-stem waveform presentation.
+
+Split out of TransportBar so the waveform can scroll with the rest of the
+practice content while the transport stays anchored to the bottom of the
+window.
+"""
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QFrame, QVBoxLayout, QWidget
+
+from src.ui.waveform_stack_widget import WaveformStackWidget
+
+
+class WaveformPanel(QWidget):
+    """The stem-lane waveform inside its card frame."""
+
+    seek_requested = Signal(float)  # Emits seconds
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._frame = QFrame()
+        self._frame.setObjectName("card-frame")
+        self._frame.setFrameShape(QFrame.Shape.StyledPanel)
+        frame_layout = QVBoxLayout(self._frame)
+        frame_layout.setContentsMargins(4, 4, 4, 4)
+
+        self._waveform = WaveformStackWidget()
+        self._waveform.seek_requested.connect(self.seek_requested.emit)
+        frame_layout.addWidget(self._waveform)
+        layout.addWidget(self._frame)
+
+    @property
+    def frame(self) -> QFrame:
+        return self._frame
+
+    @property
+    def waveform(self) -> WaveformStackWidget:
+        return self._waveform
+
+    def apply_theme(self, colors: dict[str, str]) -> None:
+        """Repaint the lanes for a new theme."""
+        self._waveform.set_theme_colors(colors)

--- a/tests/test_player_controls_facade.py
+++ b/tests/test_player_controls_facade.py
@@ -117,7 +117,8 @@ def test_facade_keeps_existing_widget_aliases(controls):
 
     assert controls._play_btn is controls.transport_bar.play_button
     assert controls._record_btn is controls.transport_bar.record_button
-    assert controls._waveform is controls.transport_bar.waveform
+    assert controls._waveform is controls.waveform_panel.waveform
+    assert controls._waveform_frame is controls.waveform_panel.frame
     assert controls._stem_rows is controls.stem_mixer.stem_rows
     assert controls._recording_rows is controls.stem_mixer.recording_rows
     assert controls._speed_combo is controls.practice_rack.speed_combo
@@ -171,7 +172,8 @@ def test_stem_and_recording_lifecycle_delegates_to_mixer(controls):
 
 
 def test_practice_cards_compose_in_intended_order(controls):
-    """Practice controls read as transport, readout, three cards, mixer.
+    """Practice controls read as waveform, readout, three cards, mixer,
+    then the anchored transport.
 
     This replaces the extraction-era order guard. That test pinned the
     pre-recomposition layout deliberately, so #131 slice 2 rewrites it rather
@@ -180,14 +182,6 @@ def test_practice_cards_compose_in_intended_order(controls):
     """
     _component_types()
     expected = [
-        # Transport
-        controls._play_btn,
-        controls._stop_btn,
-        controls._record_btn,
-        controls._time_label,
-        controls._master_vol_label_prefix,
-        controls._master_volume_slider,
-        controls._master_volume_label,
         controls._waveform_frame,
         # Song readout strip: key, chord, and tempo together
         controls._key_label,
@@ -227,6 +221,15 @@ def test_practice_cards_compose_in_intended_order(controls):
         controls._stems_frame,
         controls._recordings_label,
         controls._recordings_frame,
+        # Transport, anchored last: it sits below the scrolling content so it
+        # stays put however far the practice controls are scrolled.
+        controls._play_btn,
+        controls._stop_btn,
+        controls._record_btn,
+        controls._time_label,
+        controls._master_vol_label_prefix,
+        controls._master_volume_slider,
+        controls._master_volume_label,
     ]
     markers = set(expected)
     actual = [
@@ -312,6 +315,26 @@ def test_practice_cards_wrap_when_the_rack_is_too_narrow(controls):
 
     rack.close()
     rack.deleteLater()
+
+
+def test_transport_is_anchored_outside_the_scrolling_content(controls):
+    """The transport must not scroll away with the practice controls.
+
+    The waveform scrolls with everything else; play, stop, record, and the
+    master volume stay put.
+    """
+    scrolled = set(_layout_widgets(controls._controls_widget))
+
+    assert controls._waveform_frame in scrolled
+    for widget in (
+        controls._play_btn,
+        controls._stop_btn,
+        controls._record_btn,
+        controls._master_volume_slider,
+    ):
+        assert widget not in scrolled
+
+    assert controls._transport_bar.parent() is controls
 
 
 def test_controls_column_scrolls_rather_than_overlapping(controls):


### PR DESCRIPTION
The second half of #131 move 4, and the last piece of the v3.0 visual
recomposition. The mixer eye-travel half landed in #151.

## What changed

`TransportBar` owned both the transport row and the waveform frame, which meant
they had to live in the same place in the layout. It is now split:

- **`WaveformPanel`** (new) -- the stem-lane waveform in its card frame. Scrolls
  with the practice content.
- **`TransportBar`** -- play, stop, record, time, master volume. Anchored below
  the scroll area.

This matters more since #150 put the controls column in a `QScrollArea`: the
transport would otherwise scroll out of view exactly when a short window makes
scrolling necessary. It also fills the dead space #131 describes below the
mixer, and puts the transport nearest the mixer a player reaches for between
takes.

The bar carries a top border matching the footer, so it reads as a fixed edge
rather than as the last row that happened to scroll into view.

## Compatibility

`TransportBar` keeps its signal surface and every property except the two
waveform accessors, which move to `WaveformPanel`. `PlayerControls` exposes
`waveform_panel` alongside `transport_bar` and rebinds the `_waveform` and
`_waveform_frame` aliases, so no other call site changed.

All 41 control widgets are still reachable from the layout. The order test is
updated to the new composition -- waveform, readout strip, three cards, mixer,
then the anchored transport -- and a new test asserts the transport is *not*
inside the scrolling widget while the waveform is, which is the actual point of
the change.

## Validation

- `python -m ruff check .` clean.
- `python -m pytest -m "not slow and not hardware"` on Python 3.14:
  **1013 passed**, 10 deselected.
- `python main.py --diagnostics` clean.
- Rendered and inspected at 1366x768 and at the 900x600 minimum, both themes.
  At the minimum size the content scrolls behind the transport and the bar
  stays put.

## After this, #131 is complete

All four intended moves have landed: stacked stem lanes (#149), practice cards
and the song readout strip (#150), mixer eye travel (#151), and the persistent
transport here.
